### PR TITLE
feat: search by scheduled transaction ID

### DIFF
--- a/src/components/search/SearchAgent.ts
+++ b/src/components/search/SearchAgent.ts
@@ -360,8 +360,9 @@ export class TransactionSearchAgent extends SearchAgent<TransactionID | Timestam
             let transactions: Transaction[]
             if (transactionParam instanceof TransactionID) {
                 const tid = transactionParam.toString(false)
+                const queryParams = transactionParam.queryParam === "scheduled" ? "?scheduled=true" : ""
                 // https://testnet.mirrornode.hedera.com/api/v1/docs/#/transactions/getTransactionById
-                const r = await axios.get<TransactionByIdResponse>("api/v1/transactions/" + tid)
+                const r = await axios.get<TransactionByIdResponse>("api/v1/transactions/" + tid + queryParams)
                 transactions = r.data.transactions ?? []
             } else if (transactionParam instanceof Timestamp) {
                 // https://testnet.mirrornode.hedera.com/api/v1/docs/#/transactions/listTransactions

--- a/tests/unit/utils/TransactionID.spec.ts
+++ b/tests/unit/utils/TransactionID.spec.ts
@@ -22,6 +22,7 @@ describe("TransactionID.ts", () => {
         expect(obj?.entityID.num).toBe(88)
         expect(obj?.seconds).toBe(1640084590)
         expect(obj?.nanoSeconds).toBe(665216882)
+        expect(obj?.queryParam).toBeNull()
         expect(obj?.toString(false)).toBe(str)
     })
 
@@ -33,6 +34,7 @@ describe("TransactionID.ts", () => {
         expect(obj?.entityID.num).toBe(88)
         expect(obj?.seconds).toBe(1640084590)
         expect(obj?.nanoSeconds).toBe(665216882)
+        expect(obj?.queryParam).toBeNull()
         expect(obj?.toString(true)).toBe(str)
     })
 
@@ -50,7 +52,20 @@ describe("TransactionID.ts", () => {
         expect(obj?.entityID.num).toBe(88)
         expect(obj?.seconds).toBe(1640084590)
         expect(obj?.nanoSeconds).toBe(0)
+        expect(obj?.queryParam).toBeNull()
         expect(obj?.toString(true)).toBe(str + ".000000000")
+    })
+
+    test("0.0.88@1640084590.665216882?scheduled", () => {
+        const str = "0.0.88@1640084590.665216882?scheduled"
+        const obj = TransactionID.parse(str)
+        expect(obj?.entityID.shard).toBe(0)
+        expect(obj?.entityID.realm).toBe(0)
+        expect(obj?.entityID.num).toBe(88)
+        expect(obj?.seconds).toBe(1640084590)
+        expect(obj?.nanoSeconds).toBe(665216882)
+        expect(obj?.queryParam).toBe("scheduled")
+        expect(obj?.toString(true, true)).toBe(str)
     })
 
     test("00881640084590665216882", () => {
@@ -60,6 +75,7 @@ describe("TransactionID.ts", () => {
         expect(obj?.entityID.num).toBe(88)
         expect(obj?.seconds).toBe(1640084590)
         expect(obj?.nanoSeconds).toBe(665216882)
+        expect(obj?.queryParam).toBeNull()
         expect(obj?.toString(true)).toBe("0.0.88@1640084590.665216882")
     })
 
@@ -71,6 +87,7 @@ describe("TransactionID.ts", () => {
         expect(TransactionID.parse("0.0.88@abc")).toBeNull()
         expect(TransactionID.parse("0.0.88@12.abc")).toBeNull()
         expect(TransactionID.parse("0.0.88@12.12.14")).toBeNull()
+        expect(TransactionID.parse("0.0.88@1640084590.665216882?dummy")).toBeNull()
         expect(TransactionID.parse("001640084590665216882")).toBeNull()
         expect(TransactionID.parse("11881640084590665216882")).toBeNull()
     })


### PR DESCRIPTION
**Description**:

Changes below enables `Search Bar` to handle transaction id with its `scheduled` flag and directly navigate to `Transaction Details` of the scheduled transaction (in place of the `Transaction By ID` page).

**Related issue(s)**:

Fixes #1746 

**Notes for reviewer**:

1) Go to Explorer
2) Type `0.0.4609960@1742840362.066682661?scheduled` in `Search Bar`
    => direct link to scheduled transaction details is proposed

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
