### PR TITLE
chore: removing dependencies on Buffer class

### DIFF
--- a/src/components/token/TokenMetadataAnalyzer.ts
+++ b/src/components/token/TokenMetadataAnalyzer.ts
@@ -278,7 +278,7 @@ export class TokenMetadataAnalyzer {
             const content = await HCSAssetCache.instance.lookup(id)
             this.loadSuccessRef.value = true
             if (content?.content) {
-                result = JSON.parse(Buffer.from(content.content).toString())
+                result = JSON.parse(utf8Encode(new Uint8Array(content.content)))
             } else {
                 result = null
             }
@@ -298,7 +298,7 @@ export class TokenMetadataAnalyzer {
             const topicMessage = await TopicMessageByTimestampCache.instance.lookup(timestamp)
             this.loadSuccessRef.value = true
             if (topicMessage) {
-                result = JSON.parse(Buffer.from(topicMessage.message, 'base64').toString())
+                result = JSON.parse(utf8Encode(base64Decode(topicMessage.message)))
             } else {
                 result = null
             }

--- a/src/components/token/TokenMetadataAnalyzer.ts
+++ b/src/components/token/TokenMetadataAnalyzer.ts
@@ -8,6 +8,7 @@ import {AssetCache} from "@/utils/cache/AssetCache.ts";
 import {blob2URL} from "@/utils/URLUtils.ts";
 import {HCSAssetCache} from "@/utils/cache/HCSAssetCache.ts";
 import {HCSURI} from "@/utils/HCSURI.ts";
+import {base64Decode, utf8Encode} from "@/utils/B64Utils.ts";
 
 export interface NftAttribute {
     trait_type: string
@@ -208,7 +209,7 @@ export class TokenMetadataAnalyzer {
         this.loadErrorRef.value = false
 
         try {
-            metadata.value = Buffer.from(value ?? '', 'base64').toString()
+            metadata.value = utf8Encode(base64Decode(value ?? ''))
         } catch {
             metadata.value = value ?? ''
         }

--- a/src/components/topic/HCSContentSection.vue
+++ b/src/components/topic/HCSContentSection.vue
@@ -83,6 +83,7 @@ import MediaContent from "@/components/MediaContent.vue";
 import {HCSAsset} from "@/utils/cache/HCSAsset.ts";
 import InfoTooltip from "@/components/InfoTooltip.vue";
 import DashboardCardV2 from "@/components/DashboardCardV2.vue";
+import {utf8Encode} from "@/utils/B64Utils.ts";
 
 const props = defineProps({
   topicMemo: {
@@ -125,7 +126,7 @@ const jsonContent = computed(() => {
       && hcs1DataType.value !== null
       && (hcs1DataType.value.startsWith('application/json'))
   ) {
-    result = Buffer.from(props.hcs1Asset.content).toString()
+    result = utf8Encode(new Uint8Array(props.hcs1Asset.content))
   } else {
     result = null
   }

--- a/src/components/transaction/TransactionAnalyzer.ts
+++ b/src/components/transaction/TransactionAnalyzer.ts
@@ -4,7 +4,7 @@ import {computed, ComputedRef, ref, Ref, watch, WatchStopHandle} from "vue";
 import {TokenRelationship, Transaction, TransactionType} from "@/schemas/MirrorNodeSchemas";
 import {EntityDescriptor} from "@/utils/EntityDescriptor";
 import {computeNetAmount, isSuccessfulResult, makeOperatorAccountLabel} from "@/utils/TransactionTools";
-import {base64DecToArr, byteToHex} from "@/utils/B64Utils";
+import {base64Decode, byteToHex} from "@/utils/B64Utils";
 import {systemContractRegistry} from "@/schemas/SystemContractRegistry";
 import {TransactionID} from "@/utils/TransactionID";
 import {ContractByIdCache} from "@/utils/cache/ContractByIdCache";
@@ -78,7 +78,7 @@ export class TransactionAnalyzer {
 
     public readonly formattedHash: ComputedRef<string | null> = computed(() => {
         const hash = this.transaction.value?.transaction_hash
-        return hash ? byteToHex(base64DecToArr(hash)) : null
+        return hash ? byteToHex(base64Decode(hash)) : null
     })
 
     public readonly systemContract: ComputedRef<string | null> = computed(() => {

--- a/src/components/values/BlobValue.vue
+++ b/src/components/values/BlobValue.vue
@@ -67,6 +67,7 @@ import {blob2URL} from "@/utils/URLUtils.ts";
 import {HCSURI} from "@/utils/HCSURI.ts";
 import {routeManager} from "@/router.ts";
 import EntityLink from "@/components/values/link/EntityLink.vue";
+import {base64Decode, utf8Encode} from "@/utils/B64Utils.ts";
 
 const props = defineProps({
   blobValue: {
@@ -135,7 +136,7 @@ const b64DecodedValue = computed(() => {
   const base64regex = /^([0-9a-zA-Z+/]{4})*(([0-9a-zA-Z+/]{2}==)|([0-9a-zA-Z+/]{3}=))?$/;
   if (props.blobValue && props.base64 && base64regex.test(props.blobValue)) {
     try {
-      result = Buffer.from(props.blobValue, 'base64').toString()
+      result = utf8Encode(base64Decode(props.blobValue))
     } catch {
       result = null
     }

--- a/src/pages/ScheduleDetails.vue
+++ b/src/pages/ScheduleDetails.vue
@@ -149,7 +149,7 @@ import {ScheduleByIdCache} from "@/utils/cache/ScheduleByIdCache.ts";
 import {TransactionByTsCache} from "@/utils/cache/TransactionByTsCache.ts";
 import KeyValue from "@/components/values/KeyValue.vue";
 import TransactionLink from "@/components/values/TransactionLink.vue";
-import {base64DecToArr, byteToHex} from "@/utils/B64Utils.ts";
+import {base64Decode, byteToHex} from "@/utils/B64Utils.ts";
 import HexaValue from "@/components/values/HexaValue.vue";
 import {proto} from "@hashgraph/proto";
 import {loadingKey} from "@/AppKeys.ts";
@@ -175,7 +175,7 @@ const formattedBody = computed(() => {
   let result: string | null
   const body = schedule.value?.transaction_body
   if (body) {
-    const bodyBytes = base64DecToArr(body)
+    const bodyBytes = base64Decode(body)
     result = JSON.stringify(proto.SchedulableTransactionBody.decode(bodyBytes))
   } else {
     result = null;
@@ -184,7 +184,7 @@ const formattedBody = computed(() => {
 })
 
 const hexaFormat = (b64encoding: string) => {
-  return b64encoding ? byteToHex(base64DecToArr(b64encoding)) : null
+  return b64encoding ? byteToHex(base64Decode(b64encoding)) : null
 }
 
 const scheduleId = computed(() => props.scheduleId ?? null);

--- a/src/utils/B64Utils.ts
+++ b/src/utils/B64Utils.ts
@@ -9,7 +9,7 @@ import {ethers} from "ethers";
 // https://developer.mozilla.org/en-US/docs/Glossary/Base64
 //
 
-export function base64DecToArr(sBase64: string): Uint8Array {
+export function base64Decode(sBase64: string): Uint8Array {
     // We should simply use
     //  return ethers.decodeBase64(sBase64)
     // but in vitest environment this breaks
@@ -25,7 +25,7 @@ export function base64DecToArr(sBase64: string): Uint8Array {
 }
 
 
-export function base64EncArr(aBytes: Uint8Array): string {
+export function base64Encode(aBytes: Uint8Array): string {
     // We should simply use
     //  return ethers.encodeBase64(sBase64)
     // but in vitest environment this breaks

--- a/src/utils/B64Utils.ts
+++ b/src/utils/B64Utils.ts
@@ -41,6 +41,9 @@ export function base64Encode(aBytes: Uint8Array): string {
     // return ethers.encodeBase64(aBytes)
 }
 
+export function utf8Encode(aBytes: Uint8Array): string {
+    return ethers.toUtf8String(aBytes, ethers.Utf8ErrorFuncs.replace)
+}
 
 //
 // Hexa conversion

--- a/src/utils/B64Utils.ts
+++ b/src/utils/B64Utils.ts
@@ -9,86 +9,36 @@ import {ethers} from "ethers";
 // https://developer.mozilla.org/en-US/docs/Glossary/Base64
 //
 
-export function base64DecToArr(sBase64: string, nBlocksSize: number | undefined = undefined): Uint8Array {
+export function base64DecToArr(sBase64: string): Uint8Array {
+    // We should simply use
+    //  return ethers.decodeBase64(sBase64)
+    // but in vitest environment this breaks
+    // So we use implementation from ethers
+    // https://github.com/ethers-io/ethers.js/blob/main/src.ts/utils/base64-browser.ts
 
-    const sB64Enc = sBase64.replace(/[^A-Za-z0-9+/]/g, "")
-    const nInLen = sB64Enc.length
-    const nOutLen = nBlocksSize ? Math.ceil((nInLen * 3 + 1 >> 2) / nBlocksSize) * nBlocksSize : nInLen * 3 + 1 >> 2
-    const taBytes = new Uint8Array(nOutLen)
-
-    for (let nMod3, nMod4, nUint24 = 0, nOutIdx = 0, nInIdx = 0; nInIdx < nInLen; nInIdx += 1) {
-        nMod4 = nInIdx & 3;
-        nUint24 |= b64ToUint6(sB64Enc.charCodeAt(nInIdx)) << 6 * (3 - nMod4);
-        if (nMod4 === 3 || nInLen - nInIdx === 1) {
-            for (nMod3 = 0; nMod3 < 3 && nOutIdx < nOutLen; nMod3++, nOutIdx++) {
-                taBytes[nOutIdx] = nUint24 >>> (16 >>> nMod3 & 24) & 255;
-            }
-            nUint24 = 0;
-        }
+    sBase64 = atob(sBase64);
+    const data = new Uint8Array(sBase64.length);
+    for (let i = 0; i < sBase64.length; i++) {
+        data[i] = sBase64.charCodeAt(i);
     }
-
-    return taBytes;
-}
-
-export function b64ToUint6(nChr: number): number {
-
-    return nChr > 64 && nChr < 91 ?
-        nChr - 65
-        : nChr > 96 && nChr < 123 ?
-            nChr - 71
-            : nChr > 47 && nChr < 58 ?
-                nChr + 4
-                : nChr === 43 ?
-                    62
-                    : nChr === 47 ?
-                        63
-                        :
-                        0;
-
+    return ethers.getBytes(data);
 }
 
 
 export function base64EncArr(aBytes: Uint8Array): string {
-    let nMod3 = 2;
-    let sB64Enc = "";
+    // We should simply use
+    //  return ethers.encodeBase64(sBase64)
+    // but in vitest environment this breaks
+    // So we use implementation from ethers
+    // https://github.com/ethers-io/ethers.js/blob/main/src.ts/utils/base64-browser.ts
 
-    const nLen = aBytes.length;
-    let nUint24 = 0;
-    for (let nIdx = 0; nIdx < nLen; nIdx++) {
-        nMod3 = nIdx % 3;
-        if (nIdx > 0 && ((nIdx * 4) / 3) % 76 === 0) {
-            sB64Enc += "\r\n";
-        }
-
-        nUint24 |= aBytes[nIdx] << ((16 >>> nMod3) & 24);
-        if (nMod3 === 2 || aBytes.length - nIdx === 1) {
-            sB64Enc += String.fromCodePoint(
-                uint6ToB64((nUint24 >>> 18) & 63),
-                uint6ToB64((nUint24 >>> 12) & 63),
-                uint6ToB64((nUint24 >>> 6) & 63),
-                uint6ToB64(nUint24 & 63)
-            );
-            nUint24 = 0;
-        }
+    const data = ethers.getBytes(aBytes);
+    let textData = "";
+    for (let i = 0; i < data.length; i++) {
+        textData += String.fromCharCode(data[i]);
     }
-    return (
-        sB64Enc.substr(0, sB64Enc.length - 2 + nMod3) +
-        (nMod3 === 2 ? "" : nMod3 === 1 ? "=" : "==")
-    );
-}
-
-function uint6ToB64(nUint6: number) {
-    return nUint6 < 26
-        ? nUint6 + 65
-        : nUint6 < 52
-            ? nUint6 + 71
-            : nUint6 < 62
-                ? nUint6 - 4
-                : nUint6 === 62
-                    ? 43
-                    : nUint6 === 63
-                        ? 47
-                        : 65;
+    return btoa(textData);
+    // return ethers.encodeBase64(aBytes)
 }
 
 

--- a/src/utils/TransactionHash.ts
+++ b/src/utils/TransactionHash.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import {base64DecToArr, base64EncArr, byteToHex, hexToByte} from "@/utils/B64Utils";
+import {base64Decode, base64Encode, byteToHex, hexToByte} from "@/utils/B64Utils";
 
 export class TransactionHash {
 
@@ -16,7 +16,7 @@ export class TransactionHash {
     }
 
     public static parseBase64(base64: string): TransactionHash | null {
-        const bytes = base64DecToArr(base64)
+        const bytes = base64Decode(base64)
         return bytes !== null && bytes.length == 48 ? new TransactionHash(bytes) : null
     }
 

--- a/src/utils/analyzer/NodeAnalyzer.ts
+++ b/src/utils/analyzer/NodeAnalyzer.ts
@@ -4,7 +4,7 @@ import {computed, ComputedRef, Ref} from "vue";
 import {Key, makeShortNodeDescription, NetworkNode} from "@/schemas/MirrorNodeSchemas";
 import {NetworkAnalyzer} from "@/utils/analyzer/NetworkAnalyzer";
 import {makeAnnualizedRate, makeNodeDescription, makeRewardRate} from "@/schemas/MirrorNodeUtils.ts";
-import {base64DecToArr, byteToHex} from "@/utils/B64Utils";
+import {base64Decode, byteToHex} from "@/utils/B64Utils";
 
 export class NodeAnalyzer {
 
@@ -53,7 +53,7 @@ export class NodeAnalyzer {
 
     public certificateHash = computed(() => {
         const hash = this.node.value?.node_cert_hash ?? null
-        return hash ? byteToHex(base64DecToArr(hash)) : null
+        return hash ? byteToHex(base64Decode(hash)) : null
     })
 
     public readonly nodeDescription: ComputedRef<string | null> = computed(

--- a/src/utils/bytecode_tools/disassembler/utils/helpers.ts
+++ b/src/utils/bytecode_tools/disassembler/utils/helpers.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {EVM_OPCODES, EvmOpcode} from './evm_opcodes';
+import {hexToByte, utf8Encode} from "@/utils/B64Utils.ts";
 
 export class Helpers {
     /**
@@ -139,13 +140,12 @@ export class Helpers {
         // trace back to the begining of the encoded metadata, decode the first 6 bytes and check if they include the expected headers. If yes => remove, keep as-is otherwise.
         const potentialMetadataStartIndex =
             bytecode.length - potentialMetadataLength * 2;
-        const metadataHeader = Buffer.from(
+        const metadataHeader = utf8Encode(hexToByte(
             bytecode.substring(
                 potentialMetadataStartIndex,
-                potentialMetadataStartIndex + 6 * 2 + 1 // 6 bytes * 2 chars + 1 (included)
-            ),
-            'hex'
-        ).toString('ascii');
+                potentialMetadataStartIndex + 6 * 2 // 6 bytes * 2 chars
+            )
+        )!)
 
         if (
             metadataHeader.includes(EXPECTED_IPFS_HEADER) ||

--- a/src/utils/cache/HCSAsset.ts
+++ b/src/utils/cache/HCSAsset.ts
@@ -2,7 +2,7 @@
 
 import {TopicMessage} from "@/schemas/MirrorNodeSchemas";
 import {decompress, init} from "@bokuweb/zstd-wasm";
-import {base64Decode} from "@/utils/B64Utils.ts";
+import {base64Decode, base64Encode, byteToHex} from "@/utils/B64Utils.ts";
 import {HCSAssetFragment} from "@/utils/HCSAssetFragment.ts";
 import {getDataURLType} from "@/utils/URLUtils.ts";
 
@@ -18,7 +18,7 @@ export class HCSAsset {
         let result: string | null
         if (this.type !== null && this.content !== null) {
             const dataPrefix = `data:${this.type};base64,`
-            const urlContent = Buffer.from(this.content).toString("base64")
+            const urlContent = base64Encode(new Uint8Array<ArrayBufferLike>(this.content))
             result = dataPrefix + urlContent
         } else {
             result = null
@@ -55,9 +55,9 @@ export class HCSAsset {
                         await init()
                         this.isInitialized = true
                     }
-                    const assetContent = decompress(Buffer.from(compressedContent))
+                    const assetContent = decompress(compressedContent)
                     const assetHash = await window.crypto.subtle.digest("SHA-256", assetContent);
-                    result = new HCSAsset(assetType, assetContent, Buffer.from(assetHash).toString('hex'))
+                    result = new HCSAsset(assetType, assetContent, byteToHex(new Uint8Array(assetHash)))
                 } else { // asset is incomplete
                     result = new HCSAsset(assetType, null, null)
                 }

--- a/src/utils/cache/HCSAsset.ts
+++ b/src/utils/cache/HCSAsset.ts
@@ -2,7 +2,7 @@
 
 import {TopicMessage} from "@/schemas/MirrorNodeSchemas";
 import {decompress, init} from "@bokuweb/zstd-wasm";
-import {base64DecToArr} from "@/utils/B64Utils.ts";
+import {base64Decode} from "@/utils/B64Utils.ts";
 import {HCSAssetFragment} from "@/utils/HCSAssetFragment.ts";
 import {getDataURLType} from "@/utils/URLUtils.ts";
 
@@ -49,7 +49,7 @@ export class HCSAsset {
                     // Skip the data prefix
                     assembledContent = assembledContent.substring(assembledContent.indexOf(',') + 1)
                     // Decode from Base64
-                    const compressedContent = base64DecToArr(assembledContent)
+                    const compressedContent = base64Decode(assembledContent)
                     // Decompress (zstd)
                     if (!this.isInitialized) {
                         await init()

--- a/src/utils/wallet/client/WalletClient_Hiero.ts
+++ b/src/utils/wallet/client/WalletClient_Hiero.ts
@@ -21,7 +21,7 @@ import {
 } from "@hashgraph/sdk";
 import {ContractResultDetails, TokenAirdrop, Transaction} from "@/schemas/MirrorNodeSchemas";
 import {WalletClient, WalletClientError, WalletClientRejectError} from "@/utils/wallet/client/WalletClient";
-import {hexToByte} from "@/utils/B64Utils";
+import {base64Encode, hexToByte} from "@/utils/B64Utils";
 import {waitFor} from "@/utils/TimerUtils";
 import {TransactionByIdCache} from "@/utils/cache/TransactionByIdCache";
 import {ContractResultByTransactionIdCache} from "@/utils/cache/ContractResultByTransactionIdCache";
@@ -227,7 +227,7 @@ export class WalletClient_Hiero extends WalletClient {
             transaction.setTransactionId(TransactionId.generate(AccountId.fromString(this.accountId)))
             transaction.freeze()
             const transactionBytes = transaction.toBytes()
-            const transactionBase64 = Buffer.from(transactionBytes).toString('base64')
+            const transactionBase64 = base64Encode(transactionBytes)
             const request = {
                 method: "hedera_signAndExecuteTransaction",
                 params: {

--- a/tests/unit/search/SearchController.spec.ts
+++ b/tests/unit/search/SearchController.spec.ts
@@ -25,13 +25,13 @@ import {
     SAMPLE_TRANSACTIONS
 } from "../Mocks";
 import {fetchGetURLs} from "../MockUtils";
-import {base64DecToArr, byteToHex} from "@/utils/B64Utils.ts";
+import {base64Decode, byteToHex} from "@/utils/B64Utils.ts";
 import {SelectedTokensCache} from "@/utils/cache/SelectedTokensCache.ts";
 
 describe("SearchController.vue", () => {
 
     const mock = new MockAdapter(axios as any)
-    const TRANSACTION_HASH = byteToHex(base64DecToArr(SAMPLE_TRANSACTION.transaction_hash))
+    const TRANSACTION_HASH = byteToHex(base64Decode(SAMPLE_TRANSACTION.transaction_hash))
     const SAMPLE_SCHEDULING_TRANSACTION = SAMPLE_SCHEDULING_SCHEDULED_TRANSACTIONS.transactions![0]
     const SAMPLE_SCHEDULED_TRANSACTION = SAMPLE_SCHEDULING_SCHEDULED_TRANSACTIONS.transactions![1]
 

--- a/tests/unit/transaction/TransactionDetails.spec.ts
+++ b/tests/unit/transaction/TransactionDetails.spec.ts
@@ -46,7 +46,7 @@ import {HMSF} from "@/utils/HMSF";
 import {TransactionID} from "@/utils/TransactionID";
 import Oruga from "@oruga-ui/oruga-next";
 import ContractResult from "@/components/contract/ContractResult.vue";
-import {base64DecToArr, byteToHex} from "@/utils/B64Utils";
+import {base64Decode, byteToHex} from "@/utils/B64Utils";
 import {fetchGetURLs} from "../MockUtils";
 
 /*
@@ -294,7 +294,7 @@ describe("TransactionDetails.vue", () => {
         const SAMPLE_TRANSACTION = SAMPLE_CONTRACTCALL_TRANSACTIONS.transactions[0]
         const transactionId = SAMPLE_TRANSACTION.transaction_id
         const transactionHashBase64 = SAMPLE_TRANSACTION.transaction_hash
-        const transactionHash = byteToHex(base64DecToArr(transactionHashBase64))
+        const transactionHash = byteToHex(base64Decode(transactionHashBase64))
         const contractId = SAMPLE_TRANSACTION.entity_id
         const timestamp = SAMPLE_TRANSACTION.consensus_timestamp
 


### PR DESCRIPTION
**Description**:

Changes below replace calls to `Buffer.from()` and `Buffer.toString()` by their browser equivalent.
`Buffer` class is part of `nodejs` environment and is not natively available in `browser` environment.
With those changes, Explorer source code no longer depends on `Buffer`/`nodejs`. 
It relies on `ethers` library (which has browser compatible functions for base64, hex and utf8 encoding).

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
