### PR TITLE
chore: make labels bigger and include navigation icon

### DIFF
--- a/src/components/values/DomainLabel.vue
+++ b/src/components/values/DomainLabel.vue
@@ -7,7 +7,7 @@
 <template>
   <EntityLabel :label="props.domainName" :compact="props.compact">
     <template #icon>
-      <NotebookTabs :size="12" :class="{'low-contrast':props.compact}"/>
+      <NotebookTabs :size="14" :class="{'low-contrast':props.compact}"/>
     </template>
 
     <template #tooltip>

--- a/src/components/values/EntityLabel.vue
+++ b/src/components/values/EntityLabel.vue
@@ -14,17 +14,17 @@
       >
         <slot name="icon"/>
         <span>{{ label }}</span>
+        <SquareArrowOutUpRight
+            v-if="props.url && !compact"
+            :size="14"
+            class="link-icon"
+            @click="navigate(props.url)"
+        />
       </div>
       <template v-if="slots.tooltip" #content>
         <slot name="tooltip"/>
       </template>
     </Tooltip>
-    <SquareArrowOutUpRight
-        v-if="props.url && !compact"
-        :size="14"
-        class="shy-icon"
-        @click="navigate(props.url)"
-    />
   </div>
 </template>
 
@@ -85,17 +85,9 @@ const navigate = (url: string | null) => {
   gap: 4px
 }
 
-.shy-icon {
+.link-icon {
   color: var(--text-secondary);
   cursor: pointer;
-  opacity: 0;
-  transition: opacity 0.3s ease;
-  visibility: hidden;
-}
-
-.hover-container:hover .shy-icon {
-  opacity: 1;
-  visibility: visible;
 }
 
 </style>

--- a/src/components/values/PublicLabel.vue
+++ b/src/components/values/PublicLabel.vue
@@ -7,7 +7,7 @@
 <template>
   <EntityLabel :label="name" :url="website" :compact="props.compact">
     <template #icon>
-      <Tag :size="12" :class="{'low-contrast':props.compact}"/>
+      <Tag :size="14" :class="{'low-contrast':props.compact}"/>
     </template>
 
     <template #tooltip>

--- a/src/styles/explorer.css
+++ b/src/styles/explorer.css
@@ -323,9 +323,8 @@ hr.horizontal-line {
     border: solid 1px var(--border-secondary);
     border-radius: 4px;
     color: var(--text-primary);
-    font-size: 12px;
-    font-weight: 500;
-    line-height: 16px;
+    font-size: 14px;
+    font-weight: 400;
     padding: 3px 6px 3px;
 }
 


### PR DESCRIPTION
**Description**:

- Make EntityLabel slightly bigger
- Include navigation icon (when url field defined) instead of shy icon outside of label

**Before:**
<img width="835" alt="Screenshot 2025-05-22 at 10 37 38" src="https://github.com/user-attachments/assets/33a5eed6-6625-406b-9298-833ac4fa9f0a" />

**After:**
<img width="835" alt="Screenshot 2025-05-22 at 10 37 49" src="https://github.com/user-attachments/assets/20b836d4-0318-4cf8-aa12-15bac42f162d" />
