### PR TITLE
chore: bump NodeJS version from 20 to 22.

### DIFF
--- a/.github/workflows/zxc-compile-explorer-code.yaml
+++ b/.github/workflows/zxc-compile-explorer-code.yaml
@@ -54,7 +54,7 @@ jobs:
       - name: Setup NodeJS
         uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - name: Setup Xvfb


### PR DESCRIPTION
**Description**:

Update nodeJS version in GH workflow.