### PR TITLE
feat: Search Bar now supports schedule search by id

### DIFF
--- a/src/components/search/SearchAgent.ts
+++ b/src/components/search/SearchAgent.ts
@@ -9,6 +9,7 @@ import {
     Block,
     ContractResponse,
     ContractResultDetails,
+    Schedule,
     TokenInfo,
     TokensResponse,
     Topic,
@@ -692,6 +693,39 @@ export interface TokenLike {
     token_id: string | null
     name: string
 }
+
+
+export class ScheduleSearchAgent extends SearchAgent<EntityID, Schedule> {
+
+    //
+    // Public
+    //
+
+    public constructor() {
+        super("Schedule");
+    }
+
+    //
+    // SearchAgent
+    //
+
+    protected async load(schedID: EntityID): Promise<SearchCandidate<Schedule>[]> {
+        let result: SearchCandidate<Schedule>[]
+        try {
+            const sid = schedID.toString()
+            const scheduleInfo = (await axios.get<Schedule>("api/v1/schedules/" + sid)).data
+            const description = sid
+            const route = routeManager.makeRouteToSchedule(sid)
+            const candidate = new SearchCandidate(description, null, route, scheduleInfo, this)
+            result = [candidate]
+        } catch {
+            result = []
+        }
+
+        return Promise.resolve(result)
+    }
+}
+
 
 export class ERC20SearchAgent extends TokenNameSearchAgent {
 

--- a/src/components/search/SearchController.ts
+++ b/src/components/search/SearchController.ts
@@ -15,6 +15,7 @@ import {
     ERC721SearchAgent,
     FullTokenNameSearchAgent,
     NarrowTokenNameSearchAgent,
+    ScheduleSearchAgent,
     SearchAgent,
     TokenSearchAgent,
     TopicSearchAgent,
@@ -34,13 +35,14 @@ export class SearchController {
                                          |                  | api/v1/contracts/{shard.realm.num}
                                          |                  | api/v1/tokens/{shard.realm.num}
                                          |                  | api/v1/topics/{shard.realm.num}
-                                         |                  | api/v1/topics/{shard.realm.num}/messages
+                                         |                  | api/v1/schedules/{shard.realm.num}
     -------------------------------------+------------------+------------------------------------------------------
     integer[-checksum]                   | Incomplete       | api/v1/accounts/0.0.{integer}
                                          | Entity ID        | api/v1/contracts/0.0.{integer}
                                          |                  | api/v1/tokens/0.0.{integer}
                                          |                  | api/v1/topics/0.0.{integer}
-                                         |                  | api/v1/topics/0.0.{integer}/messages
+                                         |                  | api/v1/schedules/0.0.{integer}
+                                         |                  | api/v1/blocks/{integer}
     -------------------------------------+------------------+------------------------------------------------------
     shard.realm.num@seconds.nanoseconds  | Transaction ID   | api/v1/transactions/normalize({inputText})
     -------------------------------------+------------------+------------------------------------------------------
@@ -82,6 +84,7 @@ export class SearchController {
     private readonly contractSearchAgent = new ContractSearchAgent()
     private readonly tokenSearchAgent = new TokenSearchAgent()
     private readonly topicSearchAgent = new TopicSearchAgent()
+    private readonly scheduleSearchAgent = new ScheduleSearchAgent()
     private readonly transactionSearchAgent = new TransactionSearchAgent()
     private readonly blockSearchAgent = new BlockSearchAgent()
     private readonly narrowTokenNameSearchAgent = new NarrowTokenNameSearchAgent()
@@ -105,6 +108,7 @@ export class SearchController {
             this.accountSearchAgent,
             this.tokenSearchAgent,
             this.topicSearchAgent,
+            this.scheduleSearchAgent,
             this.transactionSearchAgent,
             this.blockSearchAgent,
             this.erc20SearchAgent,
@@ -206,6 +210,7 @@ export class SearchController {
         this.contractSearchAgent.loc.value = entityID ?? hexBytes
         this.tokenSearchAgent.loc.value = entityID ?? hexBytes
         this.topicSearchAgent.loc.value = entityID
+        this.scheduleSearchAgent.loc.value = entityID
         this.transactionSearchAgent.loc.value = transactionID ?? timestamp ?? hexBytes
         this.blockSearchAgent.loc.value = blockNb ?? hexBytes
         this.narrowTokenNameSearchAgent.loc.value = tokenName

--- a/tests/unit/search/SearchController.spec.ts
+++ b/tests/unit/search/SearchController.spec.ts
@@ -17,6 +17,7 @@ import {
     SAMPLE_CONTRACT_AS_ACCOUNT,
     SAMPLE_CONTRACT_RESULT_DETAILS,
     SAMPLE_SCHEDULING_SCHEDULED_TRANSACTIONS,
+    SAMPLE_SCHEDULE,
     SAMPLE_TOKEN,
     SAMPLE_TOKEN_DUDE,
     SAMPLE_TOPIC,
@@ -105,6 +106,12 @@ describe("SearchController.vue", () => {
             // Topic search
             const matcher0 = "api/v1/topics/" + SAMPLE_TOPIC.topic_id
             mock.onGet(matcher0).reply(200, SAMPLE_TOPIC)
+        }
+
+        {
+            // Schedule search
+            const matcher0 = "api/v1/schedules/" + SAMPLE_SCHEDULE.schedule_id
+            mock.onGet(matcher0).reply(200, SAMPLE_SCHEDULE)
         }
 
         {
@@ -206,6 +213,7 @@ describe("SearchController.vue", () => {
             "api/v1/contracts/0.0.730631",
             "api/v1/tokens/0.0.730631",
             "api/v1/topics/0.0.730631",
+            "api/v1/schedules/0.0.730631",
         ])
 
         expect(controller.visible.value).toBe(true)
@@ -265,6 +273,7 @@ describe("SearchController.vue", () => {
             "api/v1/contracts/0.0.730631",
             "api/v1/tokens/0.0.730631",
             "api/v1/topics/0.0.730631",
+            "api/v1/schedules/0.0.730631",
         ])
 
         expect(vi.getTimerCount()).toBe(0)
@@ -545,6 +554,7 @@ describe("SearchController.vue", () => {
             "api/v1/contracts/0.0.749775",
             "api/v1/tokens/0.0.749775",
             "api/v1/topics/0.0.749775",
+            "api/v1/schedules/0.0.749775",
         ])
 
         expect(vi.getTimerCount()).toBe(0)
@@ -735,6 +745,7 @@ describe("SearchController.vue", () => {
             "api/v1/contracts/0.0.29662956",
             "api/v1/tokens/0.0.29662956",
             "api/v1/topics/0.0.29662956",
+            "api/v1/schedules/0.0.29662956",
         ])
 
         expect(vi.getTimerCount()).toBe(0)
@@ -970,6 +981,7 @@ describe("SearchController.vue", () => {
             "api/v1/contracts/0.0.31407",
             "api/v1/tokens/0.0.31407",
             "api/v1/topics/0.0.31407",
+            "api/v1/schedules/0.0.31407",
         ])
 
         expect(vi.getTimerCount()).toBe(0)
@@ -985,6 +997,68 @@ describe("SearchController.vue", () => {
         expect(candidates[0].extra).toBeNull()
         expect(candidates[0].secondary).toBe(false)
         expect(candidates[0].entity).toStrictEqual(SAMPLE_TOPIC)
+
+    })
+
+
+    //
+    // Schedule
+    //
+
+    it("search schedule with id", async () => {
+
+        const inputText = ref<string>("")
+        const controller = new SearchController(inputText)
+        await flushPromises()
+        expect(vi.getTimerCount()).toBe(0)
+        expect(controller.visible.value).toBe(false)
+        expect(controller.actualInputText.value).toBe("")
+        expect(controller.loading.value).toBe(false)
+        expect(controller.candidateCount.value).toBe(0)
+        expect(controller.visibleAgents.value.length).toBe(0)
+        expect(controller.loadingDomainNameSearchAgents.value.length).toBe(0)
+
+        inputText.value = SAMPLE_SCHEDULE.schedule_id!
+        await nextTick()
+        expect(vi.getTimerCount()).toBe(1)
+        expect(controller.visible.value).toBe(false)
+        expect(controller.actualInputText.value).toBe("")
+        expect(controller.loading.value).toBe(false)
+        expect(controller.candidateCount.value).toBe(0)
+        expect(controller.visibleAgents.value.length).toBe(0)
+        expect(controller.loadingDomainNameSearchAgents.value.length).toBe(0)
+
+        vi.advanceTimersToNextTimer()
+        expect(vi.getTimerCount()).toBe(0)
+        expect(controller.visible.value).toBe(true)
+        expect(controller.actualInputText.value).toBe(SAMPLE_SCHEDULE.schedule_id)
+        expect(controller.loading.value).toBe(false)
+        expect(controller.candidateCount.value).toBe(0)
+        expect(controller.visibleAgents.value.length).toBe(0)
+        expect(controller.loadingDomainNameSearchAgents.value.length).toBe(0)
+
+        await flushPromises()
+        expect(fetchGetURLs(mock)).toStrictEqual([
+            "api/v1/accounts/0.0.1382775",
+            "api/v1/contracts/0.0.1382775",
+            "api/v1/tokens/0.0.1382775",
+            "api/v1/topics/0.0.1382775",
+            "api/v1/schedules/0.0.1382775",
+        ])
+
+        expect(vi.getTimerCount()).toBe(0)
+        expect(controller.visible.value).toBe(true)
+        expect(controller.actualInputText.value).toBe(SAMPLE_SCHEDULE.schedule_id)
+        expect(controller.loading.value).toBe(false)
+        expect(controller.candidateCount.value).toBe(1)
+        expect(controller.visibleAgents.value.length).toBe(1)
+        expect(controller.loadingDomainNameSearchAgents.value.length).toBe(0)
+        const candidates = controller.visibleAgents.value[0].candidates.value
+        expect(candidates.length).toBe(1)
+        expect(candidates[0].description).toBe(SAMPLE_SCHEDULE.schedule_id)
+        expect(candidates[0].extra).toBeNull()
+        expect(candidates[0].secondary).toBe(false)
+        expect(candidates[0].entity).toStrictEqual(SAMPLE_SCHEDULE)
 
     })
 
@@ -1045,7 +1119,7 @@ describe("SearchController.vue", () => {
 
     })
 
-    it("search scheduled transaction with id but without scheduled", async () => {
+    it("search transaction with id but without scheduled", async () => {
 
         const inputText = ref<string>("")
         const controller = new SearchController(inputText)
@@ -1359,6 +1433,7 @@ describe("SearchController.vue", () => {
             "api/v1/contracts/0.0.25175998",
             "api/v1/tokens/0.0.25175998",
             "api/v1/topics/0.0.25175998",
+            "api/v1/schedules/0.0.25175998",
             "api/v1/blocks/25175998",
         ])
 


### PR DESCRIPTION
**Description**:

Changes below enable `Search Bar` to search schedules by id.

<img width="1060" alt="image" src="https://github.com/user-attachments/assets/895bab9d-8d0e-4a2c-bda9-5513bdbc901c" />


**Related issue(s)**:

Fixes #1747 

**Notes for reviewer**:

Sample schedule on `mainnet`: `0.0.1754091`

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
