### PR TITLE
chore: removing unneeded router plugin from VTU mount() options in unit tests 

### DIFF
--- a/tests/unit/Tabs.spec.ts
+++ b/tests/unit/Tabs.spec.ts
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {describe, expect, test} from 'vitest'
-import router from "@/router";
 import {flushPromises, mount} from "@vue/test-utils";
 import Tabs from "@/components/Tabs.vue";
 
@@ -11,16 +10,12 @@ describe("Tabs.vue", () => {
 
     test("nominal case with 3 IDs and 3 labels", async () => {
 
-        await router.push("/") // To avoid "missing required param 'network'" error
-
         const tabIds = ['tab1', 'tab2', 'tab3']
         const tabLabels = ['label1', 'label2', 'label3']
         const selectedTab = 2
 
         const wrapper = mount(Tabs, {
-            global: {
-                plugins: [router]
-            }, props: {
+            props: {
                 selectedTab: tabIds[selectedTab],
                 tabIds: tabIds,
                 tabLabels: tabLabels,
@@ -44,15 +39,11 @@ describe("Tabs.vue", () => {
 
     test("case where selected tab is not one of the IDs", async () => {
 
-        await router.push("/") // To avoid "missing required param 'network'" error
-
         const tabIds = ['tab1', 'tab2', 'tab3']
         const tabLabels = ['label1', 'label2', 'label3']
 
         const wrapper = mount(Tabs, {
-            global: {
-                plugins: [router]
-            }, props: {
+            props: {
                 selectedTab: 'unknown',
                 tabIds: tabIds,
                 tabLabels: tabLabels,
@@ -77,16 +68,12 @@ describe("Tabs.vue", () => {
 
     test("test with 3 IDs and only 2 labels", async () => {
 
-        await router.push("/") // To avoid "missing required param 'network'" error
-
         const tabIds = ['tab1', 'tab2', 'tab3']
         const tabLabels = ['label1', 'label2']
         const selectedTab = 2
 
         const wrapper = mount(Tabs, {
-            global: {
-                plugins: [router]
-            }, props: {
+            props: {
                 selectedTab: tabIds[selectedTab],
                 tabIds: tabIds,
                 tabLabels: tabLabels,
@@ -117,16 +104,12 @@ describe("Tabs.vue", () => {
 
     test("test with 3 IDs and no labels", async () => {
 
-        await router.push("/") // To avoid "missing required param 'network'" error
-
         const tabIds = ['tab1', 'tab2', 'tab3']
         const tabLabels = ['label1', 'label2']
         const selectedTab = 2
 
         const wrapper = mount(Tabs, {
-            global: {
-                plugins: [router]
-            }, props: {
+            props: {
                 selectedTab: tabIds[selectedTab],
                 tabIds: tabIds,
                 tabLabels: tabLabels,
@@ -157,8 +140,6 @@ describe("Tabs.vue", () => {
 
     test("test with mutating IDs and labels", async () => {
 
-        await router.push("/") // To avoid "missing required param 'network'" error
-
         //
         // Stars with no tabs
         //
@@ -167,9 +148,7 @@ describe("Tabs.vue", () => {
         const tabLabels: string[] = []
 
         const wrapper = mount(Tabs, {
-            global: {
-                plugins: [router]
-            }, props: {
+            props: {
                 tabIds: tabIds,
                 tabLabels: tabLabels,
             },
@@ -250,8 +229,6 @@ describe("Tabs.vue", () => {
 
     test("test with interactive", async () => {
 
-        await router.push("/") // To avoid "missing required param 'network'" error
-
         //
         // Starts with ['tab1', 'tab2', 'tab3'] => default selection is tab1
         //
@@ -260,9 +237,7 @@ describe("Tabs.vue", () => {
         const tabLabels = ['label1', 'label2', 'label3']
 
         const wrapper = mount(Tabs, {
-            global: {
-                plugins: [router]
-            }, props: {
+            props: {
                 tabIds: tabIds,
                 tabLabels: tabLabels,
             },

--- a/tests/unit/contract/ContractDetails.spec.ts
+++ b/tests/unit/contract/ContractDetails.spec.ts
@@ -567,8 +567,6 @@ describe("ContractDetails.vue", () => {
     // TODO: re-enable after activation of Contract Expiry
     it.skip("Should display notification of grace period", async () => {
 
-        await router.push("/") // To avoid "missing required param 'network'" error
-
         const mock = new MockAdapter(axios as any);
 
         const contract = SAMPLE_CONTRACT_DUDE
@@ -595,7 +593,7 @@ describe("ContractDetails.vue", () => {
 
         const wrapper = mount(ContractDetails, {
             global: {
-                plugins: [router, Oruga]
+                plugins: [Oruga]
             },
             props: {
                 contractId: contract.contract_id

--- a/tests/unit/contract/ContractResult.spec.ts
+++ b/tests/unit/contract/ContractResult.spec.ts
@@ -35,8 +35,6 @@ describe("ContractResult.vue", () => {
 
     it("Should display the contract result and logs, given consensus timestamp", async () => {
 
-        await router.push("/") // To avoid "missing required param 'network'" error
-
         const contractId = SAMPLE_CONTRACT_RESULT_DETAILS.contract_id
         const timestamp = SAMPLE_CONTRACT_RESULT_DETAILS.timestamp
 
@@ -106,8 +104,6 @@ describe("ContractResult.vue", () => {
 
     it("Should display the reverted contract result and decode the error message", async () => {
 
-        await router.push("/") // To avoid "missing required param 'network'" error
-
         const contractId = SAMPLE_REVERT_CONTRACT_RESULT_DETAILS.contract_id
         const timestamp = SAMPLE_REVERT_CONTRACT_RESULT_DETAILS.timestamp
 
@@ -162,8 +158,6 @@ describe("ContractResult.vue", () => {
     });
 
     it("Should display the reverted contract result with call trace and state trace", async () => {
-
-        await router.push("/") // To avoid "missing required param 'network'" error
 
         const mock = new MockAdapter(axios as any);
 

--- a/tests/unit/dashboard/MainDashboard.spec.ts
+++ b/tests/unit/dashboard/MainDashboard.spec.ts
@@ -25,8 +25,6 @@ describe("MainDashboard.vue", () => {
 
     test("no props", async () => {
 
-        await router.push({name: "MainDashboard", params: {network: 'mainnet'}})
-
         const mock = new MockAdapter(axios as any)
 
         const matcher3 = "/api/v1/network/supply"

--- a/tests/unit/infoTooltip.spec.ts
+++ b/tests/unit/infoTooltip.spec.ts
@@ -15,11 +15,9 @@ describe("InfoTooltip.vue", () => {
 
     test("InfoTooltip with information message", async () => {
 
-        await router.push("/") // To avoid "missing required param 'network'" error
-
         const wrapper = mount(InfoTooltip, {
             global: {
-                plugins: [router, Oruga]
+                plugins: [Oruga]
             },
             props: {
                 label: sampleInfoLabel,
@@ -43,7 +41,7 @@ describe("InfoTooltip.vue", () => {
 
         const wrapper = mount(InfoTooltip, {
             global: {
-                plugins: [router, Oruga]
+                plugins: [Oruga]
             },
             props: {
                 warningLabel: sampleWarningLabel,
@@ -67,7 +65,7 @@ describe("InfoTooltip.vue", () => {
 
         const wrapper = mount(InfoTooltip, {
             global: {
-                plugins: [router, Oruga]
+                plugins: [Oruga]
             },
             props: {
                 label: sampleInfoLabel,
@@ -92,7 +90,7 @@ describe("InfoTooltip.vue", () => {
 
         const wrapper = mount(InfoTooltip, {
             global: {
-                plugins: [router, Oruga]
+                plugins: [Oruga]
             },
             props: {},
         })

--- a/tests/unit/node/NodeTable.spec.ts
+++ b/tests/unit/node/NodeTable.spec.ts
@@ -2,7 +2,6 @@
 
 import {describe, expect, it} from 'vitest'
 import {flushPromises, mount} from "@vue/test-utils"
-import router from "@/router";
 import {SAMPLE_NETWORK_NODES} from "../Mocks";
 import Oruga from "@oruga-ui/oruga-next";
 import {HMSF} from "@/utils/HMSF";
@@ -29,8 +28,6 @@ describe("NodeTable.vue", () => {
 
     it("should list the 3 nodes in the table", async () => {
 
-        await router.push("/") // To avoid "missing required param 'network'" error
-
         const mock = new MockAdapter(axios as any);
         const matcher1 = "/api/v1/network/nodes"
         mock.onGet(matcher1).reply(200, SAMPLE_NETWORK_NODES);
@@ -41,7 +38,7 @@ describe("NodeTable.vue", () => {
         }
         const wrapper = mount(NodeTable, {
             global: {
-                plugins: [router, Oruga]
+                plugins: [Oruga]
             },
             props: {
                 nodes: SAMPLE_NETWORK_NODES.nodes as Array<NetworkNode>,

--- a/tests/unit/node/Nodes.spec.ts
+++ b/tests/unit/node/Nodes.spec.ts
@@ -32,8 +32,6 @@ describe("Nodes.vue", () => {
 
     it("should display the nodes pages containing the node table", async () => {
 
-        await router.push("/") // To avoid "missing required param 'network'" error
-
         const mock = new MockAdapter(axios as any);
 
         // const config = [

--- a/tests/unit/staking/RewardsCalculator.spec.ts
+++ b/tests/unit/staking/RewardsCalculator.spec.ts
@@ -2,7 +2,6 @@
 
 import {describe, expect, it} from 'vitest'
 import {flushPromises, mount} from "@vue/test-utils"
-import router from "@/router";
 import Oruga from "@oruga-ui/oruga-next";
 import {HMSF} from "@/utils/HMSF";
 import MockAdapter from "axios-mock-adapter";
@@ -24,8 +23,6 @@ describe("RewardsCalculator.vue", () => {
 
     it("should display an empty Rewards Estimator", async () => {
 
-        await router.push("/") // To avoid "missing required param 'network'" error
-
         // Mocks axios
         const mock = new MockAdapter(axios as any);
         const matcher2 = "/api/v1/network/nodes"
@@ -38,7 +35,7 @@ describe("RewardsCalculator.vue", () => {
 
         const wrapper = mount(RewardsCalculator, {
             global: {
-                plugins: [router, Oruga]
+                plugins: [Oruga]
             },
             props: {},
         });
@@ -75,8 +72,6 @@ describe("RewardsCalculator.vue", () => {
 
     it("should display a Rewards Estimator preset with 10000Hbar and Node1", async () => {
 
-        await router.push("/") // To avoid "missing required param 'network'" error
-
         // Mocks axios
         const mock = new MockAdapter(axios as any);
         const matcher2 = "/api/v1/network/nodes"
@@ -89,7 +84,7 @@ describe("RewardsCalculator.vue", () => {
 
         const wrapper = mount(RewardsCalculator, {
             global: {
-                plugins: [router, Oruga]
+                plugins: [Oruga]
             },
             props: {
                 amountInHbar: 10000,
@@ -129,8 +124,6 @@ describe("RewardsCalculator.vue", () => {
 
     it("should input different values for Hbar amount and selected Node", async () => {
 
-        await router.push("/") // To avoid "missing required param 'network'" error
-
         const TEST_ACCOUNT = SAMPLE_ACCOUNT_STAKING_ACCOUNT
 
         // Mocks axios
@@ -147,7 +140,7 @@ describe("RewardsCalculator.vue", () => {
 
         const wrapper = mount(RewardsCalculator, {
             global: {
-                plugins: [router, Oruga]
+                plugins: [Oruga]
             },
             props: {},
         });

--- a/tests/unit/token/MetadataSection.spec.ts
+++ b/tests/unit/token/MetadataSection.spec.ts
@@ -7,7 +7,6 @@ import {IPFS_GATEWAY_PREFIX, IPFS_METADATA, IPFS_METADATA_CONTENT, IPFS_METADATA
 import MockAdapter from "axios-mock-adapter";
 import Oruga from "@oruga-ui/oruga-next";
 import {HMSF} from "@/utils/HMSF.ts";
-import router from "@/router";
 import MetadataSection from "@/components/token/MetadataSection.vue";
 import {ref} from "vue";
 import {TokenMetadataAnalyzer} from "@/components/token/TokenMetadataAnalyzer.ts";
@@ -25,8 +24,6 @@ describe("MetadataSection.vue", () => {
 
     it("Should display metadata attributes", async () => {
 
-        await router.push("/") // To avoid "missing required param 'network'" error
-
         // Mock axios
         const mock = new MockAdapter(axios as any)
         mock.onGet(IPFS_METADATA_CONTENT_URL).reply(200, IPFS_METADATA_CONTENT)
@@ -38,7 +35,7 @@ describe("MetadataSection.vue", () => {
 
         const wrapper = mount(MetadataSection, {
             global: {
-                plugins: [router, Oruga]
+                plugins: [Oruga]
             },
             props: {
                 metadataAnalyzer: analyzer,
@@ -75,8 +72,6 @@ describe("MetadataSection.vue", () => {
 
     it("Should display raw metadata property when metadata unusable", async () => {
 
-        await router.push("/") // To avoid "missing required param 'network'" error
-
         const UNUSABLE_METADATA = '==AA'
         const metadata = ref(UNUSABLE_METADATA)
         const analyzer = new TokenMetadataAnalyzer(metadata, IPFS_GATEWAY_PREFIX)
@@ -84,7 +79,7 @@ describe("MetadataSection.vue", () => {
 
         const wrapper = mount(MetadataSection, {
             global: {
-                plugins: [router, Oruga]
+                plugins: [Oruga]
             },
             props: {
                 metadataAnalyzer: analyzer,

--- a/tests/unit/token/NftAttribute.spec.ts
+++ b/tests/unit/token/NftAttribute.spec.ts
@@ -3,7 +3,6 @@
 import {describe, expect, test} from 'vitest'
 import {flushPromises, mount} from "@vue/test-utils"
 import NftAttribute from '@/components/token/NftAttribute.vue';
-import router from "@/router";
 import {HMSF} from "@/utils/HMSF";
 
 /*
@@ -24,9 +23,6 @@ describe("NftAttribute.vue", () => {
     test("NftAttribute containing string with no display type", async () => {
 
         const wrapper = mount(NftAttribute, {
-            global: {
-                plugins: [router]
-            },
             props: {
                 attribute: {
                     trait_type: "String with no type",
@@ -45,9 +41,6 @@ describe("NftAttribute.vue", () => {
     test("NftAttribute containing string with 'text' display type", async () => {
 
         const wrapper = mount(NftAttribute, {
-            global: {
-                plugins: [router]
-            },
             props: {
                 attribute: {
                     trait_type: "String with type 'text",
@@ -67,9 +60,6 @@ describe("NftAttribute.vue", () => {
     test("NftAttribute containing number with 'text' display type", async () => {
 
         const wrapper = mount(NftAttribute, {
-            global: {
-                plugins: [router]
-            },
             props: {
                 attribute: {
                     trait_type: "Number",
@@ -89,9 +79,6 @@ describe("NftAttribute.vue", () => {
     test("NftAttribute containing number with 'percentage' display type", async () => {
 
         const wrapper = mount(NftAttribute, {
-            global: {
-                plugins: [router]
-            },
             props: {
                 attribute: {
                     trait_type: "Number with percentage",
@@ -111,9 +98,6 @@ describe("NftAttribute.vue", () => {
     test("NftAttribute containing unix timestamp with 'text' display type", async () => {
 
         const wrapper = mount(NftAttribute, {
-            global: {
-                plugins: [router]
-            },
             props: {
                 attribute: {
                     trait_type: "DateTime",
@@ -133,9 +117,6 @@ describe("NftAttribute.vue", () => {
     test("NftAttribute containing unix timestamp with 'datetime' display type", async () => {
 
         const wrapper = mount(NftAttribute, {
-            global: {
-                plugins: [router]
-            },
             props: {
                 attribute: {
                     trait_type: "DateTime",

--- a/tests/unit/token/NftCell.spec.ts
+++ b/tests/unit/token/NftCell.spec.ts
@@ -3,7 +3,6 @@
 import {describe, expect, test} from 'vitest'
 import {flushPromises, mount} from "@vue/test-utils";
 import NftCell, {NftCellItem} from "@/components/token/NftCell.vue";
-import router from "@/router";
 import Oruga from "@oruga-ui/oruga-next";
 import {IPFS_IMAGE_URL, IPFS_METADATA_CONTENT, IPFS_METADATA_CONTENT_URL, SAMPLE_NFTS} from "../Mocks";
 import MockAdapter from "axios-mock-adapter";
@@ -13,11 +12,9 @@ describe("NftCell.vue", () => {
 
     test("default props", async () => {
 
-        await router.push("/") // To avoid "missing required param 'network'" error
-
         const wrapper = mount(NftCell, {
             global: {
-                plugins: [router, Oruga]
+                plugins: [Oruga]
             },
             props: {},
         })
@@ -35,8 +32,6 @@ describe("NftCell.vue", () => {
 
     test("tokenId and no serialNumber", async () => {
 
-        await router.push("/") // To avoid "missing required param 'network'" error
-
         // Mock axios
         const mock = new MockAdapter(axios as any)
 
@@ -50,7 +45,7 @@ describe("NftCell.vue", () => {
 
         const wrapper = mount(NftCell, {
             global: {
-                plugins: [router, Oruga]
+                plugins: [Oruga]
             },
             props: {
                 tokenId: nftId
@@ -70,8 +65,6 @@ describe("NftCell.vue", () => {
 
     test("tokenId and serialNumber", async () => {
 
-        await router.push("/") // To avoid "missing required param 'network'" error
-
         // Mock axios
         const mock = new MockAdapter(axios as any)
 
@@ -86,7 +79,7 @@ describe("NftCell.vue", () => {
 
         const wrapper = mount(NftCell, {
             global: {
-                plugins: [router, Oruga]
+                plugins: [Oruga]
             },
             props: {
                 tokenId: nftId,
@@ -107,8 +100,6 @@ describe("NftCell.vue", () => {
 
     test("tokenId, serialNumber and property", async () => {
 
-        await router.push("/") // To avoid "missing required param 'network'" error
-
         // Mock axios
         const mock = new MockAdapter(axios as any)
 
@@ -125,7 +116,7 @@ describe("NftCell.vue", () => {
 
         const wrapper = mount(NftCell, {
             global: {
-                plugins: [router, Oruga]
+                plugins: [Oruga]
             },
             props: {
                 tokenId: nftId,

--- a/tests/unit/token/NftFile.spec.ts
+++ b/tests/unit/token/NftFile.spec.ts
@@ -3,7 +3,6 @@
 import {describe, expect, test} from 'vitest'
 import {flushPromises, mount} from "@vue/test-utils";
 import NftFile from "@/components/token/NftFile.vue";
-import router from "@/router";
 import Oruga from "@oruga-ui/oruga-next";
 
 describe("NftFile.vue", () => {
@@ -12,11 +11,9 @@ describe("NftFile.vue", () => {
 
     test("No URL and default values", async () => {
 
-        await router.push("/") // To avoid "missing required param 'network'" error
-
         const wrapper = mount(NftFile, {
             global: {
-                plugins: [router, Oruga]
+                plugins: [Oruga]
             },
             props: {},
         })
@@ -38,11 +35,9 @@ describe("NftFile.vue", () => {
 
     test("With URL and default values", async () => {
 
-        await router.push("/") // To avoid "missing required param 'network'" error
-
         const wrapper = mount(NftFile, {
             global: {
-                plugins: [router, Oruga]
+                plugins: [Oruga]
             },
             props: {
                 url: contentUrl
@@ -69,11 +64,9 @@ describe("NftFile.vue", () => {
 
     test("With URL and custom size", async () => {
 
-        await router.push("/") // To avoid "missing required param 'network'" error
-
         const wrapper = mount(NftFile, {
             global: {
-                plugins: [router, Oruga]
+                plugins: [Oruga]
             },
             props: {
                 url: contentUrl,
@@ -103,11 +96,9 @@ describe("NftFile.vue", () => {
 
     test("With URL and image type", async () => {
 
-        await router.push("/") // To avoid "missing required param 'network'" error
-
         const wrapper = mount(NftFile, {
             global: {
-                plugins: [router, Oruga]
+                plugins: [Oruga]
             },
             props: {
                 url: contentUrl,
@@ -135,11 +126,9 @@ describe("NftFile.vue", () => {
 
     test("With URL and video type", async () => {
 
-        await router.push("/") // To avoid "missing required param 'network'" error
-
         const wrapper = mount(NftFile, {
             global: {
-                plugins: [router, Oruga]
+                plugins: [Oruga]
             },
             props: {
                 url: contentUrl,
@@ -169,11 +158,9 @@ describe("NftFile.vue", () => {
 
     test("With URL and unsupported type", async () => {
 
-        await router.push("/") // To avoid "missing required param 'network'" error
-
         const wrapper = mount(NftFile, {
             global: {
-                plugins: [router, Oruga]
+                plugins: [Oruga]
             },
             props: {
                 url: contentUrl,

--- a/tests/unit/token/NftPreview.spec.ts
+++ b/tests/unit/token/NftPreview.spec.ts
@@ -3,7 +3,6 @@
 import {describe, expect, test} from 'vitest'
 import {flushPromises, mount} from "@vue/test-utils";
 import NftPreview from "@/components/token/NftPreview.vue";
-import router from "@/router";
 import Oruga from "@oruga-ui/oruga-next";
 
 describe("NftPreview.vue", () => {
@@ -12,11 +11,9 @@ describe("NftPreview.vue", () => {
 
     test("No URL and default values", async () => {
 
-        await router.push("/") // To avoid "missing required param 'network'" error
-
         const wrapper = mount(NftPreview, {
             global: {
-                plugins: [router, Oruga]
+                plugins: [Oruga]
             },
             props: {},
         })
@@ -39,12 +36,10 @@ describe("NftPreview.vue", () => {
 
     test("No URL and custom size", async () => {
 
-        await router.push("/") // To avoid "missing required param 'network'" error
-
         const tooltipText = 'The NFT metadata does not provide any image'
         const wrapper = mount(NftPreview, {
             global: {
-                plugins: [router, Oruga]
+                plugins: [Oruga]
             },
             props: {
                 size: 250
@@ -73,11 +68,9 @@ describe("NftPreview.vue", () => {
 
     test("With URL and custom size", async () => {
 
-        await router.push("/") // To avoid "missing required param 'network'" error
-
         const wrapper = mount(NftPreview, {
             global: {
-                plugins: [router, Oruga]
+                plugins: [Oruga]
             },
             props: {
                 url: contentUrl,
@@ -107,11 +100,9 @@ describe("NftPreview.vue", () => {
 
     test("With URL, image type and custom size", async () => {
 
-        await router.push("/") // To avoid "missing required param 'network'" error
-
         const wrapper = mount(NftPreview, {
             global: {
-                plugins: [router, Oruga]
+                plugins: [Oruga]
             },
             props: {
                 url: contentUrl,
@@ -142,11 +133,9 @@ describe("NftPreview.vue", () => {
 
     test("With URL, unsupported type and custom size", async () => {
 
-        await router.push("/") // To avoid "missing required param 'network'" error
-
         const wrapper = mount(NftPreview, {
             global: {
-                plugins: [router, Oruga]
+                plugins: [Oruga]
             },
             props: {
                 url: contentUrl,

--- a/tests/unit/token/TokenCell.spec.ts
+++ b/tests/unit/token/TokenCell.spec.ts
@@ -14,13 +14,11 @@ describe("TokenCell.vue", () => {
 
     test("default props", async () => {
 
-        await router.push("/") // To avoid "missing required param 'network'" error
-
         const mock = new MockAdapter(axios as any);
 
         const wrapper = mount(TokenCell, {
             global: {
-                plugins: [router, Oruga]
+                plugins: [Oruga]
             },
             props: {},
         })
@@ -38,8 +36,6 @@ describe("TokenCell.vue", () => {
 
     test("tokenId and default property", async () => {
 
-        await router.push("/") // To avoid "missing required param 'network'" error
-
         // Mock axios
         const mock = new MockAdapter(axios as any)
 
@@ -51,7 +47,7 @@ describe("TokenCell.vue", () => {
 
         const wrapper = mount(TokenCell, {
             global: {
-                plugins: [router, Oruga]
+                plugins: [Oruga]
             },
             props: {
                 tokenId: tokenId
@@ -73,8 +69,6 @@ describe("TokenCell.vue", () => {
 
     test("tokenId and property for NFT", async () => {
 
-        await router.push("/") // To avoid "missing required param 'network'" error
-
         // Mock axios
         const mock = new MockAdapter(axios as any)
 
@@ -86,7 +80,7 @@ describe("TokenCell.vue", () => {
 
         const wrapper = mount(TokenCell, {
             global: {
-                plugins: [router, Oruga]
+                plugins: [Oruga]
             },
             props: {
                 tokenId: tokenId,
@@ -134,8 +128,6 @@ describe("TokenCell.vue", () => {
     })
 
     test("tokenId and property for Fungible", async () => {
-
-        await router.push("/") // To avoid "missing required param 'network'" error
 
         // Mock axios
         const mock = new MockAdapter(axios as any)

--- a/tests/unit/token/Tokens.spec.ts
+++ b/tests/unit/token/Tokens.spec.ts
@@ -26,8 +26,6 @@ describe("Tokens.vue", () => {
 
     test("no props", async () => {
 
-        await router.push("/") // To avoid "missing required param 'network'" error
-
         const mock = new MockAdapter(axios as any);
 
         const matcher = "/api/v1/tokens"

--- a/tests/unit/topic/HCSContentSection.spec.ts
+++ b/tests/unit/topic/HCSContentSection.spec.ts
@@ -4,7 +4,6 @@
 
 import {describe, expect, it} from 'vitest'
 import {flushPromises, mount} from "@vue/test-utils"
-import router from "@/router";
 import Oruga from "@oruga-ui/oruga-next";
 import {HMSF} from "@/utils/HMSF";
 import HCSContentSection from "@/components/topic/HCSContentSection.vue";
@@ -60,14 +59,12 @@ describe("HCSContentSection.vue", () => {
 
     it("Should display HCS-1 Content section with JSON asset", async () => {
 
-        await router.push("/") // To avoid "missing required param 'network'" error
-
         const hcs1TopicMemo = HCSTopicMemo.parse(topicMemo)
         const hcs1Asset = await HCSAsset.reassemble([topicMessage], true)
 
         const wrapper = mount(HCSContentSection, {
             global: {
-                plugins: [router, Oruga]
+                plugins: [Oruga]
             },
             props: {
                 topicMemo: hcs1TopicMemo,
@@ -97,14 +94,12 @@ describe("HCSContentSection.vue", () => {
 
     it("Should display HCS-1 Content section without preview for incomplete JSON asset", async () => {
 
-        await router.push("/") // To avoid "missing required param 'network'" error
-
         const hcs1TopicMemo = HCSTopicMemo.parse(topicMemo)
         const hcs1Asset = await HCSAsset.reassemble([topicMessage], false)
 
         const wrapper = mount(HCSContentSection, {
             global: {
-                plugins: [router, Oruga]
+                plugins: [Oruga]
             },
             props: {
                 topicMemo: hcs1TopicMemo,
@@ -132,14 +127,12 @@ describe("HCSContentSection.vue", () => {
 
     it("Should display HCS-1 Content section without preview for JSON asset with hash mismatch", async () => {
 
-        await router.push("/") // To avoid "missing required param 'network'" error
-
         const hcs1TopicMemo = HCSTopicMemo.parse(topicMemoWithWrongHash)
         const hcs1Asset = await HCSAsset.reassemble([topicMessage], false)
 
         const wrapper = mount(HCSContentSection, {
             global: {
-                plugins: [router, Oruga]
+                plugins: [Oruga]
             },
             props: {
                 topicMemo: hcs1TopicMemo,
@@ -167,14 +160,12 @@ describe("HCSContentSection.vue", () => {
 
     it("Should display HCS-1 Content section without preview for unsupported compression algorithm", async () => {
 
-        await router.push("/") // To avoid "missing required param 'network'" error
-
         const topicMemo = "3a43f42084de067e470a0ae677a601eaad58a8808b59a935dda4bdb8ae34e21b:unknown:base64"
         const hcs1TopicMemo = HCSTopicMemo.parse(topicMemo)
 
         const wrapper = mount(HCSContentSection, {
             global: {
-                plugins: [router, Oruga]
+                plugins: [Oruga]
             },
             props: {
                 topicMemo: hcs1TopicMemo,
@@ -201,8 +192,6 @@ describe("HCSContentSection.vue", () => {
     });
 
     it("Should display HCS-1 Content section with preview for asset using brotli compression algo", async () => {
-
-        await router.push("/") // To avoid "missing required param 'network'" error
 
         const topicMemo = "3a43f42084de067e470a0ae677a601eaad58a8808b59a935dda4bdb8ae34e21b:brotli:base64"
         const topicMessage = {
@@ -247,7 +236,7 @@ describe("HCSContentSection.vue", () => {
 
         const wrapper = mount(HCSContentSection, {
             global: {
-                plugins: [router, Oruga]
+                plugins: [Oruga]
             },
             props: {
                 topicMemo: hcs1TopicMemo,

--- a/tests/unit/topic/TopicMessageCell.spec.ts
+++ b/tests/unit/topic/TopicMessageCell.spec.ts
@@ -3,7 +3,6 @@
 import {describe, expect, test} from 'vitest'
 import {flushPromises, mount} from "@vue/test-utils";
 import TopicMessageCell, {TopicMessageCellItem} from "@/components/topic/TopicMessageCell.vue";
-import router from "@/router";
 import Oruga from "@oruga-ui/oruga-next";
 import {SAMPLE_TOPIC_MESSAGES} from "../Mocks";
 import MockAdapter from "axios-mock-adapter";
@@ -13,11 +12,9 @@ describe("TopicMessageCell.vue", () => {
 
     test("default props", async () => {
 
-        await router.push("/") // To avoid "missing required param 'network'" error
-
         const wrapper = mount(TopicMessageCell, {
             global: {
-                plugins: [router, Oruga]
+                plugins: [Oruga]
             },
             props: {},
         })
@@ -33,8 +30,6 @@ describe("TopicMessageCell.vue", () => {
 
     test("timestamp and default property", async () => {
 
-        await router.push("/") // To avoid "missing required param 'network'" error
-
         // Mock axios
         const mock = new MockAdapter(axios as any)
 
@@ -46,7 +41,7 @@ describe("TopicMessageCell.vue", () => {
 
         const wrapper = mount(TopicMessageCell, {
             global: {
-                plugins: [router, Oruga]
+                plugins: [Oruga]
             },
             props: {
                 timestamp: timestamp
@@ -64,8 +59,6 @@ describe("TopicMessageCell.vue", () => {
 
     test("timestamp and property", async () => {
 
-        await router.push("/") // To avoid "missing required param 'network'" error
-
         // Mock axios
         const mock = new MockAdapter(axios as any)
 
@@ -77,7 +70,7 @@ describe("TopicMessageCell.vue", () => {
 
         const wrapper = mount(TopicMessageCell, {
             global: {
-                plugins: [router, Oruga]
+                plugins: [Oruga]
             },
             props: {
                 timestamp: timestamp,

--- a/tests/unit/topic/Topics.spec.ts
+++ b/tests/unit/topic/Topics.spec.ts
@@ -25,8 +25,6 @@ describe("Topics.vue", () => {
 
     test("no props", async () => {
 
-        await router.push("/") // To avoid "missing required param 'network'" error
-
         const mock = new MockAdapter(axios as any)
 
         const matcher = "api/v1/transactions"

--- a/tests/unit/transaction/TransactionByIdTable.spec.ts
+++ b/tests/unit/transaction/TransactionByIdTable.spec.ts
@@ -30,8 +30,6 @@ describe("TransactionByIdTable.vue", () => {
 
     it("Should list transactions as parent and child", async () => {
 
-        await router.push("/") // To avoid "missing required param 'network'" error
-
         const mock = new MockAdapter(axios as any);
         const matcher1 = "/api/v1/tokens/" + "0.0.48193741"
         mock.onGet(matcher1).reply(200, SAMPLE_DUDE_WITH_KEYS)
@@ -63,8 +61,6 @@ describe("TransactionByIdTable.vue", () => {
     });
 
     it("Should list transactions as scheduling and scheduled", async () => {
-
-        await router.push("/") // To avoid "missing required param 'network'" error
 
         const SCHEDULED = SAMPLE_SCHEDULING_SCHEDULED_TRANSACTIONS.transactions![1]
         const TOKEN_ID = SCHEDULED.token_transfers ? SCHEDULED.token_transfers[0].token_id : "0.0.1304757"
@@ -106,14 +102,13 @@ describe("TransactionByIdTable.vue", () => {
 
     it("Should list transactions as unrelated", async () => {
 
-        await router.push("/") // To avoid "missing required param 'network'" error
         const mock = new MockAdapter(axios as any);
         const matcher1 = "/api/v1/tokens/" + "0.0.48193741"
         mock.onGet(matcher1).reply(200, SAMPLE_DUDE_WITH_KEYS)
 
         const wrapper = mount(TransactionByIdTable, {
             global: {
-                plugins: [router, Oruga]
+                plugins: [Oruga]
             },
             props: {
                 narrowed: true,

--- a/tests/unit/transaction/Transactions.spec.ts
+++ b/tests/unit/transaction/Transactions.spec.ts
@@ -29,8 +29,6 @@ describe("Transactions.vue", () => {
 
     test("no props", async () => {
 
-        await router.push("/") // To avoid "missing required param 'network'" error
-
         const mock = new MockAdapter(axios as any)
 
         const matcher1 = "/api/v1/transactions"
@@ -92,8 +90,6 @@ describe("Transactions.vue", () => {
 
     test("without page size selector", async () => {
 
-        await router.push("/") // To avoid "missing required param 'network'" error
-
         const mock = new MockAdapter(axios as any)
 
         const matcher1 = "/api/v1/transactions"
@@ -141,8 +137,6 @@ describe("Transactions.vue", () => {
     });
 
     test("page size selector", async () => {
-
-        await router.push("/") // To avoid "missing required param 'network'" error
 
         const mock = new MockAdapter(axios as any)
 

--- a/tests/unit/transfer_graphs/NftTransferGraph.spec.ts
+++ b/tests/unit/transfer_graphs/NftTransferGraph.spec.ts
@@ -21,12 +21,7 @@ describe("NftTransferGraph.vue", () => {
 
         await router.push("/") // To avoid "missing required param 'network'" error
 
-        const wrapper = mount(NftTransferGraph, {
-            global: {
-                plugins: [router]
-            },
-            props: {},
-        })
+        const wrapper = mount(NftTransferGraph)
 
         await flushPromises()
 
@@ -40,8 +35,6 @@ describe("NftTransferGraph.vue", () => {
     })
 
     test("Two tokens, Transfer", async () => {
-
-        await router.push("/") // To avoid "missing required param 'network'" error
 
         const transaction = {
             "nft_transfers": [
@@ -164,8 +157,6 @@ describe("NftTransferGraph.vue", () => {
 
     test("Mint, one token, one destination", async () => {
 
-        await router.push("/") // To avoid "missing required param 'network'" error
-
         const transaction = {
             "nft_transfers": [
                 {
@@ -208,8 +199,6 @@ describe("NftTransferGraph.vue", () => {
     })
 
     test("Mint, one token, two destinations", async () => {
-
-        await router.push("/") // To avoid "missing required param 'network'" error
 
         const transaction = {
             "nft_transfers": [
@@ -264,8 +253,6 @@ describe("NftTransferGraph.vue", () => {
 
     test("Burn, one token, one source", async () => {
 
-        await router.push("/") // To avoid "missing required param 'network'" error
-
         const transaction = {
             "nft_transfers": [
                 {
@@ -308,8 +295,6 @@ describe("NftTransferGraph.vue", () => {
     })
 
     test("Burn, one token, two sources", async () => {
-
-        await router.push("/") // To avoid "missing required param 'network'" error
 
         const transaction = {
             "nft_transfers": [

--- a/tests/unit/transfer_graphs/RewardTransferGraph.spec.ts
+++ b/tests/unit/transfer_graphs/RewardTransferGraph.spec.ts
@@ -17,12 +17,7 @@ describe("RewardTransferGraph.vue", () => {
 
     test("Without transaction prop", async () => {
 
-        await router.push("/") // To avoid "missing required param 'network'" error
-
         const wrapper = mount(RewardTransferGraph, {
-            global: {
-                plugins: [router]
-            },
             props: {},
         })
 
@@ -39,12 +34,7 @@ describe("RewardTransferGraph.vue", () => {
 
     test("with transfers and no rewards", async () => {
 
-        await router.push("/") // To avoid "missing required param 'network'" error
-
         const wrapper = mount(RewardTransferGraph, {
-            global: {
-                plugins: [router]
-            },
             props: {
                 transaction: SAMPLE_CRYPTO_TRANSFER_WITH_ONLY_FEE as Transaction,
             },
@@ -61,8 +51,6 @@ describe("RewardTransferGraph.vue", () => {
     })
 
     test("with multiple transfers and rewards", async () => {
-
-        await router.push("/") // To avoid "missing required param 'network'" error
 
         const mock = new MockAdapter(axios as any);
         const matcher1 = "/api/v1/network/exchangerate"

--- a/tests/unit/transfer_graphs/TokenTransferGraphC.spec.ts
+++ b/tests/unit/transfer_graphs/TokenTransferGraphC.spec.ts
@@ -23,12 +23,7 @@ describe("TokenTransferGraphC.vue", () => {
 
     test("Without transaction", async () => {
 
-        await router.push("/") // To avoid "missing required param 'network'" error
-
         const wrapper = mount(TokenTransferGraphC, {
-            global: {
-                plugins: [router]
-            },
             props: {},
         })
 
@@ -48,8 +43,6 @@ describe("TokenTransferGraphC.vue", () => {
     //
 
     test("Single token, zero source, single dest", async () => {
-
-        await router.push("/") // To avoid "missing required param 'network'" error
 
         const transaction = {
             "token_transfers": [
@@ -80,8 +73,6 @@ describe("TokenTransferGraphC.vue", () => {
     })
 
     test("Single token, single source, single dest", async () => {
-
-        await router.push("/") // To avoid "missing required param 'network'" error
 
         const transaction = {
             "token_transfers": [
@@ -114,8 +105,6 @@ describe("TokenTransferGraphC.vue", () => {
     })
 
     test("Single token, single source, two dest", async () => {
-
-        await router.push("/") // To avoid "missing required param 'network'" error
 
         const transaction = {
             "token_transfers": [
@@ -151,8 +140,6 @@ describe("TokenTransferGraphC.vue", () => {
 
     test("Single token, two sources, zero dest", async () => {
 
-        await router.push("/") // To avoid "missing required param 'network'" error
-
         const transaction = {
             "token_transfers": [
                 {"account": "0.0.101", "amount": -3, "token_id": SAMPLE_TOKEN.token_id},
@@ -183,8 +170,6 @@ describe("TokenTransferGraphC.vue", () => {
     })
 
     test("Single token, two sources, single dest", async () => {
-
-        await router.push("/") // To avoid "missing required param 'network'" error
 
         const transaction = {
             "token_transfers": [
@@ -218,8 +203,6 @@ describe("TokenTransferGraphC.vue", () => {
     })
 
     test("Single token, two sources, two dest", async () => {
-
-        await router.push("/") // To avoid "missing required param 'network'" error
 
         const transaction = {
             "token_transfers": [
@@ -260,8 +243,6 @@ describe("TokenTransferGraphC.vue", () => {
     //
 
     test("Two token", async () => {
-
-        await router.push("/") // To avoid "missing required param 'network'" error
 
         const transaction = {
             "token_transfers": [

--- a/tests/unit/transfer_graphs/TokenTransferGraphF.spec.ts
+++ b/tests/unit/transfer_graphs/TokenTransferGraphF.spec.ts
@@ -21,8 +21,6 @@ describe("TokenTransferGraphF.vue", () => {
 
     test("Without transaction", async () => {
 
-        await router.push("/") // To avoid "missing required param 'network'" error
-
         const wrapper = mount(TokenTransferGraph, {
             global: {
                 plugins: [router]
@@ -46,8 +44,6 @@ describe("TokenTransferGraphF.vue", () => {
     //
 
     test("Single token, zero source, single dest", async () => {
-
-        await router.push("/") // To avoid "missing required param 'network'" error
 
         const transaction = {
             "token_transfers": [
@@ -79,8 +75,6 @@ describe("TokenTransferGraphF.vue", () => {
     })
 
     test("Single token, single source, single dest", async () => {
-
-        await router.push("/") // To avoid "missing required param 'network'" error
 
         const transaction = {
             "token_transfers": [
@@ -135,8 +129,6 @@ describe("TokenTransferGraphF.vue", () => {
 
     test("Single token, single source, two dest", async () => {
 
-        await router.push("/") // To avoid "missing required param 'network'" error
-
         const transaction = {
             "token_transfers": [
                 {"account": "0.0.100", "amount": -10, "token_id": SAMPLE_TOKEN.token_id},
@@ -171,8 +163,6 @@ describe("TokenTransferGraphF.vue", () => {
 
     test("Single token, two sources, zero dest", async () => {
 
-        await router.push("/") // To avoid "missing required param 'network'" error
-
         const transaction = {
             "token_transfers": [
                 {"account": "0.0.101", "amount": -3, "token_id": SAMPLE_TOKEN.token_id},
@@ -204,8 +194,6 @@ describe("TokenTransferGraphF.vue", () => {
     })
 
     test("Single token, two sources, single dest", async () => {
-
-        await router.push("/") // To avoid "missing required param 'network'" error
 
         const transaction = {
             "token_transfers": [
@@ -239,8 +227,6 @@ describe("TokenTransferGraphF.vue", () => {
     })
 
     test("Single token, two sources, two dest", async () => {
-
-        await router.push("/") // To avoid "missing required param 'network'" error
 
         const transaction = {
             "token_transfers": [
@@ -281,8 +267,6 @@ describe("TokenTransferGraphF.vue", () => {
     //
 
     test("Two token", async () => {
-
-        await router.push("/") // To avoid "missing required param 'network'" error
 
         const transaction = {
             "token_transfers": [

--- a/tests/unit/values/AccountLink.spec.ts
+++ b/tests/unit/values/AccountLink.spec.ts
@@ -12,8 +12,6 @@ describe("AccountLink.vue", () => {
 
     it("props.accountId set ; no extra", async () => {
 
-        await router.push("/") // To avoid "missing required param 'network'" error
-
         const mock = new MockAdapter(axios as any);
         const matcher1 = "/api/v1/network/nodes"
         mock.onGet(matcher1).reply(200, SAMPLE_NETWORK_NODES);
@@ -42,8 +40,6 @@ describe("AccountLink.vue", () => {
 
     it("props.accountId unset, nullLabel unset", async () => {
 
-        await router.push("/") // To avoid "missing required param 'network'" error
-
         const wrapper = mount(AccountLink, {
             global: {
                 plugins: [router]
@@ -60,8 +56,6 @@ describe("AccountLink.vue", () => {
 
 
     it("props.accountId unset, nullLabel set", async () => {
-
-        await router.push("/") // To avoid "missing required param 'network'" error
 
         const wrapper = mount(AccountLink, {
             global: {
@@ -81,8 +75,6 @@ describe("AccountLink.vue", () => {
 
 
     it("props.extra set", async () => {
-
-        await router.push("/") // To avoid "missing required param 'network'" error
 
         const mock = new MockAdapter(axios as any);
         const matcher1 = "/api/v1/network/nodes"

--- a/tests/unit/values/BlockLink.spec.ts
+++ b/tests/unit/values/BlockLink.spec.ts
@@ -9,8 +9,6 @@ describe("BlockLink.vue", () => {
 
     it("should construct a valid BlockLink to block #12", async () => {
 
-        await router.push("/") // To avoid "missing required param 'network'" error
-
         const testBlockNumber = 12
         const wrapper = mount(BlockLink, {
             global: {
@@ -30,8 +28,6 @@ describe("BlockLink.vue", () => {
     });
 
     it("should construct an empty BlockLink", async () => {
-
-        await router.push("/") // To avoid "missing required param 'network'" error
 
         const wrapper = mount(BlockLink, {
             global: {

--- a/tests/unit/values/ComplexKeyValue.spec.ts
+++ b/tests/unit/values/ComplexKeyValue.spec.ts
@@ -12,8 +12,6 @@ describe("ComplexKeyValue.vue", () => {
 
     it("props.keyBytes set with complex key", async () => {
 
-        await router.push("/") // To avoid "missing required param 'network'" error
-
         const wrapper = mount(ComplexKeyValue, {
             global: {
                 plugins: [router]
@@ -32,8 +30,6 @@ describe("ComplexKeyValue.vue", () => {
 
     it("props.keyBytes set with contract key", async () => {
 
-        await router.push("/") // To avoid "missing required param 'network'" error
-
         const wrapper = mount(ComplexKeyValue, {
             global: {
                 plugins: [router]
@@ -51,8 +47,6 @@ describe("ComplexKeyValue.vue", () => {
 
     it("props.keyBytes unset, showNone=false", async () => {
 
-        await router.push("/") // To avoid "missing required param 'network'" error
-
         const wrapper = mount(ComplexKeyValue, {
             global: {
                 plugins: [router]
@@ -66,8 +60,6 @@ describe("ComplexKeyValue.vue", () => {
     });
 
     it("props.keyBytes unset, showNone=true", async () => {
-
-        await router.push("/") // To avoid "missing required param 'network'" error
 
         const wrapper = mount(ComplexKeyValue, {
             global: {

--- a/tests/unit/values/ContractLink.spec.ts
+++ b/tests/unit/values/ContractLink.spec.ts
@@ -9,8 +9,6 @@ describe("ContractLink.vue", () => {
 
     test("topicId set", async () => {
 
-        await router.push("/") // To avoid "missing required param 'network'" error
-
         const testContractId = "0.0.42"
         const wrapper = mount(ContractLink, {
             global: {
@@ -30,8 +28,6 @@ describe("ContractLink.vue", () => {
     });
 
     test("topicId unset", async () => {
-
-        await router.push("/") // To avoid "missing required param 'network'" error
 
         const wrapper = mount(ContractLink, {
             global: {

--- a/tests/unit/values/DurationValue.spec.ts
+++ b/tests/unit/values/DurationValue.spec.ts
@@ -2,7 +2,6 @@
 
 import {describe, expect, test} from 'vitest'
 import {flushPromises, mount, VueWrapper} from "@vue/test-utils"
-import router from "@/router";
 import DurationValue from "@/components/values/DurationValue.vue";
 
 describe("DurationValue.vue", () => {
@@ -13,12 +12,7 @@ describe("DurationValue.vue", () => {
 
     test("numberValue / stringValue undefined", async () => {
 
-        const wrapper = mount(DurationValue, {
-            global: {
-                plugins: [router]
-            },
-            props: {}
-        });
+        const wrapper = mount(DurationValue);
 
         await flushPromises()
 
@@ -36,12 +30,7 @@ describe("DurationValue.vue", () => {
 
     test("various cases of numberValue defined", async () => {
 
-        const wrapper = mount(DurationValue, {
-            global: {
-                plugins: [router]
-            },
-            props: {}
-        });
+        const wrapper = mount(DurationValue);
 
         const year = 31536000
         const day = 86400
@@ -78,9 +67,6 @@ describe("DurationValue.vue", () => {
         const D1 = 3600 * 5 + 60 + 42
         const S1 = "5h 1min 42s"
         const wrapper = mount(DurationValue, {
-            global: {
-                plugins: [router]
-            },
             props: {
                 numberValue: undefined,
                 stringValue: D1.toString(),
@@ -104,9 +90,6 @@ describe("DurationValue.vue", () => {
 
         const S1 = "dummy"
         const wrapper = mount(DurationValue, {
-            global: {
-                plugins: [router]
-            },
             props: {
                 stringValue: S1,
             }

--- a/tests/unit/values/Endpoints.spec.ts
+++ b/tests/unit/values/Endpoints.spec.ts
@@ -2,7 +2,6 @@
 
 import {describe, expect, it} from 'vitest'
 import {flushPromises, mount} from "@vue/test-utils"
-import router from "@/router";
 import Endpoints from "@/components/values/Endpoints.vue";
 import {SAMPLE_NETWORK_NODES} from "../Mocks";
 import {ServiceEndPoint} from "@/schemas/MirrorNodeSchemas";
@@ -10,12 +9,7 @@ import {ServiceEndPoint} from "@/schemas/MirrorNodeSchemas";
 describe("Endpoint.vue", () => {
 
     it("should output 'None' when the props is undefined", async () => {
-        const wrapper = mount(Endpoints, {
-            global: {
-                plugins: [router]
-            },
-            props: {}
-        });
+        const wrapper = mount(Endpoints);
         await flushPromises()
         expect(wrapper.text()).toBe("None")
 
@@ -25,9 +19,6 @@ describe("Endpoint.vue", () => {
 
     it("should output 'None' when the array of endpoints is empty", async () => {
         const wrapper = mount(Endpoints, {
-            global: {
-                plugins: [router]
-            },
             props: {
                 endpoints: []
             }
@@ -41,9 +32,6 @@ describe("Endpoint.vue", () => {
 
     it("should not output an endpoint where the address is undefined", async () => {
         const wrapper = mount(Endpoints, {
-            global: {
-                plugins: [router]
-            },
             props: {
                 endpoints: SAMPLE_NETWORK_NODES.nodes[1].service_endpoints as Array<ServiceEndPoint>
             }
@@ -57,9 +45,6 @@ describe("Endpoint.vue", () => {
 
     it("should output an endpoint address alone when port is undefined", async () => {
         const wrapper = mount(Endpoints, {
-            global: {
-                plugins: [router]
-            },
             props: {
                 endpoints: SAMPLE_NETWORK_NODES.nodes[2].service_endpoints as Array<ServiceEndPoint>
             }
@@ -75,9 +60,6 @@ describe("Endpoint.vue", () => {
 
     it("should ouput <address>:<port> for all 5 endpoints", async () => {
         const wrapper = mount(Endpoints, {
-            global: {
-                plugins: [router]
-            },
             props: {
                 endpoints: SAMPLE_NETWORK_NODES.nodes[0].service_endpoints as Array<ServiceEndPoint>
             }

--- a/tests/unit/values/KeyValue.spec.ts
+++ b/tests/unit/values/KeyValue.spec.ts
@@ -2,20 +2,14 @@
 
 import {describe, expect, it} from 'vitest'
 import {mount} from "@vue/test-utils"
-import router from "@/router";
 import KeyValue from "@/components/values/KeyValue.vue";
 
 describe("KeyValue.vue", () => {
 
     it("props.keyBytes set", async () => {
 
-        await router.push("/") // To avoid "missing required param 'network'" error
-
         const testBytes = "000102030405060708090A0B0C0D0E0F"
         const wrapper = mount(KeyValue, {
-            global: {
-                plugins: [router]
-            },
             props: {
                 keyBytes: testBytes
             },
@@ -28,14 +22,7 @@ describe("KeyValue.vue", () => {
 
     it("props.keyBytes unset, showNone=false", async () => {
 
-        await router.push("/") // To avoid "missing required param 'network'" error
-
-        const wrapper = mount(KeyValue, {
-            global: {
-                plugins: [router]
-            },
-            props: {},
-        });
+        const wrapper = mount(KeyValue);
 
         expect(wrapper.text()).toBe("")
 
@@ -44,12 +31,7 @@ describe("KeyValue.vue", () => {
 
     it("props.keyBytes unset, showNone=true", async () => {
 
-        await router.push("/") // To avoid "missing required param 'network'" error
-
         const wrapper = mount(KeyValue, {
-            global: {
-                plugins: [router]
-            },
             props: {
                 showNone: true
             },
@@ -62,12 +44,7 @@ describe("KeyValue.vue", () => {
 
     it("should display 'None' with a mention on the line below", async () => {
 
-        await router.push("/") // To avoid "missing required param 'network'" error
-
         const wrapper = mount(KeyValue, {
-            global: {
-                plugins: [router]
-            },
             props: {
                 showNone: true,
                 noneExtra: "This should be displayed below None"

--- a/tests/unit/values/NftCell.spec.ts
+++ b/tests/unit/values/NftCell.spec.ts
@@ -19,18 +19,12 @@ import {
 import MockAdapter from "axios-mock-adapter";
 import axios from "axios";
 import NftCell, {NftCellItem} from "@/components/token/NftCell.vue";
-import router from "@/router";
 
 describe("NftCell.vue", () => {
 
     test("no props", async () => {
 
-        const wrapper = mount(NftCell, {
-            global: {
-                plugins: [router]
-            },
-            props: {},
-        });
+        const wrapper = mount(NftCell);
         await flushPromises()
 
         expect(wrapper.text()).toBe("")
@@ -53,9 +47,6 @@ describe("NftCell.vue", () => {
         mock.onGet(IPFS_METADATA_CONTENT_URL).reply(200, IPFS_METADATA_CONTENT)
 
         const wrapper = mount(NftCell, {
-            global: {
-                plugins: [router]
-            },
             props: {
                 tokenId: nftId
             },
@@ -89,9 +80,6 @@ describe("NftCell.vue", () => {
         mock.onGet(IPFS_METADATA_CONTENT_URL).reply(200, IPFS_METADATA_CONTENT)
 
         const wrapper = mount(NftCell, {
-            global: {
-                plugins: [router]
-            },
             props: {
                 tokenId: nft.token_id,
                 serialNumber: serial
@@ -126,9 +114,6 @@ describe("NftCell.vue", () => {
         mock.onGet(IPFS_METADATA_CONTENT_URL).reply(200, IPFS_METADATA_CONTENT)
 
         const wrapper = mount(NftCell, {
-            global: {
-                plugins: [router]
-            },
             props: {
                 tokenId: nft.token_id,
                 serialNumber: serial,

--- a/tests/unit/values/OpcodeValue.spec.ts
+++ b/tests/unit/values/OpcodeValue.spec.ts
@@ -29,8 +29,6 @@ describe("OpcodeValue.vue", () => {
 
     it("should show the opcode with and without hexa opcode value", async () => {
 
-        await router.push("/") // To avoid "missing required param 'network'" error
-
         const opcode: DisassembledOpcodeOutput = {
             index16: '0x0dc2',
             hex: '63',
@@ -49,9 +47,6 @@ describe("OpcodeValue.vue", () => {
             "0x4e487b71"
 
         const wrapper = mount(OpcodeValue, {
-            global: {
-                plugins: [router]
-            },
             props: {
                 opcode: opcode,
                 showHexaOpcode: true
@@ -73,8 +68,6 @@ describe("OpcodeValue.vue", () => {
     });
 
     it("should show the opcode with a link to the contract address", async () => {
-
-        await router.push("/") // To avoid "missing required param 'network'" error
 
         const matcher1 = "/api/v1/contracts/" + SAMPLE_CONTRACT.evm_address
         mock.onGet(matcher1).reply(200, SAMPLE_CONTRACT);
@@ -136,8 +129,6 @@ describe("OpcodeValue.vue", () => {
     });
 
     it("should show the opcode with a link to the account address", async () => {
-
-        await router.push("/") // To avoid "missing required param 'network'" error
 
         const matcher1 = "/api/v1/contracts/" + SAMPLE_CONTRACT.evm_address
         mock.onGet(matcher1).reply(404);

--- a/tests/unit/values/TimestampValue.spec.ts
+++ b/tests/unit/values/TimestampValue.spec.ts
@@ -2,7 +2,6 @@
 
 import {describe, expect, test} from 'vitest'
 import {flushPromises, mount} from "@vue/test-utils"
-import router from "@/router";
 import TimestampValue from "@/components/values/TimestampValue.vue";
 import {HMSF} from "@/utils/HMSF";
 
@@ -16,12 +15,7 @@ describe("TimestampValue.vue", () => {
 
     test("timestamp undefined, showNone == false", async () => {
 
-        const wrapper = mount(TimestampValue, {
-            global: {
-                plugins: [router]
-            },
-            props: {},
-        });
+        const wrapper = mount(TimestampValue);
 
         await flushPromises()
 
@@ -34,9 +28,6 @@ describe("TimestampValue.vue", () => {
     test("timestamp undefined, showNone == true", async () => {
 
         const wrapper = mount(TimestampValue, {
-            global: {
-                plugins: [router]
-            },
             props: {
                 showNone: true
             },
@@ -63,9 +54,6 @@ describe("TimestampValue.vue", () => {
     test("timestamp expressed in seconds", async () => {
 
         const wrapper = mount(TimestampValue, {
-            global: {
-                plugins: [router]
-            },
             props: {
                 timestamp: TIMESTAMP_SECONDS
             },
@@ -88,9 +76,6 @@ describe("TimestampValue.vue", () => {
     test("timestamp expressed in nanoseconds", async () => {
 
         const wrapper = mount(TimestampValue, {
-            global: {
-                plugins: [router]
-            },
             props: {
                 timestamp: TIMESTAMP_NANOS,
                 nano: true
@@ -115,9 +100,6 @@ describe("TimestampValue.vue", () => {
     test("infinite timestamp", async () => {
 
         const wrapper = mount(TimestampValue, {
-            global: {
-                plugins: [router]
-            },
             props: {
                 timestamp: INFINITE_TIMESTAMP
             },

--- a/tests/unit/values/TokenAmount.spec.ts
+++ b/tests/unit/values/TokenAmount.spec.ts
@@ -36,8 +36,6 @@ describe("TokenAmount.vue", () => {
 
     it("no amount; tokenId", async () => {
 
-        await router.push("/") // To avoid "missing required param 'network'" error
-
         const expectedAmount = 0
 
         const wrapper = mount(TokenAmount, {
@@ -68,8 +66,6 @@ describe("TokenAmount.vue", () => {
 
     it("amount; no tokenId", async () => {
 
-        await router.push("/") // To avoid "missing required param 'network'" error
-
         const testAmount = 42
 
         const wrapper = mount(TokenAmount, {
@@ -90,8 +86,6 @@ describe("TokenAmount.vue", () => {
     });
 
     it("amount; tokenId", async () => {
-
-        await router.push("/") // To avoid "missing required param 'network'" error
 
         const testAmount = 42
 
@@ -135,8 +129,6 @@ describe("TokenAmount.vue", () => {
     });
 
     it("should detect too large decimal count", async () => {
-
-        await router.push("/") // To avoid "missing required param 'network'" error
 
         const testAmount = 42
 

--- a/tests/unit/values/TokenExtra.spec.ts
+++ b/tests/unit/values/TokenExtra.spec.ts
@@ -20,8 +20,6 @@ describe("TokenExtra.vue", () => {
 
     it("no props then with token id", async () => {
 
-        await router.push("/") // To avoid "missing required param 'network'" error
-
         const mock = new MockAdapter(axios as any);
         const matcher = "/api/v1/tokens/" + SAMPLE_TOKEN.token_id
         mock.onGet(matcher).reply(200, SAMPLE_TOKEN);

--- a/tests/unit/values/TokenLink.spec.ts
+++ b/tests/unit/values/TokenLink.spec.ts
@@ -20,8 +20,6 @@ describe("TokenLink.vue", () => {
 
     it("props.topicId set", async () => {
 
-        await router.push("/") // To avoid "missing required param 'network'" error
-
         const mock = new MockAdapter(axios as any);
         const matcher = "/api/v1/tokens/" + SAMPLE_TOKEN.token_id
         mock.onGet(matcher).reply(200, SAMPLE_TOKEN);
@@ -48,8 +46,6 @@ describe("TokenLink.vue", () => {
     });
 
     it("props.topicId set and showExtra", async () => {
-
-        await router.push("/") // To avoid "missing required param 'network'" error
 
         const mock = new MockAdapter(axios as any);
         const matcher = "/api/v1/tokens/" + SAMPLE_TOKEN.token_id
@@ -88,8 +84,6 @@ describe("TokenLink.vue", () => {
     });
 
     it("props.topicId unset", async () => {
-
-        await router.push("/mainnet/dashboard") // To avoid "missing required param 'network'" error
 
         const wrapper = mount(TokenLink, {
             global: {

--- a/tests/unit/values/TopicLink.spec.ts
+++ b/tests/unit/values/TopicLink.spec.ts
@@ -9,8 +9,6 @@ describe("TopicLink.vue", () => {
 
     it("props.topicId set", async () => {
 
-        await router.push("/") // To avoid "missing required param 'network'" error
-
         const testTopicId = "0.0.42"
         const wrapper = mount(TopicLink, {
             global: {
@@ -30,8 +28,6 @@ describe("TopicLink.vue", () => {
     });
 
     it("props.topicId unset", async () => {
-
-        await router.push("/") // To avoid "missing required param 'network'" error
 
         const wrapper = mount(TopicLink, {
             global: {

--- a/tests/unit/values/TransactionIdValue.spec.ts
+++ b/tests/unit/values/TransactionIdValue.spec.ts
@@ -2,7 +2,6 @@
 
 import {describe, expect, test} from 'vitest'
 import {flushPromises, mount} from "@vue/test-utils"
-import router from "@/router";
 import TransactionIdValue from "@/components/values/TransactionIdValue.vue";
 import {TransactionID} from "@/utils/TransactionID";
 
@@ -10,12 +9,7 @@ describe("TransactionIdValue.vue", () => {
 
     test("default props", async () => {
 
-        const wrapper = mount(TransactionIdValue, {
-            global: {
-                plugins: [router]
-            },
-            props: {},
-        });
+        const wrapper = mount(TransactionIdValue);
         await flushPromises()
 
         expect(wrapper.text()).toBe("")
@@ -30,9 +24,6 @@ describe("TransactionIdValue.vue", () => {
     test("transaction ID with at", async () => {
 
         const wrapper = mount(TransactionIdValue, {
-            global: {
-                plugins: [router]
-            },
             props: {
                 id: tId
 


### PR DESCRIPTION
**Description**:

Changes below remove unneeded `plugins: [router]` from `mount()` options in unit tests.
They also remove some useless `await router.push("/")` lines from unit tests.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
