### PR TITLE
chore: ChartController now triggers data load when its HTML container intersects viewport

### DIFF
--- a/src/charts/core/ChartView.vue
+++ b/src/charts/core/ChartView.vue
@@ -19,10 +19,14 @@
       </div>
     </div>
 
-    <div class="chart-view-container" :style="{height: props.height + 'px'}">
+    <div class="chart-view-container" ref="containerRef" :style="{height: props.height + 'px'}">
 
       <template v-if="state === ChartState.unsupported">
         <div class="unsupported">This chart is not supported for this network</div>
+      </template>
+
+      <template v-if="state === ChartState.unrevealed">
+        <div class="unsupported">This chart is unrevealed</div> <!-- for debug only : should normally not appear -->
       </template>
 
       <template v-if="state === ChartState.loading">
@@ -72,6 +76,7 @@ const props = defineProps({
 })
 
 const canvasRef = props.controller.canvas
+const containerRef = props.controller.container
 const canvasDisplay = computed(() => props.controller.state.value === ChartState.ok ? "block" : "none")
 const state = props.controller.state
 const errorExtra = props.controller.errorExtra

--- a/tests/unit/globalSetup.js
+++ b/tests/unit/globalSetup.js
@@ -22,3 +22,12 @@ Object.defineProperty(window, 'matchMedia', {
 
 /* global global */
 global["ResizeObserver"] = ResizeObserverModule.default
+
+const IntersectionObserverMock = vi.fn(() => ({
+    disconnect: vi.fn(),
+    observe: vi.fn(),
+    takeRecords: vi.fn(),
+    unobserve: vi.fn(),
+}))
+
+vi.stubGlobal('IntersectionObserver', IntersectionObserverMock)


### PR DESCRIPTION
**Description**:

`ChartController` now triggers data load only when its HTML container element intersects viewport.
This enables to avoid useless queries to Hgraph data server.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
