### PR TITLE
fix: some error messages are not decoded in Call Trace section

### DIFF
--- a/tests/unit/contract/ContractResult.spec.ts
+++ b/tests/unit/contract/ContractResult.spec.ts
@@ -152,7 +152,7 @@ describe("ContractResult.vue", () => {
 
         expect(wrapper.text()).toMatch(RegExp("^Contract Result for " + contractId + " at " + timestamp))
         expect(wrapper.get("#resultValue").text()).toBe("CONTRACT_REVERT_EXECUTED")
-        expect(wrapper.get("#errorMessageValue").text()).toBe("Insufficient token balance for wiped")
+        expect(wrapper.get("#errorMessageValue").text()).toBe("Error(\"Insufficient token balance for wiped\")")
         expect(wrapper.get("#ethereumNonceValue").text()).toBe("None")
 
         expect(wrapper.findAll("#transactionHash").length).toBe(0)
@@ -230,7 +230,7 @@ describe("ContractResult.vue", () => {
 
         expect(wrapper.text()).toMatch(RegExp("^Contract Result"))
         expect(wrapper.get("#resultValue").text()).toBe("CONTRACT_REVERT_EXECUTED")
-        expect(wrapper.get("#errorMessageValue").text()).toBe("payWithCardNFT - failed to call accept contract method")
+        expect(wrapper.get("#errorMessageValue").text()).toBe("Error(\"payWithCardNFT - failed to call accept contract method\")")
 
         const stackTrace = wrapper.findComponent(ContractResultTrace)
         expect(stackTrace.exists()).toBe(true)

--- a/tests/unit/schemas/MirrorNodeUtils.spec.ts
+++ b/tests/unit/schemas/MirrorNodeUtils.spec.ts
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {describe, expect, test} from "vitest";
+import {decodeSolidityErrorMessage} from "@/schemas/MirrorNodeUtils.ts";
+import {SAMPLE_REVERT_CONTRACT_RESULT_ACTIONS} from "../Mocks.ts";
+
+describe("MirrorNodeUtils.ts", () => {
+
+    test("decodeSolidityErrorMessage()", () => {
+
+        expect(decodeSolidityErrorMessage(null))
+            .toBe(null)
+        expect(decodeSolidityErrorMessage("0x"))
+            .toBe(null)
+        expect(decodeSolidityErrorMessage(""))
+            .toBe(null)
+
+        expect(decodeSolidityErrorMessage("0x4e487b710000000000000000000000000000000000000000000000000000000000000001"))
+            .toBe("Panic(0x01)")
+        expect(decodeSolidityErrorMessage("0x08c379a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000b566963746f72204875676f000000000000000000000000000000000000000000"))
+            .toBe("Error(\"Victor Hugo\")")
+        expect(decodeSolidityErrorMessage("0x494e56414c49445f4f5045524154494f4e"))
+            .toBe("INVALID_OPERATION")
+
+        expect(decodeSolidityErrorMessage("0xc2bb947c"))
+            .toBe("0xc2bb947c")
+
+        const actions = SAMPLE_REVERT_CONTRACT_RESULT_ACTIONS.actions
+        expect(decodeSolidityErrorMessage(actions[0].result_data)).toBe("Error(\"payWithCardNFT - failed to call accept contract method\")")
+        expect(decodeSolidityErrorMessage(actions[1].result_data)).toBeNull()
+    })
+
+})


### PR DESCRIPTION
**Description**:

Changes below fix `decodeSolidityErrorMessage()` in `MirrorNodeUtils.ts` and add some unit tests.

**Related issue(s)**:

Fixes #1878

**Notes for reviewer**:

See [1745842640.274210000](https://hashscan.io/mainnet/transaction/1745842640.274210000).
See contract calls in [0.0.5924913](https://localhost:5173/testnet/contract/0.0.5924913) for various error cases.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
