### PR TITLE
fix: fixing pagination in Node Table

### DIFF
--- a/src/components/node/NodeTable.vue
+++ b/src/components/node/NodeTable.vue
@@ -12,6 +12,7 @@
         :hoverable="true"
         :mobile-breakpoint="ORUGA_MOBILE_BREAKPOINT"
         :paginated="false"
+        :per-page="props.nodes.length"
         :striped="true"
         default-sort="node_id"
         @cell-click="handleClick"
@@ -130,7 +131,10 @@ import {NetworkAnalyzer} from "@/utils/analyzer/NetworkAnalyzer";
 import Tooltip from "@/components/Tooltip.vue";
 
 const props = defineProps({
-  nodes: Object as PropType<Array<NetworkNode> | undefined>,
+  nodes: {
+    type: Object as PropType<Array<NetworkNode>>,
+    required: true
+  },
   stakeTotal: Number
 })
 


### PR DESCRIPTION
**Description**:

Changes below update pagination setup in `Node Table` view.
This enables to fix the truncated list of  network nodes observed recently.
It seems that, in latest release of Oruga, default value `o-table.per-page` is now 20 (and no longer the number of items in data array).  Fix consists to set `per-page` with item count.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
