### PR TITLE
feat: flag ERC-1155 contracts

### DIFF
--- a/public/networks-config.json
+++ b/public/networks-config.json
@@ -13,6 +13,7 @@
     "popularTokenIndexURL": "popular-tokens.json",
     "erc20IndexURL": "mainnet/erc-20.json",
     "erc721IndexURL": "mainnet/erc-721.json",
+    "erc1155IndexURL": "mainnet/erc-1155.json",
     "sourcifySetup": {
       "activate": true,
       "repoURL": "https://repository.local/contracts/",
@@ -33,6 +34,7 @@
     "enableMarket": false,
     "erc20IndexURL": "testnet/erc-20.json",
     "erc721IndexURL": "testnet/erc-721.json",
+    "erc1155IndexURL": "testnet/erc-1155.json",
     "sourcifySetup": {
       "activate": true,
       "repoURL": "https://repository.local/contracts/",
@@ -53,6 +55,7 @@
     "enableMarket": false,
     "erc20IndexURL": null,
     "erc721IndexURL": "previewnet/erc-721.json",
+    "erc1155IndexURL": null,
     "sourcifySetup": {
       "activate": true,
       "repoURL": "https://repository.local/contracts/",

--- a/src/components/contract/ContractERCSection.vue
+++ b/src/components/contract/ContractERCSection.vue
@@ -60,35 +60,24 @@
 
 <script setup lang="ts">
 
-import {computed, onBeforeUnmount, onMounted, PropType, watch, WatchHandle} from 'vue';
+import {computed, PropType} from 'vue';
 import StringValue from "@/components/values/StringValue.vue";
 import Property from "@/components/Property.vue";
 import PlainAmount from "@/components/values/PlainAmount.vue";
-import {ERC20InfoCache} from "@/utils/cache/ERC20InfoCache.ts";
 import {formatUnits} from "ethers";
-import {ERC721InfoCache} from "@/utils/cache/ERC721InfoCache.ts";
 import DashboardCardV2 from "@/components/DashboardCardV2.vue";
+import {ERCAnalyzer} from "@/utils/analyzer/ERCAnalyzer.ts";
 
 const props = defineProps({
-  contractId: {
-    type: String as PropType<string | null>,
+  ercAnalyzer: {
+    type: Object as PropType<ERCAnalyzer | null>,
     default: null
   },
 })
-const isErc20 = defineModel(
-    "isErc20", {
-      type: Boolean,
-      required: true
-    }
-)
-const isErc721 = defineModel(
-    "isErc721", {
-      type: Boolean,
-      required: true
-    }
-)
 
-const contractId = computed(() => props.contractId ?? null)
+const erc20 = computed(() => props.ercAnalyzer?.erc20.value ?? null)
+const erc721 = computed(() => props.ercAnalyzer?.erc721.value ?? null)
+
 const ercName = computed(() => erc20.value?.name ?? erc721.value?.name)
 const ercSymbol = computed(() => erc20.value?.symbol ?? erc721.value?.symbol)
 const erc20TotalSupply = computed(() =>
@@ -96,37 +85,6 @@ const erc20TotalSupply = computed(() =>
         ? formatUnits(erc20.value.totalSupply, erc20.value.decimals)
         : null
 )
-
-//
-// ERC20
-//
-
-const erc20Lookup = ERC20InfoCache.instance.makeLookup(contractId)
-const erc20 = erc20Lookup.entity
-let watch20Handle: WatchHandle
-onMounted(() => {
-  erc20Lookup.mount()
-  watch20Handle = watch(erc20, (value) => isErc20.value = value !== null)
-})
-onBeforeUnmount(() => {
-  erc20Lookup.unmount()
-  watch20Handle()
-})
-
-//
-// ERC721
-//
-const erc721Lookup = ERC721InfoCache.instance.makeLookup(contractId)
-const erc721 = erc721Lookup.entity
-let watch721Handle: WatchHandle
-onMounted(() => {
-  erc721Lookup.mount()
-  watch721Handle = watch(erc721, (value) => isErc721.value = value !== null)
-})
-onBeforeUnmount(() => {
-  erc721Lookup.unmount()
-  watch721Handle()
-})
 
 </script>
 

--- a/src/config/NetworkConfig.ts
+++ b/src/config/NetworkConfig.ts
@@ -5,7 +5,6 @@ import {fetchBoolean, fetchNumber, fetchObject, fetchString, fetchURL} from "@/c
 import {inject} from "vue";
 import {networkConfigKey} from "@/AppKeys";
 import {hip15checksum} from "@/schemas/MirrorNodeUtils.ts";
-import {EntityID} from "@/utils/EntityID";
 import {EthereumAddress} from "@/utils/EthereumAddress";
 import {ColorMap, NetworkColorMaps} from "@/config/NetworkColorMaps.ts";
 
@@ -96,6 +95,7 @@ export class NetworkEntry {
         const popularTokenIndexURL = fetchURL(obj, "popularTokenIndexURL")
         const erc20IndexURL = fetchURL(obj, "erc20IndexURL")
         const erc721IndexURL = fetchURL(obj, "erc721IndexURL")
+        const erc1155IndexURL = fetchURL(obj, "erc1155IndexURL")
 
         const sourcifySetupObj = fetchObject(obj, "sourcifySetup")
 
@@ -130,6 +130,7 @@ export class NetworkEntry {
             popularTokenIndexURL,
             erc20IndexURL,
             erc721IndexURL,
+            erc1155IndexURL,
             sourcifySetup
         )
     }
@@ -159,6 +160,8 @@ export class NetworkEntry {
         public readonly erc20IndexURL: string | null,
         // The URL of the ERC721 contract index
         public readonly erc721IndexURL: string | null,
+        // The URL of the ERC1155 contract index
+        public readonly erc1155IndexURL: string | null,
         public readonly sourcifySetup: SourcifySetup | null
     ) {
     }
@@ -183,6 +186,9 @@ export class NetworkConfig {
             enableStaking: true,
             enableExpiry: true,
             enableMarket: true,
+            erc20IndexURL: "mainnet/erc-20.json",
+            erc721IndexURL: "mainnet/erc-721.json",
+            erc1155IndexURL: "mainnet/erc-1155.json",
             sourcifySetup: SourcifySetup.parse({
                 activate: true,
                 repoURL: "",

--- a/src/pages/ContractDetails.vue
+++ b/src/pages/ContractDetails.vue
@@ -24,6 +24,9 @@
         <div v-if="isErc721" class="h-has-pill" style="margin-top: 2px">
           ERC 721
         </div>
+        <div v-if="isErc1155" class="h-has-pill" style="margin-top: 2px">
+          ERC 1155
+        </div>
       </template>
 
       <template #right-control>
@@ -200,11 +203,7 @@
 
     <TokensSection :account-id="normalizedContractId"/>
 
-    <ContractERCSection
-        :contract-id="normalizedContractId"
-        v-model:is-erc20="isErc20"
-        v-model:is-erc721="isErc721"
-    />
+    <ContractERCSection :erc-analyzer="ercAnalyzer"/>
 
     <ContractResultsSection :contract-id="normalizedContractId ?? undefined"/>
 
@@ -224,7 +223,7 @@
 
 <script setup lang="ts">
 
-import {computed, onBeforeUnmount, onMounted, ref} from 'vue';
+import {computed, onBeforeUnmount, onMounted} from 'vue';
 import KeyValue from "@/components/values/KeyValue.vue";
 import AccountLink from "@/components/values/link/AccountLink.vue";
 import TimestampValue from "@/components/values/TimestampValue.vue";
@@ -257,6 +256,7 @@ import DashboardCardV2 from "@/components/DashboardCardV2.vue";
 import ArrowLink from "@/components/ArrowLink.vue";
 import EntityIDView from "@/components/values/EntityIDView.vue";
 import HbarAmount from "@/components/values/HbarAmount.vue";
+import {ERCAnalyzer} from "@/utils/analyzer/ERCAnalyzer.ts";
 
 const props = defineProps({
   contractId: String,
@@ -329,10 +329,11 @@ onMounted(() => contractAnalyzer.mount())
 onBeforeUnmount(() => contractAnalyzer.unmount())
 
 //
-// ERC
+// ERCAnalyzer
 //
-const isErc20 = ref(false)
-const isErc721 = ref(false)
+const ercAnalyzer = new ERCAnalyzer(normalizedContractId)
+onMounted(() => ercAnalyzer.mount())
+onBeforeUnmount(() => ercAnalyzer.unmount())
 
 //
 // contract results logs - event logs at contract level
@@ -358,6 +359,9 @@ const contractName = contractAnalyzer.contractName
 const logs = contractResultsLogsAnalyzer.logs
 const domainName = nameQuery.name
 const domainProviderName = nameQuery.providerName
+const isErc20 = ercAnalyzer.isErc20
+const isErc721 = ercAnalyzer.isErc721
+const isErc1155 = ercAnalyzer.isErc1155
 
 </script>
 

--- a/src/utils/analyzer/ERCAnalyzer.ts
+++ b/src/utils/analyzer/ERCAnalyzer.ts
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {computed, Ref} from "vue";
+import {ERC20Info, ERC20InfoCache} from "@/utils/cache/ERC20InfoCache.ts";
+import {ERC1155Cache, ERC1155Contract} from "@/utils/cache/ERC1155Cache.ts";
+import {ERC721Info, ERC721InfoCache} from "@/utils/cache/ERC721InfoCache.ts";
+import {EntityLookup} from "@/utils/cache/base/EntityCache.ts";
+
+export class ERCAnalyzer {
+
+    public readonly contractId: Ref<string | null>
+    public readonly erc20: Ref<ERC20Info | null>
+    public readonly erc721: Ref<ERC721Info | null>
+    public readonly erc1155: Ref<ERC1155Contract | null>
+
+    private erc20Lookup: EntityLookup<string, ERC20Info | null>
+    private erc721Lookup: EntityLookup<string, ERC721Info | null>
+    private erc1155Lookup: EntityLookup<string, ERC1155Contract | null>
+
+    //
+    // Public
+    //
+
+    public constructor(contractId: Ref<string | null>) {
+        this.contractId = contractId
+        this.erc20Lookup = ERC20InfoCache.instance.makeLookup(contractId)
+        this.erc721Lookup = ERC721InfoCache.instance.makeLookup(contractId)
+        this.erc1155Lookup = ERC1155Cache.instance.makeLookup(contractId)
+        this.erc20 = this.erc20Lookup.entity
+        this.erc721 = this.erc721Lookup.entity
+        this.erc1155 = this.erc1155Lookup.entity
+    }
+
+    public mount(): void {
+        this.erc20Lookup.mount()
+        this.erc721Lookup.mount()
+        this.erc1155Lookup.mount()
+    }
+
+    public unmount(): void {
+        this.erc20Lookup.unmount()
+        this.erc721Lookup.unmount()
+        this.erc1155Lookup.unmount()
+    }
+
+    public readonly isErc20 = computed(() => this.erc20.value !== null)
+    public readonly isErc721 = computed(() => this.erc721.value !== null)
+    public readonly isErc1155 = computed(() => this.erc1155.value !== null)
+}

--- a/src/utils/cache/CacheUtils.ts
+++ b/src/utils/cache/CacheUtils.ts
@@ -47,6 +47,7 @@ import {TransactionGroupCache} from "@/utils/cache/TransactionGroupCache";
 import {VerifiedContractsByAccountIdCache} from "@/utils/cache/VerifiedContractsByAccountIdCache";
 import {VerifiedContractsCache} from "@/utils/cache/VerifiedContractsCache";
 import {ScheduleByIdCache} from "@/utils/cache/ScheduleByIdCache.ts";
+import {ERC1155Cache} from "@/utils/cache/ERC1155Cache.ts";
 
 export class CacheUtils {
 
@@ -70,6 +71,7 @@ export class CacheUtils {
         ERC20InfoCache.instance.clear()
         ERC721Cache.instance.clear()
         ERC721InfoCache.instance.clear()
+        ERC1155Cache.instance.clear()
         HCSAssetCache.instance.clear()
         HbarPriceCache.instance.clear()
         LabelByIdCache.instance.clear()

--- a/src/utils/cache/ERC1155Cache.ts
+++ b/src/utils/cache/ERC1155Cache.ts
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {EntityCache} from "@/utils/cache/base/EntityCache.ts";
+import {routeManager} from "@/router.ts";
+import axios from "axios";
+
+export class ERC1155Cache extends EntityCache<string, ERC1155Contract | null> {
+
+    private contracts: ERC1155Contract[] = [];
+    private loaded = false;
+
+    //
+    // Public
+    //
+
+    public static readonly instance = new ERC1155Cache()
+
+    //
+    // EntityCache
+    //
+
+    protected async load(key: string): Promise<ERC1155Contract | null> {
+        let result: ERC1155Contract | null = null
+
+        if (!this.loaded) {
+            this.loaded = true
+            await this.loadERC1155Contracts()
+        }
+        for (const contract of this.contracts) {
+            if (contract.contractId === key) {
+                result = contract
+                break
+            }
+        }
+        return Promise.resolve(result)
+    }
+
+    public override clear(): void {
+        super.clear()
+        this.loaded = false
+    }
+
+    //
+    // Private
+    //
+
+    private async loadERC1155Contracts(): Promise<void> {
+        const url = routeManager.currentNetworkEntry.value.erc1155IndexURL
+        if (url !== null) {
+            this.contracts = (await axios.get<ERC1155Contract[]>(url)).data
+        } else {
+            this.contracts = []
+        }
+        return Promise.resolve()
+    }
+}
+
+export interface ERC1155Contract {
+    contractId: string,
+    address: string
+}

--- a/tests/unit/contract/ContractDetails.spec.ts
+++ b/tests/unit/contract/ContractDetails.spec.ts
@@ -2,9 +2,9 @@
 
 // SPDX-License-Identifier: Apache-2.0
 
-import {describe, expect, it} from 'vitest'
+import {beforeEach, describe, expect, it} from 'vitest'
 import {flushPromises, mount} from "@vue/test-utils"
-import router from "@/router";
+import router, {routeManager} from "@/router";
 import axios from "axios";
 import {
     SAMPLE_ACCOUNT_BALANCES,
@@ -28,6 +28,7 @@ import {TransactionID} from "@/utils/TransactionID";
 import ContractResultTable from "@/components/contract/ContractResultTable.vue";
 import {ContractStateResponse} from "@/schemas/MirrorNodeSchemas.ts";
 import {fetchGetURLs} from "../MockUtils";
+import {ERC1155Cache} from "@/utils/cache/ERC1155Cache.ts";
 
 /*
     Bookmarks
@@ -39,6 +40,10 @@ import {fetchGetURLs} from "../MockUtils";
 HMSF.forceUTC = true
 
 describe("ContractDetails.vue", () => {
+
+    beforeEach(() => {
+        ERC1155Cache.instance.clear()
+    })
 
     it("Should display contract details (using contract id)", async () => {
 
@@ -97,6 +102,9 @@ describe("ContractDetails.vue", () => {
             "api/v1/network/nodes",
             "api/v1/contracts/" + SAMPLE_CONTRACT.contract_id,
             "api/v1/accounts/" + SAMPLE_CONTRACT.contract_id,
+            "http://localhost:3000/mainnet/erc-20.json",
+            "http://localhost:3000/mainnet/erc-721.json",
+            "http://localhost:3000/mainnet/erc-1155.json",
             "api/v1/contracts/" + SAMPLE_CONTRACT.contract_id + "/results/logs",
             "api/v1/balances",
             "api/v1/transactions",
@@ -228,6 +236,9 @@ describe("ContractDetails.vue", () => {
             "api/v1/network/nodes",
             "api/v1/contracts/" + SAMPLE_CONTRACT.evm_address,
             "api/v1/accounts/" + SAMPLE_CONTRACT.contract_id,
+            "http://localhost:3000/mainnet/erc-20.json",
+            "http://localhost:3000/mainnet/erc-721.json",
+            "http://localhost:3000/mainnet/erc-1155.json",
             "api/v1/contracts/" + SAMPLE_CONTRACT.contract_id + "/results/logs",
             "api/v1/balances",
             "api/v1/transactions",
@@ -356,6 +367,9 @@ describe("ContractDetails.vue", () => {
             "api/v1/network/nodes",
             "api/v1/contracts/" + SAMPLE_CONTRACT.contract_id,
             "api/v1/accounts/" + SAMPLE_CONTRACT.contract_id,
+            "http://localhost:3000/mainnet/erc-20.json",
+            "http://localhost:3000/mainnet/erc-721.json",
+            "http://localhost:3000/mainnet/erc-1155.json",
             "api/v1/contracts/" + SAMPLE_CONTRACT.contract_id + "/results/logs",
             "api/v1/balances",
             "api/v1/transactions",
@@ -456,6 +470,9 @@ describe("ContractDetails.vue", () => {
             "api/v1/network/nodes",
             "api/v1/contracts/" + SAMPLE_CONTRACT.contract_id,
             "api/v1/accounts/" + SAMPLE_CONTRACT.contract_id,
+            "http://localhost:3000/mainnet/erc-20.json",
+            "http://localhost:3000/mainnet/erc-721.json",
+            "http://localhost:3000/mainnet/erc-1155.json",
             "api/v1/contracts/" + SAMPLE_CONTRACT.contract_id + "/results/logs",
             "api/v1/balances",
             "api/v1/transactions",
@@ -681,6 +698,9 @@ describe("ContractDetails.vue", () => {
             "api/v1/network/nodes",
             "api/v1/contracts/" + SAMPLE_CONTRACT_DELETED.contract_id,
             "api/v1/accounts/" + SAMPLE_CONTRACT_DELETED.contract_id,
+            "http://localhost:3000/mainnet/erc-20.json",
+            "http://localhost:3000/mainnet/erc-721.json",
+            "http://localhost:3000/mainnet/erc-1155.json",
             "api/v1/contracts/" + SAMPLE_CONTRACT_DELETED.contract_id + "/results/logs",
             "api/v1/balances",
             "api/v1/transactions",
@@ -763,6 +783,9 @@ describe("ContractDetails.vue", () => {
             "api/v1/network/nodes",
             "api/v1/contracts/" + SAMPLE_CONTRACT_DELETED.contract_id,
             "api/v1/accounts/" + SAMPLE_CONTRACT_DELETED.contract_id,
+            "http://localhost:3000/mainnet/erc-20.json",
+            "http://localhost:3000/mainnet/erc-721.json",
+            "http://localhost:3000/mainnet/erc-1155.json",
             "api/v1/contracts/" + SAMPLE_CONTRACT_DELETED.contract_id + "/results/logs",
             "api/v1/balances",
             "api/v1/transactions",
@@ -821,6 +844,114 @@ describe("ContractDetails.vue", () => {
 
         expect(wrapper.get("#notificationBanner").text()).toBe("Invalid contract ID or address: " + invalidContractId)
 
+        wrapper.unmount()
+        await flushPromises()
+    });
+
+    it("Should display ERC-1155 chip", async () => {
+
+        await router.push("/") // To avoid "missing required param 'network'" error
+
+        const mock = new MockAdapter(axios as any);
+
+        const SAMPLE_ERC1155 = [
+            {
+                contractId: SAMPLE_CONTRACT.contract_id,
+                address: SAMPLE_CONTRACT.evm_address,
+            }
+        ]
+
+        const matcherAirdrop = "api/v1/accounts/" + SAMPLE_CONTRACT.contract_id + "/airdrops/pending"
+        mock.onGet(matcherAirdrop).reply(200, {"airdrops": []})
+
+        const matcher1 = "/api/v1/contracts/" + SAMPLE_CONTRACT.contract_id
+        mock.onGet(matcher1).reply(200, SAMPLE_CONTRACT);
+
+        const matcher2 = "/api/v1/accounts/" + SAMPLE_CONTRACT.contract_id
+        mock.onGet(matcher2).reply(200, SAMPLE_CONTRACT_AS_ACCOUNT);
+
+        const matcher3 = "/api/v1/transactions"
+        mock.onGet(matcher3).reply(200, SAMPLE_TRANSACTIONS);
+
+        const matcher4 = "/api/v1/network/exchangerate"
+        mock.onGet(matcher4).reply(200, SAMPLE_NETWORK_EXCHANGERATE);
+
+        const matcher5 = "/api/v1/contracts/" + SAMPLE_CONTRACT.contract_id + "/results"
+        mock.onGet(matcher5).reply(200, SAMPLE_CONTRACT_RESULTS);
+
+        const matcher6 = "/api/v1/balances"
+        mock.onGet(matcher6).reply(200, SAMPLE_ACCOUNT_BALANCES);
+
+        const matcher7 = "api/v1/contracts/" + SAMPLE_CONTRACT.contract_id + "/state?slot=0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc"
+        mock.onGet(matcher7).reply<ContractStateResponse>(200, {state: [], links: undefined})
+
+        const matcher8 = "api/v1/contracts/" + SAMPLE_CONTRACT.contract_id + "/state?slot=0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103"
+        mock.onGet(matcher8).reply<ContractStateResponse>(200, {state: [], links: undefined})
+
+        const matcher10 = "api/v1/tokens"
+        mock.onGet(matcher10).reply(200, {tokens: []});
+
+        const matcher11 = "api/v1/accounts/" + SAMPLE_CONTRACT.contract_id + "/nfts"
+        mock.onGet(matcher11).reply(200, {nfts: []});
+
+        const matcher12 = routeManager.currentNetworkEntry.value.erc1155IndexURL
+        if (matcher12) {
+            mock.onGet(matcher12).reply(200, SAMPLE_ERC1155);
+        }
+        const wrapper = mount(ContractDetails, {
+            global: {
+                plugins: [router, Oruga],
+                provide: {"isMediumScreen": false}
+            },
+            props: {
+                contractId: SAMPLE_CONTRACT.contract_id
+            },
+        });
+
+        await flushPromises()
+        // console.log(wrapper.html())
+
+        expect(fetchGetURLs(mock)).toStrictEqual([
+            "api/v1/network/nodes",
+            "api/v1/contracts/" + SAMPLE_CONTRACT.contract_id,
+            "api/v1/accounts/" + SAMPLE_CONTRACT.contract_id,
+            "http://localhost:3000/mainnet/erc-20.json",
+            "http://localhost:3000/mainnet/erc-721.json",
+            "http://localhost:3000/mainnet/erc-1155.json",
+            "api/v1/contracts/" + SAMPLE_CONTRACT.contract_id + "/results/logs",
+            "api/v1/balances",
+            "api/v1/transactions",
+            "api/v1/contracts/" + SAMPLE_CONTRACT.auto_renew_account,
+            "api/v1/contracts/" + SAMPLE_CONTRACT.contract_id + "/state?slot=0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc",
+            "http://localhost:3000/files/any/295/0x00000000000000000000000000000000000b70cf",
+            "api/v1/network/exchangerate",
+            "api/v1/contracts/" + SAMPLE_CONTRACT.contract_id + "/state?slot=0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103",
+            "api/v1/accounts/" + SAMPLE_CONTRACT.contract_id + "/nfts",
+            "api/v1/tokens",
+            "api/v1/accounts/" + SAMPLE_CONTRACT.contract_id + "/airdrops/pending",
+            "api/v1/accounts/" + SAMPLE_CONTRACT.contract_id + "/airdrops/pending",
+            "api/v1/contracts/0xffffffffffffffffffffffffffffffffffffffff",
+            "api/v1/accounts/0xffffffffffffffffffffffffffffffffffffffff",
+            "api/v1/accounts/" + SAMPLE_CONTRACT.contract_id + "/nfts",
+            "api/v1/tokens",
+            "api/v1/accounts/" + SAMPLE_CONTRACT.contract_id + "/airdrops/pending",
+            "api/v1/accounts/" + SAMPLE_CONTRACT.contract_id + "/airdrops/pending",
+            "api/v1/contracts/" + SAMPLE_CONTRACT.contract_id + "/results",
+            "api/v1/contracts/0.0.1260",
+            "api/v1/contracts/0x00000000000000000000000000000000000004ec",
+            "api/v1/tokens/0.0.1260",
+            "api/v1/accounts/0x00000000000000000000000000000000000004ec",
+        ])
+
+        expect(wrapper.text()).toMatch(RegExp(
+            "Contract   " +
+            "ERC 1155" +
+            " Associated account " +
+            "Contract ID " +
+            SAMPLE_CONTRACT.contract_id
+        ))
+
+        mock.restore()
         wrapper.unmount()
         await flushPromises()
     });

--- a/tests/unit/search/SearchController.spec.ts
+++ b/tests/unit/search/SearchController.spec.ts
@@ -16,8 +16,8 @@ import {
     SAMPLE_CONTRACT,
     SAMPLE_CONTRACT_AS_ACCOUNT,
     SAMPLE_CONTRACT_RESULT_DETAILS,
-    SAMPLE_SCHEDULING_SCHEDULED_TRANSACTIONS,
     SAMPLE_SCHEDULE,
+    SAMPLE_SCHEDULING_SCHEDULED_TRANSACTIONS,
     SAMPLE_TOKEN,
     SAMPLE_TOKEN_DUDE,
     SAMPLE_TOPIC,
@@ -439,6 +439,8 @@ describe("SearchController.vue", () => {
         expect(fetchGetURLs(mock)).toStrictEqual([
             "api/v1/accounts/CIQAAAH4AY2OFK2FL37TSPYEQGPPUJRP4XTKWHD62HKPQX543DTOFFQ",
             "api/v1/tokens/?name=CIQAAAH4AY2OFK2FL37TSPYEQGPPUJRP4XTKWHD62HKPQX543DTOFFQ&limit=100",
+            "http://localhost:3000/mainnet/erc-20.json",
+            "http://localhost:3000/mainnet/erc-721.json",
         ])
 
         expect(vi.getTimerCount()).toBe(0)
@@ -916,6 +918,8 @@ describe("SearchController.vue", () => {
         await flushPromises()
         expect(fetchGetURLs(mock)).toStrictEqual([
             "api/v1/tokens/?name=" + SAMPLE_TOKEN_NAME + "&limit=100",
+            "http://localhost:3000/mainnet/erc-20.json",
+            "http://localhost:3000/mainnet/erc-721.json",
         ])
 
         expect(vi.getTimerCount()).toBe(0)


### PR DESCRIPTION
**Description**:

Leverage the information collected in `erc-1155.json` to flag ERC-1155 contracts in the ContractDetails view.
Given the current infrastructure at hand, the explorer is not able to display more information about these.

**Related issue(s)**:

#1500

**Notes for reviewer**:
<img width="1107" alt="Screenshot 2025-05-06 at 16 22 27" src="https://github.com/user-attachments/assets/9eacf405-7b01-453a-b2c3-a7d5acd9d126" />
