### PR TITLE
chore: remove empty charts from home page when not supported.

### DIFF
--- a/src/components/page/header/MainDashboardHeader.vue
+++ b/src/components/page/header/MainDashboardHeader.vue
@@ -6,7 +6,7 @@
 
 <template>
 
-  <div class="header">
+  <div class="header" :class="{'full-page': props.fullPage}">
 
     <!--  First line of header-->
     <div class="header-top">
@@ -39,7 +39,9 @@
     </div>
 
     <!--  Central part of header-->
-    <div class="title">Explore Hedera Blockchain</div>
+    <div class="title" :class="{'full-page': props.fullPage}">
+      Explore Hedera Blockchain
+    </div>
     <SearchBar :size="90" class="search-bar"/>
 
     <!--  Market dashboard part of header-->
@@ -70,6 +72,13 @@ import WalletStatusButton from "@/components/page/header/wallet/WalletStatusButt
 import MobileMenuButton from "@/components/page/header/MobileMenuButton.vue";
 import MarketDashboard from "@/components/dashboard/MarketDashboard.vue";
 
+const props = defineProps({
+  fullPage: {
+    type: Boolean,
+    default: false
+  }
+})
+
 const enableMarketData = routeManager.enableMarket
 const isLargeScreen = inject('isLargeScreen', true)
 const enableWallet = routeManager.enableWallet
@@ -94,15 +103,23 @@ div.header {
   padding: 0 16px 24px 16px;
 }
 
-@media (min-width: 768px) {
+div.header.full-page {
+  background: url('@/assets/main-header-background-mobile.svg') top max(calc(100vh - 526px), 114px) left no-repeat, var(--background-secondary);
+  height: max(calc(100vh - 90px), 400px);
+}
+
+@media (min-width: 390px) {
   div.header {
     background: url('@/assets/main-header-background.svg') top 114px left no-repeat, var(--background-secondary);
+  }
+
+  div.header.full-page {
+    background: url('@/assets/main-header-background.svg') top max(calc(100vh - 526px), 114px) left no-repeat, var(--background-secondary);
   }
 }
 
 @media (min-width: 1080px) {
   div.header {
-    background: url('@/assets/main-header-background.svg') top 114px left no-repeat, var(--background-secondary);
     padding: 0 32px 32px 32px;
   }
 }
@@ -133,12 +150,20 @@ div.title {
   text-align: center;
 }
 
+div.title.full-page {
+  margin-top: max(calc(50vh - 240px), 80px);
+}
+
 @media (min-width: 1080px) {
   div.title {
     font-size: 56px;
     font-weight: 500;
     line-height: 74px;
     margin-top: 48px;
+  }
+
+  div.title.full-page {
+    margin-top: max(calc(50vh - 250px), 80px);
   }
 }
 

--- a/src/pages/MainDashboard.vue
+++ b/src/pages/MainDashboard.vue
@@ -6,37 +6,46 @@
 
 <template>
 
-  <div class="h-page-frame">
-    <MainDashboardHeader/>
+  <template v-if="showCharts">
+    <div class="h-page-frame">
+      <MainDashboardHeader/>
 
-    <div class="h-page-content">
-      <div class="dashboard-title">
-        Network
+      <div class="h-page-content">
+        <div class="dashboard-title">
+          Network
+        </div>
+
+        <div class="dashboard-separator"/>
+
+        <div class="dashboard-content">
+          <ChartView :controller="txOverTimeController" data-cy="chart-view"/>
+        </div>
+
+        <div class="dashboard-content">
+          <ChartView :controller="networkFeeController" data-cy="chart-view"/>
+        </div>
+
+        <div class="dashboard-title">
+          Accounts
+        </div>
+
+        <div class="dashboard-separator"/>
+
+        <div class="dashboard-content">
+          <ChartView :controller="activeAccountsController" data-cy="chart-view"/>
+        </div>
       </div>
 
-      <div class="dashboard-separator"/>
-
-      <div class="dashboard-content">
-        <ChartView :controller="txOverTimeController" data-cy="chart-view"/>
-      </div>
-
-      <div class="dashboard-content">
-        <ChartView :controller="networkFeeController" data-cy="chart-view"/>
-      </div>
-
-      <div class="dashboard-title">
-        Accounts
-      </div>
-
-      <div class="dashboard-separator"/>
-
-      <div class="dashboard-content">
-        <ChartView :controller="activeAccountsController" data-cy="chart-view"/>
-      </div>
+      <Footer/>
     </div>
+  </template>
 
-    <Footer/>
-  </div>
+  <template v-else>
+    <div class="h-page-frame">
+      <MainDashboardHeader full-page/>
+      <Footer/>
+    </div>
+  </template>
 
 </template>
 
@@ -46,7 +55,7 @@
 
 <script setup lang="ts">
 
-import {onBeforeUnmount, onMounted} from 'vue';
+import {computed, onBeforeUnmount, onMounted} from 'vue';
 import Footer from "@/components/page/Footer.vue";
 import MainDashboardHeader from "@/components/page/header/MainDashboardHeader.vue";
 import {TxOverTimeController} from "@/charts/hgraph/TxOverTimeController.ts";
@@ -61,6 +70,8 @@ defineProps({
 })
 
 const themeController = ThemeController.inject()
+
+const showCharts = computed(() => routeManager.hgraphURL.value !== null)
 
 const txOverTimeController = new TxOverTimeController(themeController, routeManager)
 onMounted(() => txOverTimeController.mount())

--- a/tests/e2e/specs/TopNavigationBar.cy.ts
+++ b/tests/e2e/specs/TopNavigationBar.cy.ts
@@ -40,9 +40,6 @@ describe('Top Navigation Bar', () => {
             .should('have.value', 'previewnet')
 
         cy.url().should('include', '/previewnet/dashboard')
-        cy.contains('Transactions Over Time')
-        cy.contains('Network Fees')
-        cy.contains('Active Accounts')
     })
 
     it('should navigate to top level pages', () => {

--- a/tests/unit/App.spec.ts
+++ b/tests/unit/App.spec.ts
@@ -97,10 +97,7 @@ describe("App.vue", () => {
         // console.log(wrapper.text())
 
         const charts = wrapper.findAllComponents(ChartView)
-        expect(charts.length).toBe(3)
-        expect(charts[0].text()).toMatch(RegExp("^Transactions Over Time"))
-        expect(charts[1].text()).toMatch(RegExp("^Network Fees"))
-        expect(charts[2].text()).toMatch(RegExp("^Active Accounts"))
+        expect(charts.length).toBe(0)
 
         expect(wrapper.findComponent(MainDashboardHeader).exists()).toBe(true)
         expect(wrapper.findComponent(Footer).exists()).toBe(true)


### PR DESCRIPTION
**Description**:
 
Change the design of the `MainDashboard` page when chart data is not available on a network:
- remove the empty charts
- make the header take all available vertical space, with the search bar in the middle.

**Notes for reviewer**:

On staging server.

<img width="1430" alt="Screenshot 2025-03-20 at 15 31 59" src="https://github.com/user-attachments/assets/7b6b4afa-29d3-4fc7-80a7-f6e5d51be484" />

 
![Hiero Dashboard](https://github.com/user-attachments/assets/5f7f285c-75af-4a68-ab02-a27384061c0a)

