### PR TITLE
chore: move CSS font directives back to explorer.css

### DIFF
--- a/public/style-config.css
+++ b/public/style-config.css
@@ -1,33 +1,6 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 /*  ============================================================================
-    Fonts
-*/
-@import "@/fonts/styreneA/1802-UFGULA.css";
-
-@font-face {
-    font-family: 'Inter';
-    font-style: normal;
-    font-weight: 100 900;
-    font-display: swap;
-    src: url('@/fonts/Inter/Inter-VariableFont_opsz,wght.ttf') format('truetype');
-}
-
-@font-face {
-    font-family: 'Geist Mono';
-    font-style: normal;
-    font-weight: 100 900;
-    font-display: swap;
-    src: url('@/fonts/Geist_Mono/GeistMono-VariableFont_wght.ttf') format('truetype');
-}
-
-:root {
-    --font-family-heading: 'Styrene A Web';
-    --font-family-proportional: 'Inter';
-    --font-family-monospace: 'Geist Mono';
-}
-
-/*  ============================================================================
     Color Themes / Modes
 */
 :root {
@@ -110,3 +83,4 @@
     --dark-status-error-color: #C40E3A;
     --dark-search-bar-default: #2C2C2C;
     --dark-graph-line-color: #1300FF;
+}

--- a/src/styles/explorer.css
+++ b/src/styles/explorer.css
@@ -3,6 +3,32 @@
 @import "../../node_modules/@oruga-ui/theme-oruga/dist/oruga.css";
 @import "oruga-customization.css";
 
+/*  ============================================================================
+    Fonts
+*/
+@import "@/fonts/styreneA/1802-UFGULA.css";
+
+@font-face {
+    font-family: 'Inter';
+    font-style: normal;
+    font-weight: 100 900;
+    font-display: swap;
+    src: url('@/fonts/Inter/Inter-VariableFont_opsz,wght.ttf') format('truetype');
+}
+
+@font-face {
+    font-family: 'Geist Mono';
+    font-style: normal;
+    font-weight: 100 900;
+    font-display: swap;
+    src: url('@/fonts/Geist_Mono/GeistMono-VariableFont_wght.ttf') format('truetype');
+}
+
+:root {
+    --font-family-heading: 'Styrene A Web';
+    --font-family-proportional: 'Inter';
+    --font-family-monospace: 'Geist Mono';
+}
 
 /*  ============================================================================
     Color Themes / Modes
@@ -34,7 +60,7 @@
     --status-success-color: var(--light-status-success-color);
     --status-error-color: var(--light-status-error-color);
     --search-bar-default: var(--light-search-bar-default);
-    --graph-line-color:  var(--light-graph-line-color);
+    --graph-line-color: var(--light-graph-line-color);
 
     --network-button-text-color: var(--light-network-button-text-color);
     --network-button-color: var(--light-network-button-color);


### PR DESCRIPTION
**Description**:

[Follow-up to PR https://github.com/hiero-ledger/hiero-mirror-node-explorer/pull/1790]
CSS font directives (`@import` and `@font-face`) need to be in `explorer.css` since the fonts are located inside the repo.
These have been unduly moved to `public/style-config.css` alongside the CSS variables in the PR above.
