### PR TITLE
chore: fixing resolveVersion() in vite.config.ts

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,7 +15,7 @@ function resolveVersion() {
   try {
     const shortHash = child.execSync("git rev-parse --short HEAD").toString().trim()
     const packageJson = JSON.parse(readFileSync('./package.json', 'utf8'))
-    return `v${packageJson.version}+${shortHash}` || child.execSync("git describe --always --tags").toString()
+    return `v${packageJson.version}+${shortHash}`
   } catch (e) {
     console.error('Could not read package.json')
     return child.execSync("git describe --always --tags").toString()


### PR DESCRIPTION
**Description**:

Changes below fix `resolveVersion()` function in `vite.config.ts`.
This function contains an unused operand that is reported by `eslint`:

```
/WS/hiero-mirror-node-explorer/vite.config.ts
  18:12  error  Unexpected constant truthiness on the left-hand side of a `||` expression  no-constant-binary-expression
```

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
