### PR TITLE
fix: network selector on mobile and miscellaneous fixes

### DIFF
--- a/src/components/page/PageFrameV2.vue
+++ b/src/components/page/PageFrameV2.vue
@@ -6,7 +6,7 @@
 
 <template>
 
-  <div class="page-frame">
+  <div class="h-page-frame">
     <PageHeader :page-title="props.pageTitle"/>
 
     <div v-if="slots.banner">
@@ -51,12 +51,4 @@ const slots = useSlots()
 <!--                                                       STYLE                                                     -->
 <!-- --------------------------------------------------------------------------------------------------------------- -->
 
-<style scoped>
-
-div.page-frame {
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-}
-
-</style>
+<style />

--- a/src/components/page/header/MainDashboardHeader.vue
+++ b/src/components/page/header/MainDashboardHeader.vue
@@ -91,7 +91,6 @@ div.header {
   border-bottom-right-radius: 32px;
   display: flex;
   flex-direction: column;
-  margin-bottom: 16px;
   padding: 0 16px 24px 16px;
 }
 

--- a/src/components/page/header/MobileMenuButton.vue
+++ b/src/components/page/header/MobileMenuButton.vue
@@ -18,8 +18,15 @@
           <X :size="18" style="color: var(--text-primary)" @click="showMobileMenu = false"
              data-cy="mobile-menu-close-icon"/>
         </div>
-        <TabBar vertical style="padding-left: 8px"/>
-        <NetworkSelector/>
+        <div class="menu-items">
+          <TabBar vertical/>
+        </div>
+        <div v-if="showNetworkSelector" class="network-selector">
+          <NetworkSelector/>
+        </div>
+        <template v-else>
+          <NetworkMenu/>
+        </template>
       </div>
     </template>
   </DropdownPanel>
@@ -33,17 +40,22 @@
 
 import {Menu, X} from 'lucide-vue-next';
 import DropdownPanel from "@/components/DropdownPanel.vue";
-import {ref, watch} from "vue";
+import {computed, ref, watch} from "vue";
 import TabBar from "@/components/page/header/TabBar.vue";
 import NetworkSelector from "@/components/page/header/NetworkSelector.vue";
 import ThemeSwitch from "@/components/ThemeSwitch.vue";
 import {routeManager} from "@/router.ts";
+import NetworkMenu from "@/components/page/header/NetworkMenu.vue";
+
+const MAX_ITEMS_IN_NETWORK_MENU = 5
 
 const showMobileMenu = ref(false)
 
 watch(routeManager.currentNetwork, () => {
   showMobileMenu.value = false
 })
+
+const showNetworkSelector = computed(() => routeManager.nbNetworks.value > MAX_ITEMS_IN_NETWORK_MENU)
 
 </script>
 
@@ -67,6 +79,15 @@ div.menu-l1 {
   justify-content: space-between;
   padding-left: 8px;
   width: 100%;
+}
+
+.menu-items {
+  padding-left: 18px;
+  padding-right: 18px;
+}
+
+.network-selector {
+  padding-left: 10px;
 }
 
 </style>

