### PR TITLE
chore: removing node typing setup and matching dependency.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,6 @@
         "@tsconfig/node18": "^18.2.4",
         "@types/file-saver": "^2.0.7",
         "@types/jsdom": "^21.1.7",
-        "@types/node": "^22.13.13",
         "@types/prismjs": "^1.26.5",
         "@vitejs/plugin-basic-ssl": "^2.0.0",
         "@vitejs/plugin-vue": "^5.2.3",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "@tsconfig/node18": "^18.2.4",
     "@types/file-saver": "^2.0.7",
     "@types/jsdom": "^21.1.7",
-    "@types/node": "^22.13.13",
     "@types/prismjs": "^1.26.5",
     "@vitejs/plugin-basic-ssl": "^2.0.0",
     "@vitejs/plugin-vue": "^5.2.3",

--- a/tsconfig.vitest.json
+++ b/tsconfig.vitest.json
@@ -5,6 +5,6 @@
   "compilerOptions": {
     "composite": true,
     "lib": [],
-    "types": ["node", "jsdom"]
+    "types": ["jsdom"]
   }
 }


### PR DESCRIPTION
**Description**:

Changes below remove typing setup for `node` api and matching dependency `@types/node`.
This will help to keep Explorer source code clean of node dependencies.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
