### PR TITLE
feat: support for `payable` keyword in Contract ABI tab

### DIFF
--- a/src/dialogs/abi/ContractAbiController.ts
+++ b/src/dialogs/abi/ContractAbiController.ts
@@ -33,7 +33,10 @@ export class ContractAbiController extends TaskController {
     //
 
     public canBeExecuted(): boolean {
-        return this.contractCallBuilder.functionData.value !== null
+        const functionDataOK = this.contractCallBuilder.functionData.value !== null
+        const payableValueOK = this.contractCallBuilder.payableValueBuilder === null
+                                || this.contractCallBuilder.payableValue.value !== null
+        return functionDataOK && payableValueOK
     }
 
     public async execute(): Promise<void> {

--- a/src/dialogs/abi/ContractAbiDialog.vue
+++ b/src/dialogs/abi/ContractAbiDialog.vue
@@ -19,9 +19,9 @@
           </template>
           <template v-if="payableValueBuilder">
             <div style="align-self: center">{{ payableValueBuilder.paramType.name }}</div>
-            <ParamTypeEditor :param-builder="payableValueBuilder" style="width: 100%"/>
+            <ParamTbarEditor :param-builder="payableValueBuilder" style="width: 100%"/>
             <div/>
-            <div>{{ payableValueBuilder.paramType.format() }}</div>
+            <div>tBAR</div>
           </template>
         </div>
       </template>
@@ -75,6 +75,7 @@ import {ContractAbiController} from "@/dialogs/abi/ContractAbiController.ts";
 import ParamTypeEditor from "@/dialogs/abi/ParamTypeEditor.vue";
 import {TaskPanelMode} from "@/dialogs/core/DialogUtils.ts";
 import TaskPanel from "@/dialogs/core/task/TaskPanel.vue";
+import ParamTbarEditor from "@/dialogs/abi/ParamTbarEditor.vue";
 
 const showDialog = defineModel("showDialog", {
   type: Boolean,

--- a/src/dialogs/abi/ContractAbiDialog.vue
+++ b/src/dialogs/abi/ContractAbiDialog.vue
@@ -12,16 +12,18 @@
       <template v-else>
         <div class="dialog-grid" style="align-self: stretch">
           <template v-for="b of paramBuilders" :key="b.paramType.name">
-            <div style="align-self: center">{{ b.paramType.name }}</div>
-            <ParamTypeEditor :param-builder="b" style="width: 100%"/>
-            <div/>
-            <div>{{ b.paramType.format() }}</div>
+            <div style="align-self: flex-start">{{ b.paramType.name }}</div>
+            <div>
+              <ParamTypeEditor :param-builder="b" style="width: 100%"/>
+              <div style="font-size: 12px; color: var(--text-secondary)">{{ b.paramType.format() }}</div>
+            </div>
           </template>
           <template v-if="payableValueBuilder">
-            <div style="align-self: center">{{ payableValueBuilder.paramType.name }}</div>
-            <ParamTbarEditor :param-builder="payableValueBuilder" style="width: 100%"/>
-            <div/>
-            <div>tBAR</div>
+            <div style="align-self: flex-start">{{ payableValueBuilder.paramType.name }}</div>
+            <div>
+              <ParamTbarEditor :param-builder="payableValueBuilder" style="width: 100%"/>
+              <div style="font-size: 12px; color: var(--text-secondary)">tBAR</div>
+            </div>
           </template>
         </div>
       </template>
@@ -123,6 +125,7 @@ const taskDialogDidSucceed = () => {
   display: grid;
   grid-template-columns: 2fr 5fr;
   grid-column-gap: 1rem;
+  row-gap: 10px;
 }
 
 </style>

--- a/src/dialogs/abi/ContractAbiDialog.vue
+++ b/src/dialogs/abi/ContractAbiDialog.vue
@@ -17,6 +17,12 @@
             <div/>
             <div>{{ b.paramType.format() }}</div>
           </template>
+          <template v-if="payableValueBuilder">
+            <div style="align-self: center">{{ payableValueBuilder.paramType.name }}</div>
+            <ParamTypeEditor :param-builder="payableValueBuilder" style="width: 100%"/>
+            <div/>
+            <div>{{ payableValueBuilder.paramType.format() }}</div>
+          </template>
         </div>
       </template>
     </template>
@@ -90,6 +96,7 @@ const controller = new ContractAbiController(showDialog, props.contractCallBuild
 
 const dialogTitle = computed(() => props.contractCallBuilder.fragment.name + "()")
 const paramBuilders = computed(() => props.contractCallBuilder.paramBuilders)
+const payableValueBuilder = computed(() => props.contractCallBuilder?.payableValueBuilder)
 const hasResult = computed(() => props.contractCallBuilder.hasResult())
 const callOutput = computed(() => props.contractCallBuilder.callOutput)
 const errorMessage = controller.errorMessage

--- a/src/dialogs/abi/ContractCallBuilder.ts
+++ b/src/dialogs/abi/ContractCallBuilder.ts
@@ -139,7 +139,7 @@ export class ContractCallBuilder {
 
 
     private static async executeWithWallet(contractId: string, functionData: string): Promise<string | null> {
-        const callResult = await walletManager.callContract(contractId, functionData)
+        const callResult = await walletManager.callContract(contractId, functionData, null)
         return typeof callResult == "string" ? null : callResult.call_result
     }
 

--- a/src/dialogs/abi/ParamTbarEditor.vue
+++ b/src/dialogs/abi/ParamTbarEditor.vue
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                     TEMPLATE                                                    -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<template>
+  <input class="input is-small has-text-white" type="number" v-model="currentText"/>
+</template>
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                      SCRIPT                                                     -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<script setup lang="ts">
+
+import {computed, onBeforeUnmount, onMounted, PropType, ref, watch, WatchStopHandle} from "vue";
+import {ContractParamBuilder} from "@/dialogs/abi/ContractCallBuilder.ts";
+import {AppStorage} from "@/AppStorage.ts";
+import {ethers} from "ethers";
+
+const props = defineProps({
+  paramBuilder: {
+    type: Object as PropType<ContractParamBuilder>,
+    required: true
+  },
+})
+
+const currentText = ref<string>("")
+
+const lastParamData = computed(() => {
+  const functionHash = props.paramBuilder.callBuilder.fragment.selector
+  const paramName = props.paramBuilder.paramType.name
+  return AppStorage.getInputParam(functionHash, paramName)
+})
+
+let watchHandle: WatchStopHandle | null = null
+onMounted(() => {
+  currentText.value = paramDataToText(lastParamData.value) ?? ""
+  watchHandle = watch(currentText, () => {
+    props.paramBuilder.paramData.value = textToParamData(currentText.value)
+  }, {immediate: true})
+})
+onBeforeUnmount(() => {
+  if (watchHandle !== null) {
+    watchHandle()
+    watchHandle = null
+  }
+  props.paramBuilder.paramData.value = null
+  currentText.value = ""
+})
+
+const textToParamData = (text: string): string|null => {
+  let result: string|null
+
+  // text is an amount in tBAR
+  // 1 tBAR <=> 10_000_000_000 weiBAR
+  // https://hips.hedera.com/hip/hip-410#value-of-gas-price-and-value-fields
+  try {
+    const weiBAR = ethers.getBigInt(text) * 10_000_000_000n
+    result = ethers.toBeHex(weiBAR, 32)
+  } catch {
+    result = null
+  }
+  return result
+}
+
+const paramDataToText = (paramData: unknown): string|null => {
+  let result: string|null
+  if (typeof paramData == "string") {
+    // paramData is hex encoding of a weiBAR amount
+    // 1 weiBAR <=> 1 / 10_000_000_000 tBAR
+    // https://hips.hedera.com/hip/hip-410#value-of-gas-price-and-value-fields
+    try {
+      const weiBAR = ethers.getBigInt(paramData)
+      const tBAR = weiBAR / 10_000_000_000n
+      result = tBAR.toString()
+    } catch {
+      result = null
+    }
+  } else {
+    result = null
+  }
+  return result
+}
+
+</script>
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                       STYLE                                                     -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<style/>

--- a/src/dialogs/abi/ParamTbarEditor.vue
+++ b/src/dialogs/abi/ParamTbarEditor.vue
@@ -5,7 +5,7 @@
 <!-- --------------------------------------------------------------------------------------------------------------- -->
 
 <template>
-  <input class="input is-small has-text-white" type="number" v-model="currentText"/>
+  <input class="input is-small has-text-white" type="number" min="0" v-model="currentText"/>
 </template>
 
 <!-- --------------------------------------------------------------------------------------------------------------- -->

--- a/src/utils/wallet/WalletManagerV4.ts
+++ b/src/utils/wallet/WalletManagerV4.ts
@@ -206,9 +206,9 @@ export class WalletManagerV4 {
         }
     }
 
-    public async callContract(contractId: string, functionData: string): Promise<ContractResultDetails | string> {
+    public async callContract(contractId: string, functionData: string, value: string|null): Promise<ContractResultDetails | string> {
         if (this.client.value !== null) {
-            return await this.client.value.callContract(contractId, functionData)
+            return await this.client.value.callContract(contractId, functionData, value)
         } else {
             throw "bug"
         }

--- a/src/utils/wallet/client/WalletClient.ts
+++ b/src/utils/wallet/client/WalletClient.ts
@@ -26,7 +26,7 @@ export abstract class WalletClient {
     }
 
 
-    public async callContract(contractId: string, functionData: string): Promise<ContractResultDetails | string> {
+    public async callContract(contractId: string, functionData: string, value: string|null): Promise<ContractResultDetails | string> {
         throw "to be implemented"
     }
 

--- a/src/utils/wallet/client/WalletClient_Ethereum.ts
+++ b/src/utils/wallet/client/WalletClient_Ethereum.ts
@@ -150,8 +150,7 @@ export class WalletClient_Ethereum extends WalletClient {
             gasPrice: "0x1D1A94A2000", // 2_000_000_000_000
         }
         if (value !== null) {
-            // ethParams["value"] = value
-            ethParams["value"] = "0x02"
+            ethParams["value"] = value
         }
         const request = {
             method: "eth_sendTransaction",

--- a/src/utils/wallet/client/WalletClient_Ethereum.ts
+++ b/src/utils/wallet/client/WalletClient_Ethereum.ts
@@ -94,15 +94,15 @@ export class WalletClient_Ethereum extends WalletClient {
     }
 
 
-    public async callContract(contractId: string, functionData: string): Promise<ContractResultDetails | string> {
-        return this.executeCall(contractId, functionData)
+    public async callContract(contractId: string, functionData: string, value: string|null): Promise<ContractResultDetails | string> {
+        return this.executeCall(contractId, functionData, value)
     }
 
     //
     // Private
     //
 
-    private async executeCall(targetId: string, callData: string): Promise<string> {
+    private async executeCall(targetId: string, callData: string, value: string|null = null): Promise<string> {
         let result: string
 
         const accountAddress = await AccountByIdCache.instance.findAccountAddress(this.accountId)
@@ -118,7 +118,7 @@ export class WalletClient_Ethereum extends WalletClient {
             // 2) Sends transaction
             let ethHash: string
             try {
-                ethHash = await this.sendTransaction(accountAddress, "0x" + tokenAddress, callData)
+                ethHash = await this.sendTransaction(accountAddress, "0x" + tokenAddress, callData, value)
             } catch (reason) {
                 if (eth_isUserReject(reason)) {
                     throw new WalletClientRejectError()
@@ -141,13 +141,17 @@ export class WalletClient_Ethereum extends WalletClient {
         return result
     }
 
-    private async sendTransaction(fromAddress: string, toAddress: string, callData: string): Promise<string> {
-        const ethParams = {
+    private async sendTransaction(fromAddress: string, toAddress: string, callData: string, value: string|null): Promise<string> {
+        const ethParams: Record<string, any> = {
             from: fromAddress,
             to: toAddress,
             data: callData,
             gas: "0x1E8480", // 2_000_000
-            gasPrice: "0x1D1A94A2000" // 2_000_000_000_000
+            gasPrice: "0x1D1A94A2000", // 2_000_000_000_000
+        }
+        if (value !== null) {
+            // ethParams["value"] = value
+            ethParams["value"] = "0x02"
         }
         const request = {
             method: "eth_sendTransaction",

--- a/src/utils/wallet/client/WalletClient_Hiero.ts
+++ b/src/utils/wallet/client/WalletClient_Hiero.ts
@@ -189,7 +189,7 @@ export class WalletClient_Hiero extends WalletClient {
         return Promise.resolve(result)
     }
 
-    public async callContract(contractId: string, functionData: string): Promise<ContractResultDetails | string> {
+    public async callContract(contractId: string, functionData: string, value: string|null): Promise<ContractResultDetails | string> {
         let result: string | ContractResultDetails
 
         const fp = hexToByte(functionData)


### PR DESCRIPTION
**Description**:

Changes below implement support for `payable` keyword in `Contract` `ABI` tab.

When a contract function is declared `payable`, `Contract Call` dialog now displays an additional text field to input an amount of `tBAR` : this amount is converted to `weiBAR` and passed to `value` field (of `eth_sendTransaction`).

<img width="467" alt="image" src="https://github.com/user-attachments/assets/a6a0523e-bf59-4968-966d-8c7025e4133d" />

**Related issue(s)**:

Fixes #1737 

**Notes for reviewer**:

- navigate to testnet contract `0.0.5712725`
- goto `ABI` tab in `Contract Bytecode` section
- run `deposit()` function
- type an amount of `tbar`, execute and approve transaction in your wallet
- goto `Recent Contract Calls` section : last executed transaction matches `deposit()` call and shows transferred `value`

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
