### PR TITLE
feat: include transaction timestamps (HH:MM:SS) in exported CSV output

### DIFF
--- a/src/utils/downloader/EntityDownloader.ts
+++ b/src/utils/downloader/EntityDownloader.ts
@@ -22,6 +22,7 @@ export abstract class EntityDownloader<E, R> {
     private runPromise: Promise<void> | null = null
     private abortRequested = false
     private readonly dateFormat = EntityDownloader.makeDateFormat()
+    private readonly dateTimeFormat = EntityDownloader.makeDateTimeFormat()
     private readonly now = new Date()
 
     //
@@ -133,7 +134,7 @@ export abstract class EntityDownloader<E, R> {
     public csvBlob: ComputedRef<Blob | null> = computed(() => {
         let result: Blob | null
         if (this.state.value == DownloaderState.Completed && this.entitiesRef.value.length >= 1) {
-            const encoder = this.makeCSVEncoder(this.dateFormat)
+            const encoder = this.makeCSVEncoder(this.dateTimeFormat)
             result = new Blob([encoder.encode()], {type: "text/csv"})
         } else {
             result = null
@@ -223,6 +224,19 @@ export abstract class EntityDownloader<E, R> {
     private static makeDateFormat(): Intl.DateTimeFormat {
         const locale = "en-US"
         const dateOptions: Intl.DateTimeFormatOptions = {
+            day: "2-digit",
+            month: "2-digit",
+            year: "numeric",
+        }
+        return new Intl.DateTimeFormat(locale, dateOptions)
+    }
+
+    private static makeDateTimeFormat(): Intl.DateTimeFormat {
+        const locale = "en-US"
+        const dateOptions: Intl.DateTimeFormatOptions = {
+            second: "2-digit",
+            minute: "2-digit",
+            hour: "2-digit",
             day: "2-digit",
             month: "2-digit",
             year: "numeric",


### PR DESCRIPTION
**Description**:

Changes below update cvs generator so that `#date` column includes both `date` and `time`.

<img width="842" alt="image" src="https://github.com/user-attachments/assets/4bc721f1-0f8d-42d8-9080-8d1bb49994ee" />


**Related issue(s)**:

Fixes #1764 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
