### PR TITLE
fix: miscellaneous NodeDetails fixes

### DIFF
--- a/src/components/node/NetworkDashboardItemV2.vue
+++ b/src/components/node/NetworkDashboardItemV2.vue
@@ -74,9 +74,12 @@ div.item-root {
 }
 
 div.item-l1 {
+  align-items: center;
   color: var(--text-secondary);
+  display: flex;
   font-size: 12px;
   font-weight: 500;
+  gap: 8px;
   height: 16px;
 }
 

--- a/src/components/node/NetworkDashboardItemV2.vue
+++ b/src/components/node/NetworkDashboardItemV2.vue
@@ -7,11 +7,11 @@
 <template>
 
   <div>
-    <Tooltip :text="props.tooltipLabel">
+    <Tooltip :text="tooltip">
       <div class="item-root">
         <div class="item-l1">
           {{ title }}
-          <InfoTooltip v-if="props.infoLabel" :label="props.infoLabel"/>
+          <InfoTooltip v-if="props.value && props.infoLabel" :label="props.infoLabel"/>
         </div>
 
         <div v-if="props.value !== null" class="item-l2">
@@ -20,7 +20,7 @@
         </div>
         <div v-else class="none-value">None</div>
 
-        <div v-if="props.extra" class=" item-l3">
+        <div v-if="props.value && props.extra" class=" item-l3">
           {{ props.extra }}
         </div>
       </div>
