### PR TITLE
chore: renaming NetworkEntry.mirrorNodeURL as url

### DIFF
--- a/src/components/MirrorLink.vue
+++ b/src/components/MirrorLink.vue
@@ -39,7 +39,7 @@ const props = defineProps({
 const isMediumScreen = inject("isMediumScreen")
 
 const endpointURL = computed(() => {
-  let result = routeManager.currentNetworkEntry.value.mirrorNodeURL
+  let result = routeManager.currentNetworkEntry.value.url
   result += `api/v1/${props.entityUrl}`
   if (props.loc !== null) {
     result += `/${props.loc}`

--- a/src/config/NetworkConfig.ts
+++ b/src/config/NetworkConfig.ts
@@ -144,7 +144,7 @@ export class NetworkEntry {
     private constructor(
         public readonly name: string,
         public readonly displayName: string,
-        public readonly mirrorNodeURL: string,
+        public readonly url: string,
         public readonly ledgerID: string,
         public readonly baseRealm: number,
         public readonly baseShard: number,

--- a/src/utils/RouteManager.ts
+++ b/src/utils/RouteManager.ts
@@ -71,7 +71,7 @@ export class RouteManager {
         this.router.beforeEach(this.setupTitleAndHeaders)
 
         const currentNetworkDidChange = () => {
-            axios.defaults.baseURL = this.currentNetworkEntry.value.mirrorNodeURL
+            axios.defaults.baseURL = this.currentNetworkEntry.value.url
             this.switchThemes()
         }
         watch(this.currentNetwork, () => {
@@ -132,7 +132,7 @@ export class RouteManager {
     public readonly hgraphURL = computed(() => {
         let result: string | null
         const hgraphKey = this.hgraphKey.value
-        switch (this.currentNetworkEntry.value.mirrorNodeURL) {
+        switch (this.currentNetworkEntry.value.url) {
             case "https://mainnet-public.mirrornode.hedera.com/":
             case "https://mainnet.mirrornode.hedera.com/":
                 result = hgraphKey !== null


### PR DESCRIPTION
**Description**:

Change below rename `NetworkEntry.mirrorNodeURL` field as `url` to be consistent with `networks-config.json`.
This will also ease unit test writing.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
