### PR TITLE
fix: mask HTTP 400 errors in ContractDetails

### DIFF
--- a/src/utils/ERCUtils.ts
+++ b/src/utils/ERCUtils.ts
@@ -101,17 +101,19 @@ export class ERCUtils {
     // Private
     //
 
+    private static privateAxios = axios.create()
+
     private static async call(targetAddress: string, abi: string, values: unknown[]): Promise<unknown[] | null> {
         let result: unknown[] | null
         const itf = new ethers.Interface([abi])
         const functionData = itf.encodeFunctionData(abi, values)
-        const url = "api/v1/contracts/call"
+        const url = axios.defaults.baseURL + "api/v1/contracts/call"
         const body: ContractCallRequest = {
             data: functionData,
             to: targetAddress,
         }
         try {
-            const response = await axios.post<ContractCallResponse>(url, body)
+            const response = await ERCUtils.privateAxios.post<ContractCallResponse>(url, body)
             result = itf.decodeFunctionResult(abi, response.data.result)
         } catch (error) {
             if (axios.isAxiosError(error) && error.status === 400) {


### PR DESCRIPTION
**Description**:

Use a private axios instance in `ERCUtils` to make calls to `api/v1/contracts/call`. These contract calls return CONTRACT_REVERT_EXECUTED when the contract does not support the interface, causing MN to return an HTTP 400 error, which is by default highlighted in the page header by `AxiosMonitor`.