@@ -41,7 +41,10 @@ import Tooltip from "@/components/Tooltip.vue";
 
 const props = defineProps({
   title: String,
-  value: String as PropType<string | null>,
+  value: {
+    type: String as PropType<string | null>,
+    default: null
+  },
   unit: String,
   tooltipLabel: {
     type: String as PropType<string | null>,
@@ -58,6 +61,7 @@ const props = defineProps({
 })
 
 const title = computed(() => props.title?.toUpperCase())
+const tooltip = computed(() => props.value ? props.tooltipLabel : null)
 
 </script>
 

--- a/src/pages/NodeDetails.vue
+++ b/src/pages/NodeDetails.vue
@@ -86,47 +86,47 @@
           <NetworkDashboardItemV2
               id="yearlyRate"
               title="Last Period Reward Rate"
-              :value="annualizedRate.toString()"
+              :value="node ? annualizedRate.toString() : null"
               unit="APPROX ANNUAL EQUIVALENT"
           />
           <NetworkDashboardItemV2
               id="consensusStake"
               title="Stake for Consensus"
-              :value="makeFloorHbarAmount(stake)"
+              :value="node ? makeFloorHbarAmount(stake) : null"
               :unit=cryptoName
-              :info-label="node ? stakeLabel : null"
+              :info-label="stakeLabel"
               :extra="stake > 0 ? `${stakePercentage} of total` : undefined"
           />
           <NetworkDashboardItemV2
               id="rewarded"
               title="Staked for Reward"
-              :value="makeFloorHbarAmount(stakeRewarded)"
+              :value="node ? makeFloorHbarAmount(stakeRewarded): null"
               :unit=cryptoName
               :extra="`${stakeRewardedPercentage}% of total`"
           />
           <NetworkDashboardItemV2
               id="notRewarded"
               title="Staked For No Reward"
-              :value="makeFloorHbarAmount(stakeUnrewarded)"
+              :value="node ? makeFloorHbarAmount(stakeUnrewarded) : null"
               :unit=cryptoName
               :extra="`${stakeUnrewardedPercentage}% of total`"
           />
           <NetworkDashboardItemV2
               id="minStake"
               title="Min Stake"
-              :value="makeFloorHbarAmount(minStake)"
+              :value="node ? makeFloorHbarAmount(minStake) : null"
               :unit=cryptoName
           />
           <NetworkDashboardItemV2
               id="maxStake"
               title="Max Stake"
-              :value="makeFloorHbarAmount(maxStake)"
+              :value="node ? makeFloorHbarAmount(maxStake) :  null"
               :unit=cryptoName
           />
           <NetworkDashboardItemV2
               title="Current Staking Period"
               id="stakingPeriod"
-              value="24"
+              :value="node ? '24' : null"
               unit="HOURS"
               extra="from 00:00 am today to 11:59 pm today UTC"
           />

--- a/src/pages/NodeDetails.vue
+++ b/src/pages/NodeDetails.vue
@@ -94,7 +94,7 @@
               title="Stake for Consensus"
               :value="makeFloorHbarAmount(stake)"
               :unit=cryptoName
-              :info-label="stakeLabel"
+              :info-label="node ? stakeLabel : null"
               :extra="stake > 0 ? `${stakePercentage} of total` : undefined"
           />
           <NetworkDashboardItemV2

--- a/src/pages/NodeDetails.vue
+++ b/src/pages/NodeDetails.vue
@@ -161,7 +161,7 @@
 
 <script setup lang="ts">
 
-import {computed, onBeforeUnmount, onMounted, ref} from 'vue';
+import {computed, inject, onBeforeUnmount, onMounted, ref} from 'vue';
 import KeyValue from "@/components/values/KeyValue.vue";
 import AccountLink from "@/components/values/link/AccountLink.vue";
 import TimestampValue from "@/components/values/TimestampValue.vue";
@@ -183,6 +183,7 @@ import DashboardCardV2 from "@/components/DashboardCardV2.vue";
 import NetworkDashboardItemV2 from "@/components/node/NetworkDashboardItemV2.vue";
 import MirrorLink from "@/components/MirrorLink.vue";
 import HexaValue from "@/components/values/HexaValue.vue";
+import {loadingKey} from "@/AppKeys.ts";
 
 const props = defineProps({
   nodeId: {
@@ -193,6 +194,7 @@ const props = defineProps({
 })
 
 const cryptoName = CoreConfig.inject().cryptoName
+const loading = inject(loadingKey, ref(false))
 
 const nodeIdNb = computed(() => PathParam.parseNodeId(props.nodeId))
 const nodeAnalyzer = new NodeAnalyzer(nodeIdNb)
@@ -221,11 +223,9 @@ const stakeUnrewardedPercentage = computed(() =>
     networkAnalyzer.stakeUnrewardedTotal.value != 0 ? Math.round(nodeAnalyzer.stakeUnrewarded.value / networkAnalyzer.stakeUnrewardedTotal.value * 10000) / 100 : 0
 )
 
-const unknownNodeId = ref(false)
-
 const notification = computed(() => {
-  let result
-  if (unknownNodeId.value) {
+  let result: string | null
+  if (!loading.value && node.value === null) {
     result = "Node with ID " + props.nodeId + " was not found"
   } else {
     result = null

--- a/src/utils/analyzer/NodeAnalyzer.ts
+++ b/src/utils/analyzer/NodeAnalyzer.ts
@@ -3,12 +3,7 @@
 import {computed, ComputedRef, Ref} from "vue";
 import {Key, makeShortNodeDescription, NetworkNode} from "@/schemas/MirrorNodeSchemas";
 import {NetworkAnalyzer} from "@/utils/analyzer/NetworkAnalyzer";
-import {
-    makeAnnualizedRate,
-    makeNodeDescription,
-    makeRewardRate,
-    makeUnclampedStake
-} from "@/schemas/MirrorNodeUtils.ts";
+import {makeAnnualizedRate, makeNodeDescription, makeRewardRate} from "@/schemas/MirrorNodeUtils.ts";
 import {base64DecToArr, byteToHex} from "@/utils/B64Utils";
 
 export class NodeAnalyzer {
@@ -58,7 +53,7 @@ export class NodeAnalyzer {
 
     public certificateHash = computed(() => {
         const hash = this.node.value?.node_cert_hash ?? null
-        return hash != undefined ? byteToHex(base64DecToArr(hash)) : ""
+        return hash ? byteToHex(base64DecToArr(hash)) : null
     })
 
     public readonly nodeDescription: ComputedRef<string | null> = computed(

--- a/tests/unit/node/NodeDetails.spec.ts
+++ b/tests/unit/node/NodeDetails.spec.ts
@@ -64,6 +64,11 @@ describe("NodeDetails.vue", () => {
             }
         });
 
+        expect(fetchGetURLs(mock)).toStrictEqual([
+            "api/v1/network/nodes",
+            "api/v1/network/stake",
+        ])
+
         await flushPromises()
         // console.log(wrapper.html())
         // console.log(wrapper.text())
@@ -176,6 +181,12 @@ describe("NodeDetails.vue", () => {
         // console.log(wrapper.html())
         // console.log(wrapper.text())
 
+        expect(fetchGetURLs(mock)).toStrictEqual([
+            "api/v1/network/nodes",
+            "api/v1/network/stake",
+            "api/v1/contracts/0.0.5",
+        ])
+
         expect(wrapper.text()).toMatch(RegExp("Node " + node))
 
         expect(wrapper.get("#adminKeyValue").text()).toBe("Complex Key (6 levels) See details")
@@ -184,4 +195,44 @@ describe("NodeDetails.vue", () => {
         wrapper.unmount()
         await flushPromises()
     });
+
+    it("should display notification for unknown node ID", async () => {
+
+        await router.push("/") // To avoid "missing required param 'network'" error
+        const mock = new MockAdapter(axios as any);
+
+        const UNKNOWN_ID = "99999"
+        const matcher1 = "api/v1/network/nodes?node.id=" + UNKNOWN_ID
+        mock.onGet(matcher1).reply(404);
+
+        const matcher2 = "api/v1/network/stake"
+        mock.onGet(matcher2).reply(200, SAMPLE_NETWORK_STAKE);
+
+        const wrapper = mount(NodeDetails, {
+            global: {
+                plugins: [router, Oruga],
+                provide: {"isMediumScreen": false}
+            },
+            props: {
+                nodeId: UNKNOWN_ID
+            }
+        });
+
+        await flushPromises()
+        // console.log(wrapper.html())
+        // console.log(wrapper.text())
+
+        expect(fetchGetURLs(mock)).toStrictEqual([
+            "api/v1/network/nodes",
+            "api/v1/network/stake",
+        ])
+
+        expect(wrapper.text()).toMatch(RegExp("Node with ID " + UNKNOWN_ID + " was not found"))
+        expect(wrapper.get("#nodeAccountValue").text()).toBe("None")
+
+        mock.restore()
+        wrapper.unmount()
+        await flushPromises()
+    });
+
 });

--- a/tests/unit/node/NodeDetails.spec.ts
+++ b/tests/unit/node/NodeDetails.spec.ts
@@ -228,7 +228,23 @@ describe("NodeDetails.vue", () => {
         ])
 
         expect(wrapper.text()).toMatch(RegExp("Node with ID " + UNKNOWN_ID + " was not found"))
+        expect(wrapper.get("#adminKeyValue").text()).toBe("None")
         expect(wrapper.get("#nodeAccountValue").text()).toBe("None")
+        expect(wrapper.get("#descriptionValue").text()).toBe("None")
+        expect(wrapper.get("#publicKeyValue").text()).toBe("None")
+        expect(wrapper.get("#fileValue").text()).toBe("None")
+        expect(wrapper.get("#rangeFromValue").text()).toBe("None")
+        expect(wrapper.get("#rangeToValue").text()).toBe("None")
+        expect(wrapper.get("#nodeCertHashValue").text()).toBe("None")
+        expect(wrapper.get("#serviceEndpointsValue").text()).toBe("None")
+
+        expect(wrapper.get("#yearlyRate").text()).toBe("LAST PERIOD REWARD RATE None")
+        expect(wrapper.get("#consensusStake").text()).toBe("STAKE FOR CONSENSUS None")
+        expect(wrapper.get("#minStake").text()).toBe("MIN STAKE None")
+        expect(wrapper.get("#maxStake").text()).toBe("MAX STAKE None")
+        expect(wrapper.get("#rewarded").text()).toBe("STAKED FOR REWARD None")
+        expect(wrapper.get("#notRewarded").text()).toBe("STAKED FOR NO REWARD None")
+        expect(wrapper.get("#stakingPeriod").text()).toBe("CURRENT STAKING PERIOD None")
 
         mock.restore()
         wrapper.unmount()

--- a/tests/unit/transaction/ScheduleDetails.spec.ts
+++ b/tests/unit/transaction/ScheduleDetails.spec.ts
@@ -141,7 +141,7 @@ describe("TransactionDetails.vue", () => {
 
         await flushPromises()
         // console.log(wrapper.html())
-        console.log(wrapper.text())
+        // console.log(wrapper.text())
 
         expect(fetchGetURLs(mock)).toStrictEqual([
             "api/v1/network/nodes",


### PR DESCRIPTION
**Description**:

Miscellaneous fixes on the NodeDetails page when the Node ID is unknown:
- display notification banner
- display None values for all properties
- no info tooltip, or extra information in NetworkDashboardItemV2 elements
- ...

**Notes for reviewer**:

Before:

<img width="1378" alt="Screenshot 2025-03-26 at 10 50 59" src="https://github.com/user-attachments/assets/bfcb698c-a051-4ff9-821a-e5fe208f2f46" />

After:

<img width="1378" alt="Screenshot 2025-03-26 at 11 18 24" src="https://github.com/user-attachments/assets/c4c5139c-7c73-452d-8761-1fd63c1b7c2d" />

