### PR TITLE
chore: re-enabling @typescript-eslint/no-unused-expressions in eslint.config.mjs

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -29,7 +29,6 @@ export default tseslint.config(
 
             "@typescript-eslint/no-explicit-any": "off",
             "@typescript-eslint/no-unused-vars": "off",
-            "@typescript-eslint/no-unused-expressions": "off",
             "@typescript-eslint/no-require-imports": "off",
             "@typescript-eslint/no-unsafe-function-type": "off",
             "@typescript-eslint/no-this-alias": "off",

--- a/src/components/allowances/AllowancesSection.vue
+++ b/src/components/allowances/AllowancesSection.vue
@@ -171,7 +171,7 @@ const selectApprovedForAll = ref(false)
 onMounted(() => selectApprovedForAll.value = AppStorage.getSelectApprovedForAll())
 watch(selectApprovedForAll, (value) => {
   AppStorage.setSelectApprovedForAll(value)
-  value ? nftAllSerialsAllowanceTableController.refresh() : nftAllowanceTableController.refresh()
+  return value ? nftAllSerialsAllowanceTableController.refresh() : nftAllowanceTableController.refresh()
 })
 
 const defaultPageSize = isMediumScreen ? 10 : 5

--- a/src/components/transaction/TransactionAnalyzer.ts
+++ b/src/components/transaction/TransactionAnalyzer.ts
@@ -161,6 +161,7 @@ export class TransactionAnalyzer {
 
             } else {
                 this.contractId.value = null
+                this.entityDescriptor.value = EntityDescriptor.DEFAULT_ENTITY_DESCRIPTOR
             }
             const consensusTimestamp = this.transaction.value?.consensus_timestamp ?? null
             if (consensusTimestamp !== null) {

--- a/src/components/transaction/TransactionSummary.vue
+++ b/src/components/transaction/TransactionSummary.vue
@@ -36,7 +36,7 @@
 <script setup lang="ts">
 
 import {computed, onBeforeUnmount, onMounted, PropType} from "vue";
-import {Transaction, TransactionDetail, TransactionType} from "@/schemas/MirrorNodeSchemas";
+import {Transaction, TransactionType} from "@/schemas/MirrorNodeSchemas";
 import {makeSummaryLabel} from "@/utils/TransactionTools";
 import TransferGraphSection from "@/components/transfer_graphs/TransferGraphSection.vue";
 import {TransactionAnalyzer} from "@/components/transaction/TransactionAnalyzer";
@@ -85,10 +85,6 @@ const ethereumSummary = computed(() => {
     result = ""
   }
   return result
-})
-
-const transactionDetail = computed(() => {
-  return props.transaction as TransactionDetail | undefined
 })
 
 const netAmount = transactionAnalyzer.netAmount

--- a/tests/unit/contract/ContractResultLogEntry.spec.ts
+++ b/tests/unit/contract/ContractResultLogEntry.spec.ts
@@ -56,7 +56,7 @@ describe("ContractResultLogEntry.vue", () => {
         ])
 
         expect(wrapper.get("#transactionHash").text()).toBe("Transaction Hashc7b2 ecff defd ec56 b809 f93b ef6c 8528 dad2 2e58 a02a 33c2 0d27 5f2e f279 36d5 6b1e d64b 53f9 20fb ac85 d9ca da4a 4e78Copy")
-        expect(wrapper.get("#blockNumber").find("a").exists()).toBeTruthy
+        expect(wrapper.get("#blockNumber").find("a").exists()).toBeTruthy()
         expect(wrapper.get("#blockNumber").get("a").text()).toBe('9')
         expect(wrapper.get("#blockNumber").text()).toBe("Block9")
         expect(wrapper.get("#address").text()).toBe("Address0x00…0b70cfCopy(TestEvent)")

--- a/tests/unit/utils/analyzer/FunctionCallAnalyzer.spec.ts
+++ b/tests/unit/utils/analyzer/FunctionCallAnalyzer.spec.ts
@@ -119,7 +119,7 @@ describe("FunctionCallAnalyzer.spec.ts", () => {
         expect(functionCallAnalyzer.errorHash.value).toBeNull()
         expect(functionCallAnalyzer.errorSignature.value).toBeNull()
         expect(functionCallAnalyzer.errorInputs.value).toStrictEqual([])
-        expect(functionCallAnalyzer.inputDecodingStatus.value).toBeNull
+        expect(functionCallAnalyzer.inputDecodingStatus.value).toBeNull()
         expect(functionCallAnalyzer.outputDecodingStatus.value).toBe(null)
         expect(functionCallAnalyzer.errorDecodingStatus.value).toBeNull()
         expect(functionCallAnalyzer.inputArgsOnly.value).toBe("0x0000000000000000000000000000000000163b5a70a082310000000000000000000000005fe56763c7633efefe8c2272f19732521a48e300")

--- a/tests/unit/utils/bytecode_tools/bytecodeDisassembler.spec.ts
+++ b/tests/unit/utils/bytecode_tools/bytecodeDisassembler.spec.ts
@@ -21,7 +21,7 @@ describe('EVM Bytecode Disassembler Tests', () => {
         test('Should return null if bytecode has odd length', () => {
             const BYTECODE = '0x40F';
 
-            expect(Helpers.prepBytecode(BYTECODE)).to.be.null;
+            expect(Helpers.prepBytecode(BYTECODE)).toBeNull()
         });
 
         test('Should get operands for opcodes in PUSH family', () => {
@@ -135,7 +135,7 @@ describe('EVM Bytecode Disassembler Tests', () => {
         test('Should return null if bytecode is not valid', () => {
             const INVALID_BYTECODE = '0x30f';
             const disassembly = Disassembler.disassemble(INVALID_BYTECODE);
-            expect(disassembly).to.be.null;
+            expect(disassembly).toBeNull()
         });
     });
 });


### PR DESCRIPTION
**Description**:

Changes below re-enable `@typescript-eslint/no-unused-expressions` in `eslint.config.mjs` and fix the reported warnings.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