--- a/src/components/page/header/NetworkMenu.vue
+++ b/src/components/page/header/NetworkMenu.vue
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                     TEMPLATE                                                    -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<template>
+  <div class="network-menu" data-cy="network-menu">
+    <div v-for="network in networkEntries" :key="network.name" class="menu-item">
+      <Check :style="{'visibility': selectedNetwork === network.name ? 'visible' : 'hidden'}" :size="14"/>
+      <span @click="selectedNetwork=network.name" class="network-name">{{ network.displayName }}</span>
+    </div>
+  </div>
+</template>
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                      SCRIPT                                                     -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<script setup lang="ts">
+
+import {ref, watch} from "vue";
+import {routeManager} from "@/router.ts";
+import {NetworkConfig} from "@/config/NetworkConfig.ts";
+import {Check} from 'lucide-vue-next';
+
+const networkEntries = NetworkConfig.inject().entries
+
+const selectedNetwork = ref(routeManager.currentNetwork.value)
+watch(routeManager.currentNetwork, (newNetwork) => {
+  selectedNetwork.value = newNetwork // Checked : does not trigger any watch when value is unchanged
+})
+watch(selectedNetwork, (newNetwork) => {
+  if (newNetwork !== routeManager.currentNetwork.value) {
+    routeManager.routeToMainDashboard(newNetwork)
+  }
+})
+
+</script>
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                       STYLE                                                     -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<style scoped>
+
+div.network-menu {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+div.menu-item {
+  align-items: center;
+  cursor: pointer;
+  display: flex;
+  gap: 4px;
+}
+
+</style>

--- a/src/components/token/MetadataSection.vue
+++ b/src/components/token/MetadataSection.vue
@@ -32,7 +32,7 @@
         </template>
       </Property>
       <Property v-if="rawMetadata" id="metadata-location" full-width>
-        <template #name>Content Location</template>
+        <template #name>Decoded Metadata</template>
         <template #value>
           <BlobValue
               class="is-inline-block"

--- a/src/components/values/HbarAmount.vue
+++ b/src/components/values/HbarAmount.vue
@@ -110,7 +110,7 @@ const isGreen = computed(() => {
 <style scoped>
 
 div.hbar-amount {
-  display: flex;
+  display: inline-flex;
   flex-wrap: wrap;
   justify-content: flex-end;
 }

--- a/src/pages/MainDashboard.vue
+++ b/src/pages/MainDashboard.vue
@@ -6,35 +6,37 @@
 
 <template>
 
-  <MainDashboardHeader/>
+  <div class="h-page-frame">
+    <MainDashboardHeader/>
 
-  <div class="h-page-content">
-    <div class="dashboard-title">
-      Network
+    <div class="h-page-content">
+      <div class="dashboard-title">
+        Network
+      </div>
+
+      <div class="dashboard-separator"/>
+
+      <div class="dashboard-content">
+        <ChartView :controller="txOverTimeController" data-cy="chart-view"/>
+      </div>
+
+      <div class="dashboard-content">
+        <ChartView :controller="networkFeeController" data-cy="chart-view"/>
+      </div>
+
+      <div class="dashboard-title">
+        Accounts
+      </div>
+
+      <div class="dashboard-separator"/>
+
+      <div class="dashboard-content">
+        <ChartView :controller="activeAccountsController" data-cy="chart-view"/>
+      </div>
     </div>
 
-    <div class="dashboard-separator"/>
-
-    <div class="dashboard-content">
-      <ChartView :controller="txOverTimeController" data-cy="chart-view"/>
-    </div>
-
-    <div class="dashboard-content">
-      <ChartView :controller="networkFeeController" data-cy="chart-view"/>
-    </div>
-
-    <div class="dashboard-title">
-      Accounts
-    </div>
-
-    <div class="dashboard-separator"/>
-
-    <div class="dashboard-content">
-      <ChartView :controller="activeAccountsController" data-cy="chart-view"/>
-    </div>
+    <Footer/>
   </div>
-
-  <Footer/>
 
 </template>
 

--- a/src/styles/explorer.css
+++ b/src/styles/explorer.css
@@ -266,6 +266,12 @@ ul {
     list-style: none
 }
 
+.h-page-frame {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
 .h-page-content {
     display: flex;
     flex-direction: column;

--- a/tests/unit/token/MetadataSection.spec.ts
+++ b/tests/unit/token/MetadataSection.spec.ts
@@ -52,7 +52,7 @@ describe("MetadataSection.vue", () => {
         expect(wrapper.get("#raw-metadata-propertyName").text()).toBe('Raw Metadata')
         expect(wrapper.get("#raw-metadata-propertyValue").text()).toBe(metadata.value)
 
-        expect(wrapper.get("#metadata-locationName").text()).toBe('Content Location')
+        expect(wrapper.get("#metadata-locationName").text()).toBe('Decoded Metadata')
         expect(wrapper.get("#metadata-locationValue").text()).toBe(decodedMetadata)
 
         expect(wrapper.get("#typeValue").text()).toBe(IPFS_METADATA_CONTENT.type)


### PR DESCRIPTION
**Description**:

- On mobile/small screen, show display network options as menu items instead of a selector when 5 items or less.
- A couple minor unrelated visual fixes.

**Notes for reviewer**:

<img width="215" alt="Screenshot 2025-03-20 at 11 57 40" src="https://github.com/user-attachments/assets/ca4fdf47-7313-4222-a708-04dcfb526735" />
