### PR TITLE
chore: Network Fees chart now becomes linear chart and uses gradient and colors from UI design spec

### DIFF
--- a/src/charts/core/ChartController.ts
+++ b/src/charts/core/ChartController.ts
@@ -20,7 +20,7 @@ export abstract class ChartController<M> {
     public readonly range: Ref<ChartRange>
     public readonly latestMetric: Ref<M | null> = ref(null)
 
-    private metrics: M[] | null = null
+    private readonly metrics: Ref<M[] | null> = ref(null)
     private chart: Chart | null = null
     private readonly error: Ref<unknown> = ref(null)
     private readonly building: Ref<boolean> = ref(false)
@@ -41,12 +41,12 @@ export abstract class ChartController<M> {
     public mount(): void {
         this.watchHandles = [
             watch([this.range, this.routeManager.currentNetworkEntry], this.updateMetrics, {immediate: true}),
-            watch([this.canvas, this.themeController.darkSelected], this.updateChart, {immediate: true}),
+            watch([this.metrics, this.canvas, this.themeController.darkSelected], this.updateChart, {immediate: true}),
         ]
     }
 
     public unmount(): void {
-        this.metrics = null
+        this.metrics.value = null
         this.latestMetric.value = null
         if (this.chart !== null) {
             this.chart.destroy()
@@ -66,7 +66,7 @@ export abstract class ChartController<M> {
         } else if (this.error.value !== null) {
             result = ChartState.error
         } else {
-            const metricCount = this.metrics?.length ?? 0
+            const metricCount = this.metrics.value?.length ?? 0
             result = metricCount == 0 ? ChartState.empty : ChartState.ok
         }
         return result
@@ -127,23 +127,22 @@ export abstract class ChartController<M> {
             if (this.isSupported()) {
                 const loadedData = await this.loadData(this.range.value)
                 const rawMetrics = loadedData.metrics.length >= 1 ? loadedData.metrics : null
-                this.metrics = rawMetrics !== null
+                this.metrics.value = rawMetrics !== null
                     ? await this.transformMetrics(rawMetrics, this.range.value)
                     : null
                 this.latestMetric.value = loadedData.latestMetric
                 this.error.value = null
             } else {
-                this.metrics = null
+                this.metrics.value = null
                 this.latestMetric.value = null
                 this.error.value = null
             }
         } catch (error) {
-            this.metrics = null
+            this.metrics.value = null
             this.latestMetric.value = null
             this.error.value = error
         } finally {
             this.building.value = false
-            this.updateChart()
         }
     }
 
@@ -154,11 +153,11 @@ export abstract class ChartController<M> {
             // destroy() resets display to "none" => we restore
             this.canvas.value!.style.display = "block"
         }
-        if (this.canvas.value !== null && this.metrics !== null) {
+        if (this.canvas.value !== null && this.metrics.value !== null) {
             try {
                 const context = this.canvas.value.getContext("2d")!
                 const chartConfig = this.makeChartConfig(
-                    this.metrics, this.range.value, context)
+                    this.metrics.value, this.range.value, context)
                 this.chart = new Chart(this.canvas.value, chartConfig)
             } catch (error) {
                 this.chart = null

--- a/src/charts/core/ChartController.ts
+++ b/src/charts/core/ChartController.ts
@@ -115,7 +115,7 @@ export abstract class ChartController<M> {
         return metrics
     }
 
-    protected abstract makeChartConfig(metrics: M[], range: ChartRange): ChartConfiguration
+    protected abstract makeChartConfig(metrics: M[], range: ChartRange, context: CanvasRenderingContext2D): ChartConfiguration
 
     //
     // Private
@@ -156,7 +156,9 @@ export abstract class ChartController<M> {
         }
         if (this.canvas.value !== null && this.metrics !== null) {
             try {
-                const chartConfig = this.makeChartConfig(this.metrics, this.range.value)
+                const context = this.canvas.value.getContext("2d")!
+                const chartConfig = this.makeChartConfig(
+                    this.metrics, this.range.value, context)
                 this.chart = new Chart(this.canvas.value, chartConfig)
             } catch (error) {
                 this.chart = null

--- a/src/charts/hgraph/ActiveAccountController.ts
+++ b/src/charts/hgraph/ActiveAccountController.ts
@@ -21,7 +21,9 @@ export class ActiveAccountController extends GenericMetricController {
     // ChartController
     //
 
-    protected makeChartConfig(metrics: EcosystemMetric[], range: ChartRange): ChartConfiguration {
-        return this.makeBarChartConfig(metrics, range, false, "# of accounts")
+    protected makeChartConfig(metrics: EcosystemMetric[],
+                              range: ChartRange,
+                              context: CanvasRenderingContext2D): ChartConfiguration {
+        return this.makeBarChartConfig(metrics, range, false, "# of accounts", context)
     }
 }

--- a/src/charts/hgraph/HgraphChartController.ts
+++ b/src/charts/hgraph/HgraphChartController.ts
@@ -90,6 +90,13 @@ export abstract class HgraphChartController extends ChartController<EcosystemMet
                 datasets: [graphDataSet],
             },
             options: {
+                elements: {
+                  line: {
+                      tension: 0.4,
+                      cubicInterpolationMode: "default",
+                      // cubicInterpolationMode: "monotone",
+                  }
+                },
                 plugins: {
                     legend: {
                         display: false

--- a/src/charts/hgraph/HgraphChartController.ts
+++ b/src/charts/hgraph/HgraphChartController.ts
@@ -22,10 +22,11 @@ export abstract class HgraphChartController extends ChartController<EcosystemMet
     //
 
     protected makeBarChartConfig(metrics: EcosystemMetric[], range: ChartRange,
-                                 logarithmic: boolean, yLabel: string | null): ChartConfiguration {
+                                 logarithmic: boolean, yLabel: string | null,
+                                 context: CanvasRenderingContext2D): ChartConfiguration {
         const granularity = computeGranularityForRange(range)
         const graphLabels = makeGraphLabels(metrics, granularity)
-        const graphDataSet = this.makeGraphDataSet(metrics) as any
+        const graphDataSet = this.makeBarGraphDataSet(metrics, context) as any
         const textPrimaryColor = this.themeController.getTextPrimaryColor()
         const textSecondaryColor = this.themeController.getTextSecondaryColor()
         const yScaleType = logarithmic ? "logarithmic" : "linear"
@@ -73,10 +74,11 @@ export abstract class HgraphChartController extends ChartController<EcosystemMet
     }
 
     protected makeLineChartConfig(metrics: EcosystemMetric[], range: ChartRange,
-                                  logarithmic: boolean, yLabel: string | null): ChartConfiguration {
+                                  logarithmic: boolean, yLabel: string | null,
+                                  context: CanvasRenderingContext2D): ChartConfiguration {
         const granularity = computeGranularityForRange(range)
         const graphLabels = makeGraphLabels(metrics, granularity)
-        const graphDataSet = this.makeGraphDataSet(metrics) as any
+        const graphDataSet = this.makeLineGraphDataSet(metrics, context) as any
         const textPrimaryColor = this.themeController.getTextPrimaryColor()
         const textSecondaryColor = this.themeController.getTextSecondaryColor()
         const yScaleType = logarithmic ? "logarithmic" : "linear"
@@ -123,7 +125,8 @@ export abstract class HgraphChartController extends ChartController<EcosystemMet
         }
     }
 
-    protected makeGraphDataSet(metrics: EcosystemMetric[]): object {
+    protected makeBarGraphDataSet(metrics: EcosystemMetric[],
+                                  context: CanvasRenderingContext2D): object {
         const totals = metrics.map((m: EcosystemMetric) => m.total)
         const graphBarColor = this.themeController.getGraphBarColor()
         return {
@@ -132,6 +135,25 @@ export abstract class HgraphChartController extends ChartController<EcosystemMet
             borderWidth: 1,
             borderColor: graphBarColor,
             backgroundColor: graphBarColor
+        }
+    }
+
+    protected makeLineGraphDataSet(metrics: EcosystemMetric[],
+                                   context: CanvasRenderingContext2D): object {
+        const totals = metrics.map((m: EcosystemMetric) => m.total)
+        const graphBarColor = this.themeController.getGraphBarColor()
+        const gradient = context.createLinearGradient(0, 0, 0, 300)
+        const startColor = graphBarColor // Should use a lighter version of graphBarColor
+        const endColor = this.themeController.getBackgroundTertiaryColor()
+        gradient.addColorStop(0, startColor)
+        gradient.addColorStop(1, endColor)
+        return {
+            label: this.chartTitle,
+            data: totals,
+            borderWidth: 1,
+            borderColor: graphBarColor,
+            backgroundColor: gradient,
+            fill: true,
         }
     }
 

--- a/src/charts/hgraph/HgraphChartController.ts
+++ b/src/charts/hgraph/HgraphChartController.ts
@@ -72,6 +72,57 @@ export abstract class HgraphChartController extends ChartController<EcosystemMet
         }
     }
 
+    protected makeLineChartConfig(metrics: EcosystemMetric[], range: ChartRange,
+                                  logarithmic: boolean, yLabel: string | null): ChartConfiguration {
+        const granularity = computeGranularityForRange(range)
+        const graphLabels = makeGraphLabels(metrics, granularity)
+        const graphDataSet = this.makeGraphDataSet(metrics) as any
+        const textPrimaryColor = this.themeController.getTextPrimaryColor()
+        const textSecondaryColor = this.themeController.getTextSecondaryColor()
+        const yScaleType = logarithmic ? "logarithmic" : "linear"
+
+        return {
+            type: 'line',
+            data: {
+                labels: graphLabels,
+                datasets: [graphDataSet],
+            },
+            options: {
+                plugins: {
+                    legend: {
+                        display: false
+                    }
+                },
+                scales: {
+                    x: {
+                        ticks: {
+                            color: textPrimaryColor
+                        },
+                        grid: {
+                            display: false
+                        }
+                    },
+                    y: {
+                        type: yScaleType,
+                        ticks: {
+                            color: textPrimaryColor
+                        },
+                        grid: {
+                            display: false
+                        },
+                        beginAtZero: true,
+                        title: {
+                            display: yLabel !== null,
+                            text: yLabel ?? "",
+                            color: textSecondaryColor
+                        },
+                    }
+                },
+                maintainAspectRatio: false
+            }
+        }
+    }
+
     protected makeGraphDataSet(metrics: EcosystemMetric[]): object {
         const totals = metrics.map((m: EcosystemMetric) => m.total)
         const graphBarColor = this.themeController.getGraphBarColor()
@@ -79,6 +130,7 @@ export abstract class HgraphChartController extends ChartController<EcosystemMet
             label: this.chartTitle,
             data: totals,
             borderWidth: 1,
+            borderColor: graphBarColor,
             backgroundColor: graphBarColor
         }
     }

--- a/src/charts/hgraph/HgraphChartController.ts
+++ b/src/charts/hgraph/HgraphChartController.ts
@@ -141,17 +141,18 @@ export abstract class HgraphChartController extends ChartController<EcosystemMet
     protected makeLineGraphDataSet(metrics: EcosystemMetric[],
                                    context: CanvasRenderingContext2D): object {
         const totals = metrics.map((m: EcosystemMetric) => m.total)
-        const graphBarColor = this.themeController.getGraphBarColor()
+        const graphLineColor = this.themeController.getGraphLineColor()
         const gradient = context.createLinearGradient(0, 0, 0, 300)
-        const startColor = graphBarColor // Should use a lighter version of graphBarColor
-        const endColor = this.themeController.getBackgroundTertiaryColor()
+        const startColor = this.themeController.getGraphGradientStartColor()
+        const endColor = this.themeController.getGraphGradientEndColor()
         gradient.addColorStop(0, startColor)
         gradient.addColorStop(1, endColor)
         return {
             label: this.chartTitle,
             data: totals,
             borderWidth: 1,
-            borderColor: graphBarColor,
+            borderColor: graphLineColor,
+            pointBackgroundColor: graphLineColor,
             backgroundColor: gradient,
             fill: true,
         }

--- a/src/charts/hgraph/NetworkFeeController.ts
+++ b/src/charts/hgraph/NetworkFeeController.ts
@@ -29,9 +29,11 @@ export class NetworkFeeController extends GenericMetricController {
         return Promise.resolve(result)
     }
 
-    protected makeChartConfig(metrics: EcosystemMetric[], range: ChartRange): ChartConfiguration {
+    protected makeChartConfig(metrics: EcosystemMetric[],
+                              range: ChartRange,
+                              context: CanvasRenderingContext2D): ChartConfiguration {
         const coreConfig = this.routeManager.coreConfig.value
         const cryptoSymbole = coreConfig.cryptoSymbol ?? coreConfig.cryptoName
-        return this.makeLineChartConfig(metrics, range, false, cryptoSymbole)
+        return this.makeLineChartConfig(metrics, range, false, cryptoSymbole, context)
     }
 }

--- a/src/charts/hgraph/NetworkFeeController.ts
+++ b/src/charts/hgraph/NetworkFeeController.ts
@@ -32,6 +32,6 @@ export class NetworkFeeController extends GenericMetricController {
     protected makeChartConfig(metrics: EcosystemMetric[], range: ChartRange): ChartConfiguration {
         const coreConfig = this.routeManager.coreConfig.value
         const cryptoSymbole = coreConfig.cryptoSymbol ?? coreConfig.cryptoName
-        return this.makeBarChartConfig(metrics, range, false, cryptoSymbole)
+        return this.makeLineChartConfig(metrics, range, false, cryptoSymbole)
     }
 }

--- a/src/charts/hgraph/TPSController.ts
+++ b/src/charts/hgraph/TPSController.ts
@@ -27,7 +27,9 @@ export class TPSController extends GenericMetricController {
         return Promise.resolve(result)
     }
 
-    protected makeChartConfig(metrics: EcosystemMetric[], range: ChartRange): ChartConfiguration {
-        return this.makeBarChartConfig(metrics, range, true, "tx / second")
+    protected makeChartConfig(metrics: EcosystemMetric[],
+                              range: ChartRange,
+                              context: CanvasRenderingContext2D): ChartConfiguration {
+        return this.makeBarChartConfig(metrics, range, true, "tx / second", context)
     }
 }

--- a/src/charts/hgraph/TxOverTimeController.ts
+++ b/src/charts/hgraph/TxOverTimeController.ts
@@ -69,8 +69,10 @@ export class TxOverTimeController extends HgraphChartController {
         return Promise.resolve(result)
     }
 
-    protected makeChartConfig(metrics: EcosystemMetric[], range: ChartRange): ChartConfiguration {
-        return this.makeBarChartConfig(metrics, range, false, "# of transactions")
+    protected makeChartConfig(metrics: EcosystemMetric[],
+                              range: ChartRange,
+                              context: CanvasRenderingContext2D): ChartConfiguration {
+        return this.makeBarChartConfig(metrics, range, false, "# of transactions", context)
     }
 
 }

--- a/src/components/ThemeController.ts
+++ b/src/components/ThemeController.ts
@@ -47,8 +47,16 @@ export class ThemeController {
         return this.getCssVariable("--network-graph-bar-color")
     }
 
-    public getBackgroundTertiaryColor(): string {
-        return this.getCssVariable("--background-tertiary")
+    public getGraphLineColor(): string {
+        return this.getCssVariable("--graph-line-color")
+    }
+
+    public getGraphGradientStartColor(): string {
+        return this.getCssVariable("--graph-gradient-start-color")
+    }
+
+    public getGraphGradientEndColor(): string {
+        return this.getCssVariable("--graph-gradient-end-color")
     }
 
     public getCssVariable(name: string): string {
@@ -107,11 +115,13 @@ export class ThemeController {
             document.documentElement.style.setProperty('--status-success-color', 'var(--dark-status-success-color)')
             document.documentElement.style.setProperty('--status-error-color', 'var(--dark-status-error-color)')
             document.documentElement.style.setProperty('--search-bar-default', 'var(--dark-search-bar-default)')
+            document.documentElement.style.setProperty('--graph-line-color', 'var(--dark-graph-line-color)')
             document.getElementById('product-logo')?.setAttribute('src', this.coreConfig.productLogoDarkURL ?? '')
             document.getElementById('product-mini-logo')?.setAttribute('src', this.coreConfig.productMiniLogoDarkURL ?? '')
             document.getElementById('sponsor-logo')?.setAttribute('src', this.coreConfig.sponsorLogoDarkURL ?? '')
             document.getElementById('built-on-logo')?.setAttribute('src', this.coreConfig.builtOnLogoDarkURL ?? '')
             document.getElementById('crypto-logo')?.setAttribute('src', this.coreConfig.cryptoLogoDarkURL ?? '')
+
         } else {
             AppStorage.setTheme('light')
             document.documentElement.style.setProperty('--network-button-text-color', 'var(--light-network-button-text-color)')
@@ -150,11 +160,13 @@ export class ThemeController {
             document.documentElement.style.setProperty('--status-success-color', 'var(--light-status-success-color)')
             document.documentElement.style.setProperty('--status-error-color', 'var(--light-status-error-color)')
             document.documentElement.style.setProperty('--search-bar-default', 'var(--light-search-bar-default)')
+            document.documentElement.style.setProperty('--graph-line-color', 'var(--light-graph-line-color)')
             document.getElementById('product-logo')?.setAttribute('src', this.coreConfig.productLogoLightURL ?? '')
             document.getElementById('product-mini-logo')?.setAttribute('src', this.coreConfig.productMiniLogoLightURL ?? '')
             document.getElementById('sponsor-logo')?.setAttribute('src', this.coreConfig.sponsorLogoLightURL ?? '')
             document.getElementById('built-on-logo')?.setAttribute('src', this.coreConfig.builtOnLogoLightURL ?? '')
             document.getElementById('crypto-logo')?.setAttribute('src', this.coreConfig.cryptoLogoLightURL ?? '')
         }
+
     }
 }

--- a/src/components/ThemeController.ts
+++ b/src/components/ThemeController.ts
@@ -47,6 +47,10 @@ export class ThemeController {
         return this.getCssVariable("--network-graph-bar-color")
     }
 
+    public getBackgroundTertiaryColor(): string {
+        return this.getCssVariable("--background-tertiary")
+    }
+
     public getCssVariable(name: string): string {
         return window.getComputedStyle(document.body).getPropertyValue(name)
     }

--- a/src/styles/explorer.css
+++ b/src/styles/explorer.css
@@ -77,9 +77,6 @@
     --light-search-bar-default: #FFFFFF;
     --light-graph-line-color: #5A4DFF;
 
-    /*
-    --light-graphbar-blue: #5A4DFF;
-    */
 
     /* DARK MODE */
 
@@ -118,9 +115,6 @@
     --dark-status-success-color: #00722D;
     --dark-status-error-color: #C40E3A;
     --dark-search-bar-default: #2C2C2C;
-    /*
-    --dark-graphbar-blue: #1300FF;
-    */
     --dark-graph-line-color: #1300FF;
 
     /* CURRENT MODE */
@@ -218,7 +212,6 @@
     --yellow-dark-border-accent-color: #FFDE00;
 
 
-    --graph-line-color: #FFDE00;
     --graph-gradient-start-color: hsl(from var(--graph-line-color) h s l / 16%);
     --graph-gradient-end-color: hsl(from #2962FF h s l / 5%);
 

--- a/src/styles/explorer.css
+++ b/src/styles/explorer.css
@@ -75,6 +75,8 @@
     --light-status-success-color: #00722D;
     --light-status-error-color: #C40E3A;
     --light-search-bar-default: #FFFFFF;
+    --light-graph-line-color: #5A4DFF;
+
     /*
     --light-graphbar-blue: #5A4DFF;
     */
@@ -119,6 +121,7 @@
     /*
     --dark-graphbar-blue: #1300FF;
     */
+    --dark-graph-line-color: #1300FF;
 
     /* CURRENT MODE */
     --text-primary: var(--light-text-primary);
@@ -145,6 +148,7 @@
     --status-success-color: var(--light-status-success-color);
     --status-error-color: var(--light-status-error-color);
     --search-bar-default: var(--light-search-bar-default);
+    --graph-line-color:  var(--light-graph-line-color);
 
     --network-button-text-color: var(--light-network-button-text-color);
     --network-button-color: var(--light-network-button-color);
@@ -212,6 +216,12 @@
     --yellow-dark-chip-color: #FFE221D4;
     --yellow-dark-text-accent-color: #FFDE00;
     --yellow-dark-border-accent-color: #FFDE00;
+
+
+    --graph-line-color: #FFDE00;
+    --graph-gradient-start-color: hsl(from var(--graph-line-color) h s l / 16%);
+    --graph-gradient-end-color: hsl(from #2962FF h s l / 5%);
+
 }
 
 


### PR DESCRIPTION
**Description**:

Changes below turn `Network Fees` chart as a linear chart with the gradient and colors specified in UI design.

<img width="1085" alt="image" src="https://github.com/user-attachments/assets/e7eed134-014e-4e6f-801e-3b2425a6dbdc" />

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
