### PR TITLE
chore: refactor Tooltip component

### DIFF
--- a/src/components/Tooltip.vue
+++ b/src/components/Tooltip.vue
@@ -7,14 +7,16 @@
 <template>
 
   <o-tooltip
-      v-if="props.text"
+      v-if="props.text || slots.content"
       :label="props.text"
       :position="position ?? 'auto'"
       :delay="props.delay"
       multiline
-      class="tooltip"
   >
     <slot/>
+    <template #content>
+      <slot name="content"/>
+    </template>
   </o-tooltip>
 
   <slot v-else/>
@@ -27,7 +29,7 @@
 
 <script setup lang="ts">
 
-import {PropType} from 'vue';
+import {PropType, useSlots} from 'vue';
 
 const props = defineProps({
   text: {
@@ -44,16 +46,12 @@ const props = defineProps({
   }
 })
 
+const slots = useSlots()
+
 </script>
 
 <!-- --------------------------------------------------------------------------------------------------------------- -->
 <!--                                                       STYLE                                                     -->
 <!-- --------------------------------------------------------------------------------------------------------------- -->
 
-<style scoped>
-
-.tooltip {
-  cursor: default;
-}
-
-</style>
+<style/>

--- a/src/components/node/NodeTable.vue
+++ b/src/components/node/NodeTable.vue
@@ -59,7 +59,7 @@
           id="stake-range-column" v-slot="props" field="stake-range" label="STAKE RANGE" position="right"
           style="padding-bottom: 2px; padding-top: 12px;"
       >
-        <o-tooltip :delay="tooltipDelay" class="h-tooltip">
+        <Tooltip>
           <StakeRange
               :node="props.row"
               :network-analyzer="networkAnalyzer"
@@ -89,7 +89,7 @@
               </div>
             </div>
           </template>
-        </o-tooltip>
+        </Tooltip>
       </o-table-column>
 
       <o-table-column v-if="enableStaking" v-slot="props" field="last_reward_rate" label="REWARD RATE" position="right">


### PR DESCRIPTION
**Description**:

Refactor `Tooltip component` and add a `#content` slot so it can be leveraged instead of using directly o-tooltip when the tooltip content is structured. Apply to NodeTable.
