### PR TITLE
feat: adding 30d chart range

### DIFF
--- a/src/charts/core/ChartRange.ts
+++ b/src/charts/core/ChartRange.ts
@@ -3,6 +3,7 @@
 
 export enum ChartRange {            // Matching granularity
     day = "day",                    // => hour
+    month = "month",                // => day
     year = "year",                  // => month
     all = "all"                     // => year
 }
@@ -28,6 +29,10 @@ export function computeStartDateForRange(period: ChartRange): Date {
             result = new Date(y - 1, m)
             break
         }
+        case ChartRange.month: {
+            result = new Date(now.getTime() - 30 * 24 * 3600 * 1000)
+            break
+        }
         case ChartRange.day: {
             result = new Date(now.getTime() - 24 * 3600 * 1000)
             break
@@ -46,6 +51,9 @@ export function computeGranularityForRange(period: ChartRange): ChartGranularity
             break
         case ChartRange.year:
             result = ChartGranularity.month
+            break
+        case ChartRange.month:
+            result = ChartGranularity.day
             break
         case ChartRange.day:
             result = ChartGranularity.hour

--- a/src/charts/core/RangeSelectView.vue
+++ b/src/charts/core/RangeSelectView.vue
@@ -32,13 +32,19 @@ const props = defineProps({
   }
 })
 
-const ids = [ChartRange.day, ChartRange.year, ChartRange.all]
-const labels = ['24h', '1Y', 'All']
-const active = computed(() => [dayRangeSupported.value, yearRangeSupported.value, allRangeSupported.value])
+const ids = [ChartRange.day, ChartRange.month, ChartRange.year, ChartRange.all]
+const labels = ['24h', '30d', '1Y', 'All']
+const active = computed(() => [
+  dayRangeSupported.value,
+  monthRangeSupported.value,
+  yearRangeSupported.value,
+  allRangeSupported.value
+])
 
 const loading = computed(() => props.controller.state.value === ChartState.loading)
 const selectedRange = props.controller.range
 const dayRangeSupported = computed(() => props.controller.isRangeSupported(ChartRange.day))
+const monthRangeSupported = computed(() => props.controller.isRangeSupported(ChartRange.month))
 const yearRangeSupported = computed(() => props.controller.isRangeSupported(ChartRange.year))
 const allRangeSupported = computed(() => props.controller.isRangeSupported(ChartRange.all))
 

--- a/src/charts/hgraph/TxOverTimeController.ts
+++ b/src/charts/hgraph/TxOverTimeController.ts
@@ -15,7 +15,7 @@ export class TxOverTimeController extends HgraphChartController {
 
     public constructor(themeController: ThemeController, routeManager: RouteManager) {
         super("Transactions Over Time", themeController, routeManager,
-            [ChartRange.all, ChartRange.year, ChartRange.day])
+            [ChartRange.all, ChartRange.year, ChartRange.month, ChartRange.day])
     }
 
     //


### PR DESCRIPTION
**Description**:

Changes below add `30d` to `Chart Range Selector`.

<img width="1362" alt="image" src="https://github.com/user-attachments/assets/ce3f8ee3-5ed0-4ae2-b87b-380cb749a47a" />


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
