### PR TITLE
ci: Update step-security conventional-pr-title-check-action to v3.2.1

### DIFF
--- a/.github/workflows/flow-pull-request-formatting.yaml
+++ b/.github/workflows/flow-pull-request-formatting.yaml
@@ -1,6 +1,12 @@
 name: "PR Formatting"
 on:
   workflow_dispatch:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - edited
+      - synchronize
   pull_request_target:
     types:
       - opened
@@ -31,6 +37,6 @@ jobs:
           egress-policy: audit
 
       - name: Check PR Title
-        uses: step-security/conventional-pr-title-action@19fb561b33015fd2184055a05ce5a3bcf2ba3f54 # v3.2.0
+        uses: step-security/conventional-pr-title-action@8a8989588c2547f23167c4c42f0fb2356479e81b # v3.2.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**Description**:

Update the step-security/conventional-pr-title-action to use v3.2.1

**Related issue(s)**:

Fixes #1830