### PR TITLE
feat: support for schedule entities

### DIFF
--- a/src/components/values/link/ScheduleLink.vue
+++ b/src/components/values/link/ScheduleLink.vue
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                     TEMPLATE                                                    -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<template>
+
+  <div class="is-inline-block">
+
+    <EntityLink :route="scheduleRoute">
+      <EntityIOL :entity-id="props.scheduleId"/>
+    </EntityLink>
+
+  </div>
+
+</template>
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                      SCRIPT                                                     -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<script setup lang="ts">
+
+import {computed} from "vue";
+import {routeManager} from "@/router";
+import EntityLink from "@/components/values/link/EntityLink.vue";
+import EntityIOL from "@/components/values/link/EntityIOL.vue";
+
+const props = defineProps({
+  scheduleId: String,
+})
+
+const scheduleRoute = computed(() => props.scheduleId ? routeManager.makeRouteToSchedule(props.scheduleId) : null)
+
+</script>
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                       STYLE                                                     -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<style/>
+

--- a/src/components/values/link/SmartLink.vue
+++ b/src/components/values/link/SmartLink.vue
@@ -17,29 +17,28 @@
   <div v-else-if="routeName === 'TopicDetails'">
     <TopicLink :topic-id="entityId"/>
   </div>
+  <div v-else-if="routeName === 'ScheduleDetails'">
+    <ScheduleLink :schedule-id="entityId"/>
+  </div>
 </template>
 
 <!-- --------------------------------------------------------------------------------------------------------------- -->
 <!--                                                      SCRIPT                                                     -->
 <!-- --------------------------------------------------------------------------------------------------------------- -->
 
-<script lang="ts">
+<script setup lang="ts">
 
-import {defineComponent} from "vue";
 import AccountLink from "@/components/values/link/AccountLink.vue";
 import TokenLink from "@/components/values/link/TokenLink.vue";
 import TopicLink from "@/components/values/link/TopicLink.vue";
 import ContractLink from "@/components/values/link/ContractLink.vue";
+import ScheduleLink from "@/components/values/link/ScheduleLink.vue";
 
-export default defineComponent({
-  name: "EntityLink",
-  components: {TokenLink, AccountLink, ContractLink, TopicLink},
-  props: {
-    entityId: String,
-    routeName: String,
-    showExtra: Boolean,
-  },
-});
+defineProps({
+  entityId: String,
+  routeName: String,
+  showExtra: Boolean,
+})
 
 </script>
 

--- a/src/pages/ScheduleDetails.vue
+++ b/src/pages/ScheduleDetails.vue
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: Apache-2.0
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                     TEMPLATE                                                    -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<template>
+
+  <PageFrameV2 page-title="Schedule Details">
+    <template v-if="notification" #banner>
+      <NotificationBanner :message="notification"/>
+    </template>
+
+    <DashboardCardV2 collapsible-key="scheduleDetails">
+
+      <template #title>
+        Schedule {{ scheduleId }}
+        <div
+            class="h-has-pill h-chip-default"
+            :class="{'h-chip-success':schedule?.executed_timestamp, 'h-chip-default':!schedule?.executed_timestamp}"
+            style="margin-top: 2px">
+          {{ schedule?.executed_timestamp ? 'EXECUTED' : 'NOT EXECUTED' }}
+        </div>
+      </template>
+
+      <template #content>
+        <Property v-if="schedule?.executed_timestamp" id="scheduled-transaction" :full-width="true">
+          <template #name>Scheduled Transaction</template>
+          <template #value>
+            <router-link :to="routeManager.makeRouteToTransaction(schedule?.executed_timestamp)">
+              {{ makeTypeLabel(scheduledTx?.name) }}
+            </router-link>
+          </template>
+        </Property>
+        <Property v-if="schedule?.executed_timestamp" id="executed-at" :full-width="true">
+          <template #name>Executed at</template>
+          <template #value>
+            <TimestampValue :show-none="true" :timestamp="schedule?.executed_timestamp"/>
+          </template>
+        </Property>
+        <Property id="memo" :full-width="true">
+          <template #name>Memo</template>
+          <template #value>
+            <BlobValue :base64="true" :blob-value="schedule?.memo" :show-none="true" :show-base64-as-extra="true"/>
+          </template>
+        </Property>
+        <Property v-if="schedule?.consensus_timestamp" id="create-transaction" :full-width="true">
+          <template #name>Schedule Create Transaction</template>
+          <template #value>
+            <router-link :to="routeManager.makeRouteToTransaction(schedule.consensus_timestamp)">
+              <TransactionLink :transactionLoc="schedule.consensus_timestamp"/>
+            </router-link>
+          </template>
+        </Property>
+        <Property id="creator-id" :full-width="true">
+          <template #name>Creator Account</template>
+          <template #value>
+            <AccountLink :accountId="schedule?.creator_account_id" :show-extra="true"/>
+          </template>
+        </Property>
+        <Property id="payer-id" :full-width="true">
+          <template #name>Payer Account</template>
+          <template #value>
+            <AccountLink :accountId="schedule?.payer_account_id" :show-extra="true"/>
+          </template>
+        </Property>
+        <Property v-if="!schedule?.executed_timestamp" id="expiration-date" :full-width="true">
+          <template #name>Expiration Date</template>
+          <template #value>
+            <TimestampValue :show-none="true" :timestamp="schedule?.expiration_time"/>
+          </template>
+        </Property>
+        <Property v-if="schedule?.expiration_time" id="wait-for-expiry" :full-width="true">
+          <template #name>Wait for Expiry</template>
+          <template #value>
+            {{ schedule?.wait_for_expiry ? 'True' : 'False' }}
+          </template>
+        </Property>
+        <Property id="admin-key" :full-width="true">
+          <template #name>Admin Key</template>
+          <template #value>
+            <KeyValue :key-bytes="schedule?.admin_key?.key" :key-type="schedule?.admin_key?._type" :show-none="true"/>
+          </template>
+        </Property>
+        <Property id="transaction-body" :full-width="true">
+          <template #name>Transaction Body</template>
+          <template #value>
+            <BlobValue :blob-value="schedule?.transaction_body" :base64="false" :show-none="true"/>
+          </template>
+        </Property>
+
+        <template v-for="(s, index) in schedule?.signatures" :key="s.consensus_timestamp">
+          <div class="h-sub-section">Signature {{ index + 1 }}</div>
+
+          <Property id="timestamp" :full-width="true">
+            <template #name>
+              <span style="padding-left: 16px;">Timestamp</span>
+            </template>
+            <template #value>
+              <TimestampValue :show-none="true" :timestamp="s.consensus_timestamp"/>
+            </template>
+          </Property>
+          <Property id="key-prefix" :full-width="true">
+            <template #name>
+              <span style="padding-left: 16px;">Key Prefix</span>
+            </template>
+            <template #value>
+              <BlobValue :show-none="true" :blob-value="s.public_key_prefix"/>
+            </template>
+          </Property>
+          <Property id="signature" :full-width="true">
+            <template #name>
+              <span style="padding-left: 16px;">Signature</span>
+            </template>
+            <template #value>
+              <BlobValue :show-none="true" :blob-value="s.signature"/>
+              <div class="h-is-extra-text">{{ s.type }}</div>
+            </template>
+          </Property>
+        </template>
+      </template>
+
+    </DashboardCardV2>
+
+    <MirrorLink :network="props.network" entityUrl="schedules" :loc="scheduleId"/>
+
+  </PageFrameV2>
+
+</template>
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                      SCRIPT                                                     -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<script setup lang="ts">
+
+import {computed, onBeforeUnmount, onMounted, ref} from 'vue';
+import {makeTypeLabel} from "@/utils/TransactionTools";
+import AccountLink from "@/components/values/link/AccountLink.vue";
+import TimestampValue from "@/components/values/TimestampValue.vue";
+import BlobValue from "@/components/values/BlobValue.vue";
+import PageFrameV2 from "@/components/page/PageFrameV2.vue";
+import NotificationBanner from "@/components/NotificationBanner.vue";
+import Property from "@/components/Property.vue";
+import {routeManager} from "@/router"
+import MirrorLink from "@/components/MirrorLink.vue";
+import DashboardCardV2 from "@/components/DashboardCardV2.vue";
+import {ScheduleByIdCache} from "@/utils/cache/ScheduleByIdCache.ts";
+import {TransactionByTsCache} from "@/utils/cache/TransactionByTsCache.ts";
+import KeyValue from "@/components/values/KeyValue.vue";
+import TransactionLink from "@/components/values/TransactionLink.vue";
+
+const props = defineProps({
+  scheduleId: String,
+  network: String
+})
+
+const notification = ref(null);
+
+const scheduleId = computed(() => props.scheduleId ?? null);
+const scheduleLookup = ScheduleByIdCache.instance.makeLookup(scheduleId)
+const schedule = scheduleLookup.entity
+onMounted(() => scheduleLookup.mount())
+onBeforeUnmount(() => scheduleLookup.unmount())
+
+const scheduledTxTimestamp = computed(() => schedule.value?.executed_timestamp ?? null)
+const scheduledTxLookup = TransactionByTsCache.instance.makeLookup(scheduledTxTimestamp)
+const scheduledTx = scheduledTxLookup.entity
+onMounted(() => scheduledTxLookup.mount())
+onBeforeUnmount(() => scheduledTxLookup.unmount())
+
+</script>
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                       STYLE                                                     -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<style scoped>
+
+</style>

