### PR TITLE
chore: avoid unneeded calls to 4byte directory in FunctionCallAnalyzer

### DIFF
--- a/src/utils/analyzer/FunctionCallAnalyzer.ts
+++ b/src/utils/analyzer/FunctionCallAnalyzer.ts
@@ -42,7 +42,7 @@ export class FunctionCallAnalyzer {
 
     public mount(): void {
         this.watchHandle.value = [
-            watch([this.functionHash], this.updateSignatureResponse, {immediate: true}),
+            watch([this.functionHash, this.contractAnalyzer.report], this.updateSignatureResponse, {immediate: true}),
             watch([this.functionHash, this.contractAnalyzer.interface, this.signatureResponse, this.input], this.updateFunctionFragment, {immediate: true}),
             watch([this.input, this.functionFragment], this.updateInputResult, {immediate: true}),
             watch([this.output, this.functionFragment], this.updateOutputResult, {immediate: true}),
@@ -209,7 +209,9 @@ export class FunctionCallAnalyzer {
     }
 
     private readonly updateSignatureResponse = async () => {
-        if (this.functionHash.value !== null) {
+        if (this.functionHash.value !== null
+            && this.contractAnalyzer.report.value !== null
+            && this.contractAnalyzer.report.value.abi === null) {
             try {
                 this.signatureResponse.value = await SignatureCache.instance.lookup(this.functionHash.value)
             } catch {

--- a/tests/unit/contract/ContractResult.spec.ts
+++ b/tests/unit/contract/ContractResult.spec.ts
@@ -1,3 +1,5 @@
+// noinspection DuplicatedCode
+
 // SPDX-License-Identifier: Apache-2.0
 
 import {describe, expect, it} from 'vitest'
@@ -65,7 +67,6 @@ describe("ContractResult.vue", () => {
             "api/v1/contracts/results",
             "api/v1/network/fees",
             "api/v1/contracts/" + SAMPLE_CONTRACT_RESULT_DETAILS.contract_id + "/results/1646025151.667604000",
-            "https://www.4byte.directory/api/v1/signatures/?format=json&hex_signature=0x18cbafe5",
             "api/v1/contracts/0.0.846260",
             "api/v1/contracts/" + SAMPLE_CONTRACT_RESULT_DETAILS.contract_id,
             "api/v1/transactions",
@@ -79,6 +80,7 @@ describe("ContractResult.vue", () => {
             "api/v1/accounts/" + SAMPLE_CONTRACT_RESULT_DETAILS.logs[2].address,
             "api/v1/tokens/" + SAMPLE_CONTRACT_RESULT_DETAILS.contract_id,
             "api/v1/tokens/" + SAMPLE_CONTRACT_RESULT_DETAILS.logs[1].contract_id,
+            "https://www.4byte.directory/api/v1/signatures/?format=json&hex_signature=0x18cbafe5",
         ])
 
         expect(wrapper.text()).toMatch(RegExp("^Contract Result for " + contractId + " at " + timestamp))
@@ -136,7 +138,6 @@ describe("ContractResult.vue", () => {
             "api/v1/contracts/results",
             "api/v1/network/fees",
             "api/v1/contracts/" + SAMPLE_REVERT_CONTRACT_RESULT_DETAILS.contract_id + "/results/1677085141.263832358",
-            "https://www.4byte.directory/api/v1/signatures/?format=json&hex_signature=0x49257b42",
             "api/v1/contracts/0.0.1466",
             "api/v1/contracts/" + SAMPLE_REVERT_CONTRACT_RESULT_DETAILS.contract_id,
             "api/v1/transactions",
@@ -146,6 +147,7 @@ describe("ContractResult.vue", () => {
             "api/v1/accounts/" + SAMPLE_REVERT_CONTRACT_RESULT_DETAILS.from,
             "api/v1/accounts/" + SAMPLE_REVERT_CONTRACT_RESULT_DETAILS.to,
             "api/v1/tokens/" + SAMPLE_REVERT_CONTRACT_RESULT_DETAILS.contract_id,
+            "https://www.4byte.directory/api/v1/signatures/?format=json&hex_signature=0x49257b42",
         ])
 
         expect(wrapper.text()).toMatch(RegExp("^Contract Result for " + contractId + " at " + timestamp))
@@ -198,7 +200,6 @@ describe("ContractResult.vue", () => {
             "api/v1/contracts/results",
             "api/v1/network/fees",
             "api/v1/contracts/" + SAMPLE_REVERT_CONTRACT_RESULT_DETAILS_WITH_TRACES.contract_id + "/results/1677504382.107973330",
-            "https://www.4byte.directory/api/v1/signatures/?format=json&hex_signature=0x7d1ee005",
             "api/v1/contracts/0.0.8942",
             "api/v1/contracts/results/" + SAMPLE_REVERT_CONTRACT_RESULT_DETAILS_WITH_TRACES.hash + "/actions?limit=100",
             "api/v1/transactions",
@@ -223,6 +224,7 @@ describe("ContractResult.vue", () => {
             "api/v1/tokens/0.0.10410",
             "api/v1/tokens/0.0.33481",
             "api/v1/tokens/" + SAMPLE_REVERT_CONTRACT_RESULT_DETAILS_WITH_TRACES.contract_id,
+            "https://www.4byte.directory/api/v1/signatures/?format=json&hex_signature=0x7d1ee005",
             "api/v1/tokens/0.0.33483",
         ])
 

--- a/tests/unit/transaction/TransactionDetails.spec.ts
+++ b/tests/unit/transaction/TransactionDetails.spec.ts
@@ -241,7 +241,6 @@ describe("TransactionDetails.vue", () => {
             "api/v1/contracts/" + SAMPLE_CONTRACTCALL_TRANSACTIONS.transactions[0].transfers[1].account,
             "api/v1/contracts/" + SAMPLE_CONTRACT_RESULT_DETAILS.contract_id + "/results/1646665766.574738471",
             "api/v1/accounts/",
-            "https://www.4byte.directory/api/v1/signatures/?format=json&hex_signature=0x18cbafe5",
             "api/v1/contracts/0.0.846260", // SAMPLE_CONTRACT_RESULT_DETAILS.from as entity id
             "api/v1/contracts/" + SAMPLE_CONTRACT_RESULT_DETAILS.contract_id,
             "api/v1/contracts/results/" + SAMPLE_CONTRACT_RESULT_DETAILS.hash + "/actions?limit=100",
@@ -255,6 +254,7 @@ describe("TransactionDetails.vue", () => {
             "api/v1/accounts/0x0000000000000000000000000000000000108a83",
             "api/v1/tokens/" + SAMPLE_CONTRACT_RESULT_DETAILS.contract_id,
             "api/v1/tokens/" + SAMPLE_CONTRACT_RESULT_DETAILS.logs[1].contract_id,
+            "https://www.4byte.directory/api/v1/signatures/?format=json&hex_signature=0x18cbafe5",
         ])
 
         expect(wrapper.text()).toMatch(RegExp("Transaction " + TransactionID.normalizeForDisplay(transactionId)))

--- a/tests/unit/utils/analyzer/ContractActionAnalyzer.spec.ts
+++ b/tests/unit/utils/analyzer/ContractActionAnalyzer.spec.ts
@@ -47,9 +47,9 @@ describe("ContractActionAnalyzer.spec.ts", () => {
         expect(analyzer.fromId.value).toBe("0.0.96039")
         expect(analyzer.toId.value).toBe("0.0.96037")
         expect(fetchGetURLs(mock)).toStrictEqual([
-            "https://www.4byte.directory/api/v1/signatures/?format=json&hex_signature=0x70a08231",
             "api/v1/contracts/0.0.96037",
             "api/v1/tokens/0.0.96037",
+            "https://www.4byte.directory/api/v1/signatures/?format=json&hex_signature=0x70a08231",
         ])
 
         // 4) unmount
@@ -58,9 +58,9 @@ describe("ContractActionAnalyzer.spec.ts", () => {
         expect(analyzer.fromId.value).toBeNull()
         expect(analyzer.toId.value).toBeNull()
         expect(fetchGetURLs(mock)).toStrictEqual([
-            "https://www.4byte.directory/api/v1/signatures/?format=json&hex_signature=0x70a08231",
             "api/v1/contracts/0.0.96037",
             "api/v1/tokens/0.0.96037",
+            "https://www.4byte.directory/api/v1/signatures/?format=json&hex_signature=0x70a08231",
         ])
 
         SignatureCache.instance.clear()
@@ -104,9 +104,9 @@ describe("ContractActionAnalyzer.spec.ts", () => {
         await flushPromises()
         expect(fetchGetURLs(mock)).toStrictEqual([
             "api/v1/accounts/0x0000000000000000000000000000000000017727",
-            "https://www.4byte.directory/api/v1/signatures/?format=json&hex_signature=0x70a08231",
             "api/v1/contracts/0.0.96037",
             "api/v1/tokens/0.0.96037",
+            "https://www.4byte.directory/api/v1/signatures/?format=json&hex_signature=0x70a08231",
         ])
         expect(analyzer.action.value).toStrictEqual(SAMPLE_ACTION)
         expect(analyzer.fromId.value).toBe("0.0.96039")
@@ -119,9 +119,9 @@ describe("ContractActionAnalyzer.spec.ts", () => {
         expect(analyzer.toId.value).toBeNull()
         expect(fetchGetURLs(mock)).toStrictEqual([
             "api/v1/accounts/0x0000000000000000000000000000000000017727",
-            "https://www.4byte.directory/api/v1/signatures/?format=json&hex_signature=0x70a08231",
             "api/v1/contracts/0.0.96037",
             "api/v1/tokens/0.0.96037",
+            "https://www.4byte.directory/api/v1/signatures/?format=json&hex_signature=0x70a08231",
         ])
 
         AccountByAddressCache.instance.clear()
@@ -166,9 +166,9 @@ describe("ContractActionAnalyzer.spec.ts", () => {
         await flushPromises()
         expect(fetchGetURLs(mock)).toStrictEqual([
             "api/v1/accounts/0x0000000000000000000000000000000000017725",
-            "https://www.4byte.directory/api/v1/signatures/?format=json&hex_signature=0x70a08231",
             "api/v1/contracts/0.0.96037",
             "api/v1/tokens/0.0.96037",
+            "https://www.4byte.directory/api/v1/signatures/?format=json&hex_signature=0x70a08231",
         ])
         expect(analyzer.action.value).toStrictEqual(SAMPLE_ACTION)
         expect(analyzer.fromId.value).toBe("0.0.96039")
@@ -181,9 +181,9 @@ describe("ContractActionAnalyzer.spec.ts", () => {
         expect(analyzer.toId.value).toBeNull()
         expect(fetchGetURLs(mock)).toStrictEqual([
             "api/v1/accounts/0x0000000000000000000000000000000000017725",
-            "https://www.4byte.directory/api/v1/signatures/?format=json&hex_signature=0x70a08231",
             "api/v1/contracts/0.0.96037",
             "api/v1/tokens/0.0.96037",
+            "https://www.4byte.directory/api/v1/signatures/?format=json&hex_signature=0x70a08231",
         ])
 
         AccountByAddressCache.instance.clear()
@@ -223,9 +223,7 @@ describe("ContractActionAnalyzer.spec.ts", () => {
         // 3) setup action
         action.value = SAMPLE_ACTION
         await flushPromises()
-        expect(fetchGetURLs(mock)).toStrictEqual([
-            "https://www.4byte.directory/api/v1/signatures/?format=json&hex_signature=0x70a08231",
-        ])
+        expect(fetchGetURLs(mock)).toStrictEqual([])
         expect(analyzer.action.value).toStrictEqual(SAMPLE_ACTION)
         expect(analyzer.fromId.value).toBe("0.0.96039")
         expect(analyzer.toId.value).toBe("0.0.359")
@@ -235,9 +233,7 @@ describe("ContractActionAnalyzer.spec.ts", () => {
         expect(analyzer.action.value).toStrictEqual(SAMPLE_ACTION)
         expect(analyzer.fromId.value).toBeNull()
         expect(analyzer.toId.value).toBeNull()
-        expect(fetchGetURLs(mock)).toStrictEqual([
-            "https://www.4byte.directory/api/v1/signatures/?format=json&hex_signature=0x70a08231",
-        ])
+        expect(fetchGetURLs(mock)).toStrictEqual([])
 
         SignatureCache.instance.clear()
         mock.restore()

--- a/tests/unit/utils/analyzer/ContractResultAnalyzer.spec.ts
+++ b/tests/unit/utils/analyzer/ContractResultAnalyzer.spec.ts
@@ -102,7 +102,6 @@ describe("ContractResultAnalyzer.spec.ts", () => {
         expect(fetchGetURLs(mock)).toStrictEqual([
             "api/v1/contracts/results",
             "api/v1/contracts/0.0.6810663/results/1704186823.658538003",
-            "https://www.4byte.directory/api/v1/signatures/?format=json&hex_signature=0x5d123e3f",
             "api/v1/contracts/0.0.6810663",
             sourcifyURL + "files/any/295/0x06a50d1f642cA50284EFb59988AF9b60683FAD3F",
         ])
@@ -200,7 +199,6 @@ describe("ContractResultAnalyzer.spec.ts", () => {
         expect(fetchGetURLs(mock)).toStrictEqual([
             "api/v1/contracts/results",
             "api/v1/contracts/0.0.6810663/results/1704186823.658538003",
-            // "https://www.4byte.directory/api/v1/signatures/?format=json&hex_signature=0x5d123e3f", WHY ?
             "api/v1/contracts/0.0.6810663",
             sourcifyURL + "files/any/295/0x06a50d1f642cA50284EFb59988AF9b60683FAD3F",
         ])
@@ -295,7 +293,6 @@ describe("ContractResultAnalyzer.spec.ts", () => {
         expect(fetchGetURLs(mock)).toStrictEqual([
             "api/v1/contracts/results",
             "api/v1/contracts/results/0x4f0887dcc3c3f23ce2e80a2e3c3bfa246d488698d5e0cc17c76ef13262580d73",
-            "https://www.4byte.directory/api/v1/signatures/?format=json&hex_signature=0x49146bde",
         ])
 
         mock.restore()

--- a/tests/unit/utils/analyzer/FunctionCallAnalyzer.spec.ts
+++ b/tests/unit/utils/analyzer/FunctionCallAnalyzer.spec.ts
@@ -64,9 +64,7 @@ describe("FunctionCallAnalyzer.spec.ts", () => {
         contractId.value = "0.0.359"
         await flushPromises()
         await vi.dynamicImportSettled()
-        expect(fetchGetURLs(mock)).toStrictEqual([
-            "https://www.4byte.directory/api/v1/signatures/?format=json&hex_signature=0x49146bde",
-        ])
+        expect(fetchGetURLs(mock)).toStrictEqual([])
         expect(functionCallAnalyzer.functionHash.value).toBe("0x49146bde")
         expect(functionCallAnalyzer.signature.value).toBe("associateToken(address,address)")
         expect(functionCallAnalyzer.inputs.value).toStrictEqual([
@@ -90,10 +88,7 @@ describe("FunctionCallAnalyzer.spec.ts", () => {
         output.value = "0x00000000000000000000000000000000000000000000000000003dc604b33217"
         contractId.value = "0.0.359"
         await flushPromises()
-        expect(fetchGetURLs(mock)).toStrictEqual([
-            "https://www.4byte.directory/api/v1/signatures/?format=json&hex_signature=0x49146bde",
-            "https://www.4byte.directory/api/v1/signatures/?format=json&hex_signature=0x618dc65e",
-        ])
+        expect(fetchGetURLs(mock)).toStrictEqual([])
         expect(functionCallAnalyzer.functionHash.value).toBe("0x618dc65e")
         expect(functionCallAnalyzer.signature.value).toBe("redirectForToken(address,bytes)")
         expect(functionCallAnalyzer.inputs.value).toEqual([
@@ -136,10 +131,7 @@ describe("FunctionCallAnalyzer.spec.ts", () => {
         error.value = "0x"
         contractId.value = "0.0.359"
         await flushPromises()
-        expect(fetchGetURLs(mock)).toStrictEqual([
-            "https://www.4byte.directory/api/v1/signatures/?format=json&hex_signature=0x49146bde",
-            "https://www.4byte.directory/api/v1/signatures/?format=json&hex_signature=0x618dc65e",
-        ])
+        expect(fetchGetURLs(mock)).toStrictEqual([])
         expect(functionCallAnalyzer.functionHash.value).toBe("0x49146bde")
         expect(functionCallAnalyzer.signature.value).toBe("associateToken(address,address)")
         expect(functionCallAnalyzer.inputs.value).toStrictEqual([
@@ -160,10 +152,7 @@ describe("FunctionCallAnalyzer.spec.ts", () => {
         // 6) unmount
         functionCallAnalyzer.unmount()
         await flushPromises()
-        expect(fetchGetURLs(mock)).toStrictEqual([
-            "https://www.4byte.directory/api/v1/signatures/?format=json&hex_signature=0x49146bde",
-            "https://www.4byte.directory/api/v1/signatures/?format=json&hex_signature=0x618dc65e",
-        ])
+        expect(fetchGetURLs(mock)).toStrictEqual([])
         expect(functionCallAnalyzer.functionHash.value).toBe("0x49146bde")
         expect(functionCallAnalyzer.signature.value).toBeNull()
         expect(functionCallAnalyzer.inputs.value).toStrictEqual([])
@@ -237,7 +226,6 @@ describe("FunctionCallAnalyzer.spec.ts", () => {
         contractId.value = "0.0.3045981"
         await flushPromises()
         expect(fetchGetURLs(mock)).toStrictEqual([
-            "https://www.4byte.directory/api/v1/signatures/?format=json&hex_signature=0xf305d719",
             "api/v1/contracts/" + CONTRACT_DETAILS.contract_id,
             "http://localhost:3000/files/any/295/0x00000000000000000000000000000000002E7A5D",
         ])
@@ -268,7 +256,6 @@ describe("FunctionCallAnalyzer.spec.ts", () => {
         functionCallAnalyzer.unmount()
         await flushPromises()
         expect(fetchGetURLs(mock)).toStrictEqual([
-            "https://www.4byte.directory/api/v1/signatures/?format=json&hex_signature=0xf305d719",
             "api/v1/contracts/" + CONTRACT_DETAILS.contract_id,
             "http://localhost:3000/files/any/295/0x00000000000000000000000000000000002E7A5D",
         ])
@@ -347,7 +334,6 @@ describe("FunctionCallAnalyzer.spec.ts", () => {
         functionCallAnalyzer.mount()
         await flushPromises()
         expect(fetchGetURLs(mock)).toStrictEqual([
-            "https://www.4byte.directory/api/v1/signatures/?format=json&hex_signature=0xf305d719",
             "api/v1/contracts/" + CONTRACT_DETAILS.contract_id,
             "http://localhost:3000/files/any/295/0x00000000000000000000000000000000002E7A5D",
         ])
@@ -378,7 +364,6 @@ describe("FunctionCallAnalyzer.spec.ts", () => {
         functionCallAnalyzer.unmount()
         await flushPromises()
         expect(fetchGetURLs(mock)).toStrictEqual([
-            "https://www.4byte.directory/api/v1/signatures/?format=json&hex_signature=0xf305d719",
             "api/v1/contracts/" + CONTRACT_DETAILS.contract_id,
             "http://localhost:3000/files/any/295/0x00000000000000000000000000000000002E7A5D",
         ])
@@ -453,9 +438,9 @@ describe("FunctionCallAnalyzer.spec.ts", () => {
         contractId.value = "0.0.3045981"
         await flushPromises()
         expect(fetchGetURLs(mock)).toStrictEqual([
-            "https://www.4byte.directory/api/v1/signatures/?format=json&hex_signature=0xf305d719",
             "api/v1/contracts/0.0.3045981",
             "api/v1/tokens/0.0.3045981",
+            "https://www.4byte.directory/api/v1/signatures/?format=json&hex_signature=0xf305d719",
         ])
         expect(functionCallAnalyzer.functionHash.value).toBe("0xf305d719")
         expect(functionCallAnalyzer.signature.value).toBe("addLiquidityETH(address,uint256,uint256,uint256,address,uint256)")
@@ -483,9 +468,9 @@ describe("FunctionCallAnalyzer.spec.ts", () => {
         functionCallAnalyzer.unmount()
         await flushPromises()
         expect(fetchGetURLs(mock)).toStrictEqual([
-            "https://www.4byte.directory/api/v1/signatures/?format=json&hex_signature=0xf305d719",
             "api/v1/contracts/0.0.3045981",
             "api/v1/tokens/0.0.3045981",
+            "https://www.4byte.directory/api/v1/signatures/?format=json&hex_signature=0xf305d719",
         ])
         expect(functionCallAnalyzer.functionHash.value).toBe("0xf305d719")
         expect(functionCallAnalyzer.signature.value).toBeNull()


### PR DESCRIPTION
**Description**:

Changes below make sure that `FunctionCallAnalyzer` calls `4byte` directory only when no ABI has been found in `SystemContractRegistry` or in `sourcify`.
Unit tests are updated accordingly.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
