### PR TITLE
fix: explorer gives a blank page when cookie are fully disabled

### DIFF
--- a/src/dialogs/wallet_chooser/WalletChooserDialog.vue
+++ b/src/dialogs/wallet_chooser/WalletChooserDialog.vue
@@ -27,13 +27,23 @@
     <template #modalDialogTitle>Connect Wallet</template>
 
     <template #modalDialogContent>
-      <div style="display: flex; align-items: center; justify-content: center;">
-        <div class="wallet-chooser-container" :style="{ 'grid-template-columns': gridTemplateColumns }">
-          <template v-for="i in walletItems" :key="i.name">
-            <WalletChooserItem v-model:selection="chosenWallet" :wallet-item="i" @connect="handleConnect"/>
-          </template>
+      <template v-if="walletItems.length >= 1">
+        <div style="display: flex; align-items: center; justify-content: center;">
+          <div class="wallet-chooser-container" :style="{ 'grid-template-columns': gridTemplateColumns }">
+            <template v-for="i in walletItems" :key="i.name">
+              <WalletChooserItem v-model:selection="chosenWallet" :wallet-item="i" @connect="handleConnect"/>
+            </template>
+          </div>
         </div>
-      </div>
+      </template>
+      <template v-else>
+        <TaskPanel :mode="TaskPanelMode.error">
+          <template #taskPanelMessage>No wallet available</template>
+          <template #taskPanelExtra1>
+            <div>You must install a wallet extension in your browser</div>
+          </template>
+        </TaskPanel>
+      </template>
     </template>
 
     <template #modalDialogButtons>
@@ -66,6 +76,8 @@ import OptOutDialog from "@/dialogs/OptOutDialog.vue";
 import {EIP6963Agent} from "@/utils/wallet/EIP6963Agent.ts";
 import {AppStorage} from "@/AppStorage.ts";
 import WalletChooserItem from "@/dialogs/wallet_chooser/WalletChooserItem.vue";
+import {TaskPanelMode} from "@/dialogs/core/DialogUtils.ts";
+import TaskPanel from "@/dialogs/core/task/TaskPanel.vue";
 
 const showDialog = defineModel("showDialog", {
   type: Boolean,

--- a/src/utils/wallet/WalletConnectAgent.ts
+++ b/src/utils/wallet/WalletConnectAgent.ts
@@ -9,7 +9,7 @@ import {networkToChainId, WalletClient_Ethereum} from "@/utils/wallet/client/Wal
 import {EIP1193Provider} from "@/utils/wallet/eip1193";
 import {CAAccountId, CAChainId} from "@/utils/wallet/caip";
 import {AccountByIdCache} from "@/utils/cache/AccountByIdCache";
-import SignClient from "@walletconnect/sign-client";
+import type SignClient from "@walletconnect/sign-client";
 import {ProposalTypes, SessionTypes, SignClientTypes} from "@walletconnect/types";
 import {routeManager} from "@/router";
 import type {WalletConnectModal} from "@walletconnect/modal"; // "type" to avoid unit test break
@@ -36,6 +36,7 @@ export class WalletConnectAgent {
                 url: window.location.origin,
                 icons: [],
             }
+            const { SignClient } = await import("@walletconnect/sign-client")
             const signClient = await SignClient.init({
                 logger: 'error',
                 projectId: projectId,

--- a/src/utils/wallet/WalletManagerV4.ts
+++ b/src/utils/wallet/WalletManagerV4.ts
@@ -4,7 +4,7 @@
 
 
 import {computed, ref, watch} from "vue";
-import {WalletClient} from "@/utils/wallet/client/WalletClient";
+import {WalletClient, WalletClientError} from "@/utils/wallet/client/WalletClient";
 import {WalletClient_Hiero} from "@/utils/wallet/client/WalletClient_Hiero";
 import {WalletClient_Ethereum} from "@/utils/wallet/client/WalletClient_Ethereum";
 import {WalletConnectAgent} from "@/utils/wallet/WalletConnectAgent";
@@ -113,8 +113,10 @@ export class WalletManagerV4 {
                     this.traceError(error, "WalletManagerV4.connect()")
                     this.walletSession.value = null
                 }
-            } else { // Bug
+            } else {
+                // WalletConnectAgent.makeInstance() did fail => browser setup does not allow WalletConnect to work
                 this.walletSession.value = null
+                throw new WalletConnectDisableByBrowserError()
             }
         } else {
             // Connection through browser extension
@@ -126,6 +128,7 @@ export class WalletManagerV4 {
             } catch (error) {
                 this.traceError(error, "WalletManagerV4.connect()")
                 this.walletSession.value = null
+                throw error
             }
         }
 
@@ -381,6 +384,13 @@ export class WalletManagerV4 {
 
     private traceError(reason: unknown, caller: string): void {
         console.trace(caller + " caught error: " + JSON.stringify(reason))
+    }
+}
+
+export class WalletConnectDisableByBrowserError extends WalletClientError {
+
+    public constructor() {
+        super("Browser setup does not allow to use WalletConnect right now", "Check that cookies are enabled")
     }
 }
 


### PR DESCRIPTION
**Description**:

When `cookies` are fully disabled, Explorer crashes at load time and displays a blank page.
Root cause is the following `import` line in `WalletConnectAgent` class:
```
import SignClient from "@walletconnect/sign-client";
```
=> `@walletconnect/sign-client` does not work when `cookies` are fully disabled.

Changes below make sure that Explorer starts correctly whether cookies are disabled or not.
Import line above is replaced by a dynamic import (which also reports an error but at connection time only).
In that case, Explorer reports issue with a specific message:

<img width="444" alt="image" src="https://github.com/user-attachments/assets/508b8fe8-e3bb-416c-9da5-b3e29fd29b0d" />

Additional change: when there is no wallet at all, Wallet Chooser dialog now displays the following message (in place of an empty list of wallets):
<img width="444" alt="image" src="https://github.com/user-attachments/assets/49ebd450-e83b-41e1-890d-865270eb58d2" />

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