--- a/src/pages/ScheduleDetails.vue
+++ b/src/pages/ScheduleDetails.vue
@@ -85,7 +85,7 @@
         <Property id="transaction-body" :full-width="true">
           <template #name>Transaction Body</template>
           <template #value>
-            <BlobValue :blob-value="schedule?.transaction_body" :base64="false" :show-none="true"/>
+            <BlobValue :blob-value="formattedBody" pretty show-none/>
           </template>
         </Property>
 
@@ -105,7 +105,7 @@
               <span style="padding-left: 16px;">Key Prefix</span>
             </template>
             <template #value>
-              <BlobValue :show-none="true" :blob-value="s.public_key_prefix"/>
+              <HexaValue :byteString="hexaFormat(s.public_key_prefix)" :show-none="true"/>
             </template>
           </Property>
           <Property id="signature" :full-width="true">
@@ -113,7 +113,7 @@
               <span style="padding-left: 16px;">Signature</span>
             </template>
             <template #value>
-              <BlobValue :show-none="true" :blob-value="s.signature"/>
+              <HexaValue :byteString="hexaFormat(s.signature)" :show-none="true"/>
               <div class="h-is-extra-text">{{ s.type }}</div>
             </template>
           </Property>
@@ -149,6 +149,9 @@ import {ScheduleByIdCache} from "@/utils/cache/ScheduleByIdCache.ts";
 import {TransactionByTsCache} from "@/utils/cache/TransactionByTsCache.ts";
 import KeyValue from "@/components/values/KeyValue.vue";
 import TransactionLink from "@/components/values/TransactionLink.vue";
+import {base64DecToArr, byteToHex} from "@/utils/B64Utils.ts";
+import HexaValue from "@/components/values/HexaValue.vue";
+import {proto} from "@hashgraph/proto";
 
 const props = defineProps({
   scheduleId: String,
@@ -156,6 +159,22 @@ const props = defineProps({
 })
 
 const notification = ref(null);
+
+const formattedBody = computed(() => {
+  let result: string | null
+  const body = schedule.value?.transaction_body
+  if (body) {
+    const bodyBytes = base64DecToArr(body)
+    result = JSON.stringify(proto.SchedulableTransactionBody.decode(bodyBytes))
+  } else {
+    result = null;
+  }
+  return result;
+})
+
+const hexaFormat = (b64encoding: string) => {
+  return b64encoding ? byteToHex(base64DecToArr(b64encoding)) : null
+}
 
 const scheduleId = computed(() => props.scheduleId ?? null);
 const scheduleLookup = ScheduleByIdCache.instance.makeLookup(scheduleId)

--- a/src/pages/ScheduleDetails.vue
+++ b/src/pages/ScheduleDetails.vue
@@ -64,7 +64,7 @@
             <AccountLink :accountId="schedule?.payer_account_id" :show-extra="true"/>
           </template>
         </Property>
-        <Property v-if="!schedule?.executed_timestamp" id="expiration-date" :full-width="true">
+        <Property v-if="schedule?.expiration_time" id="expiration-date" :full-width="true">
           <template #name>Expiration Date</template>
           <template #value>
             <TimestampValue :show-none="true" :timestamp="schedule?.expiration_time"/>

--- a/src/pages/ScheduleDetails.vue
+++ b/src/pages/ScheduleDetails.vue
@@ -15,7 +15,7 @@
 
       <template #title>
         Schedule {{ scheduleId }}
-        <div
+        <div v-if="schedule"
             class="h-has-pill h-chip-default"
             :class="{'h-chip-success':schedule?.executed_timestamp, 'h-chip-default':!schedule?.executed_timestamp}"
             style="margin-top: 2px">
@@ -134,7 +134,7 @@
 
 <script setup lang="ts">
 
-import {computed, onBeforeUnmount, onMounted, ref} from 'vue';
+import {computed, inject, onBeforeUnmount, onMounted, ref} from 'vue';
 import {makeTypeLabel} from "@/utils/TransactionTools";
 import AccountLink from "@/components/values/link/AccountLink.vue";
 import TimestampValue from "@/components/values/TimestampValue.vue";
@@ -152,13 +152,24 @@ import TransactionLink from "@/components/values/TransactionLink.vue";
 import {base64DecToArr, byteToHex} from "@/utils/B64Utils.ts";
 import HexaValue from "@/components/values/HexaValue.vue";
 import {proto} from "@hashgraph/proto";
+import {loadingKey} from "@/AppKeys.ts";
 
 const props = defineProps({
   scheduleId: String,
   network: String
 })
 
-const notification = ref(null);
+const loading = inject(loadingKey, ref(false))
+
+const notification = computed(() => {
+  let result: string | null
+  if (!loading.value && schedule.value === null) {
+    result = "Schedule with ID " + props.scheduleId + " was not found"
+  } else {
+    result = null
+  }
+  return result
+})
 
 const formattedBody = computed(() => {
   let result: string | null

--- a/src/pages/TopicDetails.vue
+++ b/src/pages/TopicDetails.vue
@@ -88,6 +88,7 @@
             <div class="exempt-list">
               <KeyValue
                   v-for="k in topic?.fee_exempt_key_list ?? []"
+                  :key="k.key"
                   :key-bytes="k.key"
                   :key-type="k._type"
                   :show-none="true"

--- a/src/pages/TransactionDetails.vue
+++ b/src/pages/TransactionDetails.vue
@@ -181,7 +181,7 @@
           <template #name>Scheduled</template>
           <template #value>True</template>
         </Property>
-        <Property v-if="transaction?.scheduled===true" id="scheduled-transaction">
+        <Property v-if="transaction?.scheduled===true && schedulingTransaction" id="scheduleCreateTransaction">
           <template #name>Schedule Create Transaction</template>
           <template #value>
             <div class="multi-item-property-value">

--- a/src/pages/TransactionDetails.vue
+++ b/src/pages/TransactionDetails.vue
@@ -46,18 +46,23 @@
           <template #name>Type</template>
           <template #value>
             <StringValue :string-value="transactionType ? makeTypeLabel(transactionType) : null"/>
-            <ArrowLink
-                v-if="scheduledTransaction"
-                id="scheduledLink"
-                :route="routeManager.makeRouteToTransactionObj(scheduledTransaction)"
-                text="Scheduled transaction"
-            />
           </template>
         </Property>
         <Property v-if="displayResult" id="result">
           <template #name>Result</template>
           <template #value>
             <StringValue :string-value="transaction?.result"/>
+          </template>
+        </Property>
+        <Property v-if="scheduledTransaction" id="scheduledTransaction">
+          <template #name>Scheduled Transaction</template>
+          <template #value>
+            <div class="multi-item-property-value">
+              <TransactionLink :transactionLoc="scheduledTransaction?.consensus_timestamp ?? undefined"/>
+              <div class="h-has-pill h-chip-default" style="line-height: 15px">
+                {{ schedule?.executed_timestamp ? 'EXECUTED' : 'NOT EXECUTED' }}
+              </div>
+            </div>
           </template>
         </Property>
         <Property id="consensusAt">
@@ -109,7 +114,7 @@
           <template #name>{{ entity?.label }}</template>
           <template #value>
             <SmartLink v-if="entity?.routeName"
-                       :entity-id="transaction?.entity_id"
+                       :entity-id="transaction?.entity_id ?? undefined"
                        :route-name="routeName ?? undefined"
                        :show-extra="true"
             />
@@ -172,22 +177,16 @@
             {{ transaction?.nonce }}
           </template>
         </Property>
-        <Property id="scheduled">
+        <Property v-if="transaction?.scheduled===true" id="scheduled">
           <template #name>Scheduled</template>
-          <template v-if="transaction?.scheduled===true" #value>
-            True
-            <ArrowLink
-                v-if="schedulingTransaction"
-                id="schedulingLink"
-                :route="routeManager.makeRouteToTransactionObj(schedulingTransaction)"
-                text="Schedule create transaction"
-            />
-          </template>
-          <template v-else-if="scheduledTransaction!==null" #value>
-            False
-          </template>
-          <template v-else #value>
-            <span class="h-is-low-contrast">False</span>
+          <template #value>True</template>
+        </Property>
+        <Property v-if="transaction?.scheduled===true" id="scheduled-transaction">
+          <template #name>Schedule Create Transaction</template>
+          <template #value>
+            <div class="multi-item-property-value">
+              <TransactionLink :transactionLoc="schedulingTransaction?.consensus_timestamp ?? undefined"/>
+            </div>
           </template>
         </Property>
         <Property v-if="parentTransaction" id="parentTransaction">
@@ -287,6 +286,8 @@ import SelectView from "@/elements/SelectView.vue";
 import DashboardCardV2 from "@/components/DashboardCardV2.vue";
 import HexaValue from "@/components/values/HexaValue.vue";
 import ArrowLink from "@/components/ArrowLink.vue";
+import {ScheduleByIdCache} from "@/utils/cache/ScheduleByIdCache.ts";
+import TransactionLink from "@/components/values/TransactionLink.vue";
 
 const MAX_INLINE_CHILDREN = 10
 
@@ -298,8 +299,9 @@ const props = defineProps({
 const cryptoName = CoreConfig.inject().cryptoName
 
 const displayAllTransactionsLink = computed(() => {
+  const hasSchedule = transactionGroupAnalyzer.schedulingTransaction.value !== null
   const txnCount = transactionGroupAnalyzer.transactions.value?.length ?? 0
-  return txnCount >= 2
+  return !hasSchedule && txnCount >= 2
 })
 
 const txIdForm = ref(TransactionID.useAtForm.value ? 'atForm' : 'dashForm')
@@ -414,6 +416,24 @@ const schedulingTransaction = computed(() => {
   return result
 })
 
+const scheduleId = computed(() => transactionGroupAnalyzer.schedulingTransaction.value?.entity_id ?? null)
+const scheduleLookup = ScheduleByIdCache.instance.makeLookup(scheduleId)
+const schedule = scheduleLookup.entity
+onMounted(() => scheduleLookup.mount())
+onBeforeUnmount(() => scheduleLookup.unmount())
+
+const operatorAccount = computed(() => {
+  let result: string | null = null
+  if (transactionDetail.value?.scheduled) {
+    result = schedule.value?.payer_account_id ?? null
+  }
+  if (result === null) {
+    result = transactionAnalyzer.operatorAccount.value
+
+  }
+  return result
+})
+
 const transactionId = transactionLocParser.transactionId
 const transaction = transactionDetail
 const formattedTransactionId = transactionAnalyzer.formattedTransactionId
@@ -425,7 +445,6 @@ const formattedHash = transactionAnalyzer.formattedHash
 const transactionType = transactionAnalyzer.transactionType
 const transactionSucceeded = transactionAnalyzer.hasSucceeded
 const senderAccount = transactionAnalyzer.senderAccount
-const operatorAccount = transactionAnalyzer.operatorAccount
 const blockNumber = transactionAnalyzer.blockNumber
 const notification = transactionLocParser.errorNotification
 const topicMessage = topicMessageLookup.entity
@@ -439,5 +458,12 @@ const associatedTokens = transactionAnalyzer.tokens
 <!-- --------------------------------------------------------------------------------------------------------------- -->
 
 <style scoped>
+
+div.multi-item-property-value {
+  align-items: center;
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
 
 </style>

--- a/src/schemas/MirrorNodeSchemas.ts
+++ b/src/schemas/MirrorNodeSchemas.ts
@@ -319,6 +319,40 @@ export function compareTokenTransferByTokenId(t1: TokenTransfer, t2: TokenTransf
     return compareString(t1.token_id, t2.token_id)
 }
 
+// ---------------------------------------------------------------------------------------------------------------------
+//                                                      Schedule
+// ---------------------------------------------------------------------------------------------------------------------
+
+export interface Schedule {
+    admin_key: Key | null
+    consensus_timestamp: string
+    creator_account_id: string | null
+    deleted: boolean
+    executed_timestamp: string | null
+    expiration_time: string | null
+    memo: string
+    payer_account_id: string | null
+    schedule_id: string | null
+    signatures: ScheduleSignature[]
+    transaction_body: string
+    wait_for_expiry: boolean
+}
+
+export interface ScheduleSignature {
+    consensus_timestamp: string
+    public_key_prefix: string
+    signature: string
+    type: SignatureType
+}
+
+export enum SignatureType {
+    CONTRACT = "CONTRACT",
+    ED25519 = "ED25519",
+    RSA_3072 = "RSA_3072",
+    ECDSA_384 = "ECDSA_384",
+    ECDSA_SECP256K1 = "ECDSA_SECP256K1",
+    UNKNOWN = "UNKNOWN",
+}
 
 // ---------------------------------------------------------------------------------------------------------------------
 //                                                      Token

--- a/src/styles/explorer.css
+++ b/src/styles/explorer.css
@@ -323,6 +323,7 @@ ul {
     font-family: var(--font-family-heading), sans-serif;
     font-size: 10px;
     font-weight: 400;
+    line-height: 15px;
     height: 20px;
     padding: 2px 8px;
     text-wrap: nowrap;

--- a/src/utils/EntityDescriptor.ts
+++ b/src/utils/EntityDescriptor.ts
@@ -78,7 +78,7 @@ export class EntityDescriptor {
             case TransactionType.SCHEDULECREATE:
             case TransactionType.SCHEDULEDELETE:
             case TransactionType.SCHEDULESIGN:
-                result = new EntityDescriptor("Schedule ID", null);
+                result = new EntityDescriptor("Schedule ID", "ScheduleDetails");
                 break;
 
             case TransactionType.TOKENAIRDROP:

--- a/src/utils/RouteManager.ts
+++ b/src/utils/RouteManager.ts
@@ -18,6 +18,7 @@ import RoutingSpec from "@/pages/RoutingSpec.vue";
 import Transactions from "@/pages/Transactions.vue";
 import TransactionsById from "@/pages/TransactionsById.vue";
 import TransactionDetails from "@/pages/TransactionDetails.vue";
+import ScheduleDetails from "@/pages/ScheduleDetails.vue";
 import Accounts from "@/pages/Accounts.vue";
 import AccountsWithKey from "@/pages/AccountsWithKey.vue";
 import AccountDetails from "@/pages/AccountDetails.vue";
@@ -245,6 +246,17 @@ export class RouteManager {
 
     public makeRouteToTransactionsById(transactionId: string): RouteLocationRaw {
         return {name: 'TransactionsById', params: {transactionId: transactionId, network: this.currentNetwork.value}}
+    }
+
+    //
+    // Schedule
+    //
+
+    public makeRouteToSchedule(scheduleId: string): RouteLocationRaw {
+        return {
+            name: 'ScheduleDetails',
+            params: {scheduleId: scheduleId, network: this.currentNetwork.value}
+        }
     }
 
     //
@@ -565,6 +577,9 @@ export class RouteManager {
             case "TransactionDetails3091":
                 document.title = titlePrefix + "Transaction " + to.params.transactionLoc
                 break;
+            case "ScheduleDetails":
+                document.title = titlePrefix + "Schedule " + to.params.scheduleId
+                break;
             case "TokenDetails":
                 document.title = titlePrefix + "Token " + to.params.tokenId
                 break;
@@ -795,6 +810,15 @@ const routes: Array<RouteRecordRaw> = [
         path: '/:network/transaction/:transactionLoc',
         name: 'TransactionDetails',
         component: TransactionDetails,
+        props: true,
+        meta: {
+            tabId: TabId.Transactions
+        }
+    },
+    {
+        path: '/:network/schedule/:scheduleId',
+        name: 'ScheduleDetails',
+        component: ScheduleDetails,
         props: true,
         meta: {
             tabId: TabId.Transactions

--- a/src/utils/cache/CacheUtils.ts
+++ b/src/utils/cache/CacheUtils.ts
@@ -46,6 +46,7 @@ import {TransactionGroupByBlockCache} from "@/utils/cache/TransactionGroupByBloc
 import {TransactionGroupCache} from "@/utils/cache/TransactionGroupCache";
 import {VerifiedContractsByAccountIdCache} from "@/utils/cache/VerifiedContractsByAccountIdCache";
 import {VerifiedContractsCache} from "@/utils/cache/VerifiedContractsCache";
+import {ScheduleByIdCache} from "@/utils/cache/ScheduleByIdCache.ts";
 
 export class CacheUtils {
 
@@ -80,6 +81,7 @@ export class CacheUtils {
         NftBySerialCache.instance.clear()
         NftCollectionCache.instance.clear()
         PendingAirdropCache.instance.clear()
+        ScheduleByIdCache.instance.clear()
         SelectedTokensCache.instance.clear()
         // SignatureCache.instance => no clear: we preserve it because 4byte content is valid for all networks
         SourcifyCache.instance.clear()

--- a/src/utils/cache/ScheduleByIdCache.ts
+++ b/src/utils/cache/ScheduleByIdCache.ts
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {Schedule} from "@/schemas/MirrorNodeSchemas";
+import {EntityCache} from "@/utils/cache/base/EntityCache";
+import axios from "axios";
+
+export class ScheduleByIdCache extends EntityCache<string, Schedule | null> {
+
+    public static readonly instance = new ScheduleByIdCache()
+
+    //
+    // Cache
+    //
+
+    protected async load(scheduleId: string): Promise<Schedule | null> {
+        let result: Promise<Schedule | null>
+        try {
+            const response = await axios.get<Schedule>("api/v1/schedules/" + scheduleId)
+            result = Promise.resolve(response.data)
+        } catch (error) {
+            if (axios.isAxiosError(error) && error.response?.status == 404) {
+                result = Promise.resolve(null)
+            } else {
+                throw error
+            }
+        }
+        return result
+    }
+}

--- a/tests/e2e/specs/TransactionNavigation.cy.ts
+++ b/tests/e2e/specs/TransactionNavigation.cy.ts
@@ -81,29 +81,37 @@ describe('Transaction Navigation', () => {
     it('should follow schedule relationship links', () => {
         const schedulingConsensusTimestamp = "1674825796.070463898"
         const scheduledConsensusTimestamp = "1674825835.244778007"
+        const scheduleId = "0.0.1754091"
 
         const targetURL = 'mainnet/transaction/' + schedulingConsensusTimestamp
         cy.visit(targetURL)
         cy.url().should('include', targetURL)
 
-        cy.get('#transactionTypeValue')
+        cy.get('#scheduledTransactionValue')
             .find('a')
             .click()
             .then(() => {
-                // cy.log('Selected operator Id: ' + $id.text())
                 cy.url().should('include', '/mainnet/transaction/')
                 cy.url().should('include', scheduledConsensusTimestamp)
                 cy.get('title').contains('Transaction ' + scheduledConsensusTimestamp)
             })
 
-        cy.get('#scheduledValue')
+        cy.get('#scheduleCreateTransaction')
             .find('a')
             .click()
             .then(() => {
-                // cy.log('Selected operator Id: ' + $id.text())
                 cy.url().should('include', '/mainnet/transaction/')
                 cy.url().should('include', schedulingConsensusTimestamp)
                 cy.get('title').contains('Transaction ' + schedulingConsensusTimestamp)
+            })
+
+        cy.get('#entityIdValue')
+            .find('a')
+            .click()
+            .then(() => {
+                cy.url().should('include', '/mainnet/schedule/')
+                cy.url().should('include', scheduleId)
+                cy.get('title').contains('Schedule ' + scheduleId)
             })
     })
 

--- a/tests/unit/Mocks.ts
+++ b/tests/unit/Mocks.ts
@@ -5,7 +5,14 @@
 // Fungible token inspired from https://testnet.mirrornode.hedera.com/api/v1/tokens/0.0.29662956
 //
 
-import {ContractStateResponse, KeyType, TransactionResponse, TransactionType} from "@/schemas/MirrorNodeSchemas.ts";
+import {
+    ContractStateResponse,
+    KeyType,
+    Schedule,
+    SignatureType,
+    TransactionResponse,
+    TransactionType
+} from "@/schemas/MirrorNodeSchemas.ts";
 
 export const SAMPLE_TOKEN = {
     "admin_key": null,
@@ -2098,6 +2105,106 @@ export const SAMPLE_SCHEDULING_SCHEDULED_TRANSACTIONS: TransactionResponse = {
     }],
     "links": {
         "next": null
+    }
+}
+
+export const SAMPLE_SCHEDULE: Schedule = {
+    "admin_key": null,
+    "deleted": false,
+    "consensus_timestamp": "1666754908.576858590",
+    "creator_account_id": "0.0.503733",
+    "executed_timestamp": "1666754925.508764007",
+    "expiration_time": null,
+    "memo": "",
+    "payer_account_id": "0.0.540286",
+    "schedule_id": "0.0.1382775",
+    "signatures": [{
+        "consensus_timestamp": "1666754925.508764000",
+        "public_key_prefix": "AsevvtoymvMCmYe9+MTyyAmv0GhXiIeLcmjnsHAz2TL6",
+        "signature": "CtdYldUBNrDUv14pAX5N4XDYOiboEkDAPVelVrNa9IRSH+z72wkCk1q06GTgzDYZ8RlpBDjFIYlK\naHYs2Rsl9w==",
+        "type": SignatureType.ECDSA_SECP256K1
+    }, {
+        "consensus_timestamp": "1666754925.508764002",
+        "public_key_prefix": "AtGoyN6a6njsqjz61ZOI+H2MxHT+ttSaCPH8TpdPXRxi",
+        "signature": "Eib7p24XNyULTvlygVY5iQMcA5KHQy/0WqID1yGG0YheImuWg28XwB7sQ0QLLPK7WISaxdqXI85r\nDGpaCgDZ5w==",
+        "type": SignatureType.ECDSA_SECP256K1
+    }],
+    "transaction_body": "CIDC1y8SJDE5MmEyMzBiLTQzYTAtNDkwYS1iMDcwLWEzMjdlMjI3NjNkZUo8CjoKHQoWIhQQBSQ38M0RvDemJfugI1pv6epzjhCA0coICgsKBRjdvY0CEICJegoMCgUY9YjfAhD/2cQJ",
+    "wait_for_expiry": false
+}
+
+export const SCHEDULE_TRANSACTION_BODY = {
+    "transactionFee": {
+        "low": 100000000,
+        "high": 0,
+        "unsigned": true
+    },
+    "memo": "192a230b-43a0-490a-b070-a327e22763de",
+    "cryptoTransfer": {
+        "tokenTransfers": [],
+        "transfers": {
+            "accountAmounts": [
+                {
+                    "accountID": {
+                        "alias": {
+                            "0": 16,
+                            "1": 5,
+                            "2": 36,
+                            "3": 55,
+                            "4": 240,
+                            "5": 205,
+                            "6": 17,
+                            "7": 188,
+                            "8": 55,
+                            "9": 166,
+                            "10": 37,
+                            "11": 251,
+                            "12": 160,
+                            "13": 35,
+                            "14": 90,
+                            "15": 111,
+                            "16": 233,
+                            "17": 234,
+                            "18": 115,
+                            "19": 142
+                        }
+                    },
+                    "amount": {
+                        "low": 9000000,
+                        "high": 0,
+                        "unsigned": false
+                    }
+                },
+                {
+                    "accountID": {
+                        "accountNum": {
+                            "low": 4415197,
+                            "high": 0,
+                            "unsigned": false
+                        }
+                    },
+                    "amount": {
+                        "low": 1000000,
+                        "high": 0,
+                        "unsigned": false
+                    }
+                },
+                {
+                    "accountID": {
+                        "accountNum": {
+                            "low": 5751925,
+                            "high": 0,
+                            "unsigned": false
+                        }
+                    },
+                    "amount": {
+                        "low": -10000000,
+                        "high": -1,
+                        "unsigned": false
+                    }
+                }
+            ]
+        }
     }
 }
 

--- a/tests/unit/transaction/ScheduleDetails.spec.ts
+++ b/tests/unit/transaction/ScheduleDetails.spec.ts
@@ -119,4 +119,40 @@ describe("TransactionDetails.vue", () => {
         mock.restore()
     });
 
+    it("Should display a banner for invalid schedule ID", async () => {
+
+        await router.push("/") // To avoid "missing required param 'network'" error
+
+        const INVALID_SCHEDULE_ID = "0.0.98"
+
+        const mock = new MockAdapter(axios as any)
+        const matcher2 = "/api/v1/schedules/" + INVALID_SCHEDULE_ID
+        mock.onGet(matcher2).reply(404);
+
+        const wrapper = mount(ScheduleDetails, {
+            global: {
+                plugins: [router, Oruga],
+                provide: {"isMediumScreen": false}
+            },
+            props: {
+                scheduleId: INVALID_SCHEDULE_ID!
+            },
+        });
+
+        await flushPromises()
+        // console.log(wrapper.html())
+        console.log(wrapper.text())
+
+        expect(fetchGetURLs(mock)).toStrictEqual([
+            "api/v1/network/nodes",
+            "api/v1/schedules/" + INVALID_SCHEDULE_ID,
+        ])
+
+        expect(wrapper.text()).toMatch(RegExp("Schedule with ID " + INVALID_SCHEDULE_ID + " was not found"))
+
+        wrapper.unmount()
+        await flushPromises()
+        mock.restore()
+    });
+
 });

--- a/tests/unit/transaction/ScheduleDetails.spec.ts
+++ b/tests/unit/transaction/ScheduleDetails.spec.ts
@@ -1,0 +1,122 @@
+// noinspection DuplicatedCode
+
+// SPDX-License-Identifier: Apache-2.0
+
+import {describe, expect, it} from 'vitest'
+import {flushPromises, mount} from "@vue/test-utils"
+import router from "@/router";
+import axios, {AxiosRequestConfig} from "axios";
+import {SAMPLE_SCHEDULE, SAMPLE_SCHEDULING_SCHEDULED_TRANSACTIONS} from "../Mocks";
+import MockAdapter from "axios-mock-adapter";
+import {HMSF} from "@/utils/HMSF";
+import {TransactionID} from "@/utils/TransactionID";
+import Oruga from "@oruga-ui/oruga-next";
+import {fetchGetURLs} from "../MockUtils";
+import ScheduleDetails from "@/pages/ScheduleDetails.vue";
+
+/*
+    Bookmarks
+        https://jestjs.io/docs/api
+        https://test-utils.vuejs.org/api/
+
+ */
+
+HMSF.forceUTC = true
+
+describe("TransactionDetails.vue", () => {
+
+    it("Should display the schedule details", async () => {
+
+        await router.push("/") // To avoid "missing required param 'network'" error
+
+        const SCHEDULING = SAMPLE_SCHEDULING_SCHEDULED_TRANSACTIONS.transactions![0]
+        const SCHEDULED = SAMPLE_SCHEDULING_SCHEDULED_TRANSACTIONS.transactions![1]
+        const SCHEDULE = SAMPLE_SCHEDULE
+        const SCHEDULE_ID = SAMPLE_SCHEDULE.schedule_id
+
+
+
+        const mock = new MockAdapter(axios as any)
+        const matcher1 = "/api/v1/transactions"
+        mock.onGet(matcher1).reply(((config: AxiosRequestConfig) => {
+            if (config.params.timestamp == SCHEDULING.consensus_timestamp) {
+                return [200, {transactions: [SCHEDULING]}]
+            } else if (config.params.timestamp == SCHEDULED.consensus_timestamp) {
+                return [200, {transactions: [SCHEDULED]}]
+            } else {
+                return [404]
+            }
+        }) as any);
+        const matcher11 = "/api/v1/transactions/" + SCHEDULING.transaction_id
+        mock.onGet(matcher11).reply(200, SAMPLE_SCHEDULING_SCHEDULED_TRANSACTIONS);
+        const matcher2 = "/api/v1/schedules/" + SCHEDULE_ID
+        mock.onGet(matcher2).reply(200, SAMPLE_SCHEDULE);
+
+        const wrapper = mount(ScheduleDetails, {
+            global: {
+                plugins: [router, Oruga],
+                provide: {"isMediumScreen": false}
+            },
+            props: {
+                scheduleId: SCHEDULE_ID!
+            },
+        });
+
+        await flushPromises()
+        // console.log(wrapper.html())
+        // console.log(wrapper.text())
+
+        expect(fetchGetURLs(mock)).toStrictEqual([
+            "api/v1/network/nodes",
+            "api/v1/schedules/" + SCHEDULE_ID,
+            "api/v1/transactions",
+            "api/v1/contracts/" + SCHEDULE.payer_account_id,
+            "api/v1/contracts/" + SCHEDULE.creator_account_id,
+            "api/v1/transactions",
+        ])
+
+        expect(wrapper.text()).toMatch(RegExp("Schedule " + SCHEDULE_ID + " EXECUTED"))
+
+        const scheduled = wrapper.get("#scheduled-transactionValue")
+        expect(scheduled.text()).toBe("TOKEN MINT")
+        const link1 = scheduled.get('a')
+        expect(link1.attributes("href")).toBe(
+            "/mainnet/transaction/" + SCHEDULE.executed_timestamp
+        )
+
+        expect (wrapper.get("#executed-atValue").text()).toBe("3:28:45.5087 AMOct 26, 2022, UTC")
+        expect (wrapper.get("#memoValue").text()).toBe("None")
+
+        const createTx = wrapper.get("#create-transactionValue")
+        expect(createTx.text()).toBe(TransactionID.normalizeForDisplay(SCHEDULING.transaction_id))
+        const link2 = createTx.get('a')
+        expect(link2.attributes("href")).toBe(
+            "/mainnet/transaction/" + SCHEDULE.consensus_timestamp
+        )
+
+        expect (wrapper.get("#creator-idValue").text()).toBe("0.0.503733")
+        expect (wrapper.get("#payer-idValue").text()).toBe("0.0.540286")
+        expect (wrapper.get("#admin-keyValue").text()).toBe("None")
+        expect (wrapper.get("#transaction-bodyValue").text()).toContain("192a230b-43a0-490a-b070-a327e22763de")
+
+        const timestamps = wrapper.findAll("#timestampValue")
+        expect(timestamps.length).toBe(2)
+        expect(timestamps[0].text()).toBe("3:28:45.5087 AMOct 26, 2022, UTC")
+        expect(timestamps[1].text()).toBe("3:28:45.5087 AMOct 26, 2022, UTC")
+
+        const keyPrefixes = wrapper.findAll("#key-prefixValue")
+        expect(keyPrefixes.length).toBe(2)
+        expect(keyPrefixes[0].text()).toBe("0x02c7afbeda329af3029987bdf8c4f2c809afd0685788878b7268e7b07033d932fa" + "Copy")
+        expect(keyPrefixes[1].text()).toBe("0x02d1a8c8de9aea78ecaa3cfad59388f87d8cc474feb6d49a08f1fc4e974f5d1c62" + "Copy")
+
+        const signatures = wrapper.findAll("#signatureValue")
+        expect(signatures.length).toBe(2)
+        expect(signatures[0].text()).toBe("0x0ad75895d50136b0d4bf5e29017e4de170d83a26e81240c03d57a556b35af484521fecfbdb0902935ab4e864e0cc3619f119690438c521894a68762cd91b25f7" + "Copy" + "ECDSA_SECP256K1")
+        expect(signatures[1].text()).toBe("0x1226fba76e1737250b4ef97281563989031c039287432ff45aa203d72186d1885e226b96836f17c01eec43440b2cf2bb58849ac5da9723ce6b0c6a5a0a00d9e7" + "Copy" + "ECDSA_SECP256K1")
+
+        wrapper.unmount()
+        await flushPromises()
+        mock.restore()
+    });
+
+});

--- a/tests/unit/transaction/TransactionDetails.spec.ts
+++ b/tests/unit/transaction/TransactionDetails.spec.ts
@@ -31,6 +31,7 @@ import {
     SAMPLE_NONFUNGIBLE,
     SAMPLE_PARENT_CHILD_TRANSACTIONS,
     SAMPLE_SAME_ID_NOT_PARENT_TRANSACTIONS,
+    SAMPLE_SCHEDULE,
     SAMPLE_SCHEDULING_SCHEDULED_TRANSACTIONS,
     SAMPLE_SYSTEM_CONTRACT_CALL_TRANSACTIONS,
     SAMPLE_TOKEN,
@@ -678,12 +679,16 @@ describe("TransactionDetails.vue", () => {
         mock.onGet(matcher1).reply(((config: AxiosRequestConfig) => {
             if (config.params.timestamp == SCHEDULING.consensus_timestamp) {
                 return [200, {transactions: [SCHEDULING]}]
+            } else if (config.params.timestamp == SCHEDULED.consensus_timestamp) {
+                return [200, {transactions: [SCHEDULED]}]
             } else {
                 return [404]
             }
         }) as any);
         const matcher11 = "/api/v1/transactions/" + SCHEDULING.transaction_id
         mock.onGet(matcher11).reply(200, SAMPLE_SCHEDULING_SCHEDULED_TRANSACTIONS);
+        const matcher2 = "/api/v1/schedules/" + SCHEDULING.entity_id
+        mock.onGet(matcher2).reply(200, SAMPLE_SCHEDULE);
         const matcher5 = "/api/v1/tokens/" + TOKEN_ID
         mock.onGet(matcher5).reply(200, SAMPLE_TOKEN)
 
@@ -707,9 +712,11 @@ describe("TransactionDetails.vue", () => {
             "api/v1/topics/messages/",
             "api/v1/transactions/" + SCHEDULING.transaction_id,
             "api/v1/blocks",
+            "api/v1/schedules/0.0.1382775",
             "api/v1/contracts/" + SCHEDULING.node,
             "api/v1/contracts/results",
             "api/v1/network/fees",
+            "api/v1/transactions",
             "api/v1/network/exchangerate",
             "api/v1/contracts/" + SCHEDULING.transfers[2].account,
             "api/v1/contracts/" + SCHEDULING.transfers[1].account,
@@ -717,8 +724,9 @@ describe("TransactionDetails.vue", () => {
 
         expect(wrapper.text()).toMatch(RegExp("Transaction " + TransactionID.normalizeForDisplay(SCHEDULING.transaction_id)))
 
-        const link = wrapper.get("#scheduledLink")
-        expect(link.text()).toBe("Scheduled transaction")
+        const scheduled = wrapper.get("#scheduledTransactionValue")
+        expect(scheduled.text()).toBe("0.0.503733@1666754898.238965661" + "EXECUTED")
+        const link = scheduled.get('a')
         expect(link.attributes("href")).toBe(
             "/mainnet/transaction/" + SCHEDULED.consensus_timestamp
         )
@@ -739,7 +747,9 @@ describe("TransactionDetails.vue", () => {
         const mock = new MockAdapter(axios as any)
         const matcher1 = "/api/v1/transactions"
         mock.onGet(matcher1).reply(((config: AxiosRequestConfig) => {
-            if (config.params.timestamp == SCHEDULED.consensus_timestamp) {
+            if (config.params.timestamp == SCHEDULING.consensus_timestamp) {
+                return [200, {transactions: [SCHEDULING]}]
+            } else if (config.params.timestamp == SCHEDULED.consensus_timestamp) {
                 return [200, {transactions: [SCHEDULED]}]
             } else {
                 return [404]
@@ -747,6 +757,8 @@ describe("TransactionDetails.vue", () => {
         }) as any);
         const matcher11 = "/api/v1/transactions/" + SCHEDULED.transaction_id
         mock.onGet(matcher11).reply(200, SAMPLE_SCHEDULING_SCHEDULED_TRANSACTIONS);
+        const matcher12 = "/api/v1/schedules/" + SCHEDULING.entity_id
+        mock.onGet(matcher12).reply(200, SAMPLE_SCHEDULE);
         const matcher2 = "/api/v1/tokens/" + TOKEN_ID
         mock.onGet(matcher2).reply(200, SAMPLE_TOKEN);
 
@@ -770,10 +782,12 @@ describe("TransactionDetails.vue", () => {
             "api/v1/topics/messages/",
             "api/v1/transactions/" + SCHEDULING.transaction_id,
             "api/v1/blocks",
+            "api/v1/schedules/0.0.1382775",
             "api/v1/contracts/results",
             "api/v1/network/fees",
-            "api/v1/network/exchangerate",
             "api/v1/contracts/" + SCHEDULING.transfers[2].account,
+            "api/v1/network/exchangerate",
+            "api/v1/transactions",
             "api/v1/tokens/" + SCHEDULED.entity_id,
             "api/v1/contracts/" + SCHEDULED.transfers[1].account,
             "api/v1/contracts/" + SCHEDULING.transfers[1].account,
@@ -782,8 +796,9 @@ describe("TransactionDetails.vue", () => {
 
         expect(wrapper.text()).toMatch(RegExp("Transaction " + TransactionID.normalizeForDisplay(SCHEDULED.transaction_id)))
 
-        const link = wrapper.get("#schedulingLink")
-        expect(link.text()).toBe("Schedule create transaction")
+        const scheduling = wrapper.get("#scheduleCreateTransactionValue")
+        expect(scheduling.text()).toBe(TransactionID.normalizeForDisplay(SCHEDULING.transaction_id))
+        const link = scheduling.get('a')
         expect(link.attributes("href")).toBe(
             "/mainnet/transaction/" + SCHEDULING.consensus_timestamp
         )


### PR DESCRIPTION
**Description**:

Add proper support for schedule entities by adding a ScheduleDetails page and populating it by leveraging the data provided by the `api/v1/schedules/{scheduleId}` end-point of the Mirror Node.

Also slightly improve the related properties in TransactionDetails page.

**Related issue(s)**:

Fixes #1747 

**Notes for reviewer**:

Deployed on staging server.

<img width="1347" alt="Screenshot 2025-03-25 at 17 39 05" src="https://github.com/user-attachments/assets/406897ff-ba09-483d-9e29-be06f53b6923" />


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
