### PR TITLE
chore: fixing typing of handleClick() methods 

### DIFF
--- a/src/components/account/AccountCreatedContractsTable.vue
+++ b/src/components/account/AccountCreatedContractsTable.vue
@@ -93,7 +93,7 @@ const props = defineProps({
 onMounted(() => props.controller.mount())
 onBeforeUnmount(() => props.controller.unmount())
 
-const handleClick = (t: Transaction, c: unknown, i: number, ci: number, event: MouseEvent) => {
+const handleClick = (t: Transaction, c: unknown, i: number, ci: number, event: Event) => {
   routeManager.routeToContract(t.entity_id!, event)
 }
 

--- a/src/components/account/AccountTable.vue
+++ b/src/components/account/AccountTable.vue
@@ -113,7 +113,7 @@ const props = defineProps({
   }
 })
 
-const handleClick = (a: AccountInfo, c: unknown, i: number, ci: number, event: MouseEvent) => {
+const handleClick = (a: AccountInfo, c: unknown, i: number, ci: number, event: Event) => {
   if (a.account) {
     routeManager.routeToAccount(a.account, event)
   }

--- a/src/components/account/FungibleTable.vue
+++ b/src/components/account/FungibleTable.vue
@@ -115,7 +115,7 @@ watch([props.controller.rows, () => props.checkEnabled], () =>
     checkedRows.value.splice(0)
 )
 
-const handleClick = (balance: TokenBalance, c: unknown, i: number, ci: number, event: MouseEvent) => {
+const handleClick = (balance: TokenBalance, c: unknown, i: number, ci: number, event: Event) => {
   if (balance.token_id) {
     routeManager.routeToToken(balance.token_id, event)
   }

--- a/src/components/account/NftsTable.vue
+++ b/src/components/account/NftsTable.vue
@@ -130,7 +130,7 @@ watch([props.controller.rows, () => props.checkEnabled], () =>
     checkedRows.value.splice(0)
 )
 
-const handleClick = (nft: Nft, c: unknown, i: number, ci: number, event: MouseEvent,) => {
+const handleClick = (nft: Nft, c: unknown, i: number, ci: number, event: Event,) => {
   if (nft.token_id && nft.serial_number) {
     routeManager.routeToSerial(nft.token_id, nft.serial_number, event);
   }

--- a/src/components/account/PendingFungibleAirdropTable.vue
+++ b/src/components/account/PendingFungibleAirdropTable.vue
@@ -126,7 +126,7 @@ const checkedRows = defineModel("checkedAirdrops", {
 
 watch([props.controller.rows, () => props.checkEnabled], () => checkedRows.value.splice(0))
 
-const handleClick = (airdrop: TokenAirdrop, c: unknown, i: number, ci: number, event: MouseEvent) => {
+const handleClick = (airdrop: TokenAirdrop, c: unknown, i: number, ci: number, event: Event) => {
   if (airdrop.token_id) {
     routeManager.routeToToken(airdrop.token_id, event)
   }

--- a/src/components/account/PendingNftAirdropTable.vue
+++ b/src/components/account/PendingNftAirdropTable.vue
@@ -132,7 +132,7 @@ const checkedRows = defineModel("checkedAirdrops", {
 
 watch([props.controller.rows, () => props.checkEnabled], () => checkedRows.value.splice(0))
 
-const handleClick = (airdrop: TokenAirdrop, c: unknown, i: number, ci: number, event: MouseEvent) => {
+const handleClick = (airdrop: TokenAirdrop, c: unknown, i: number, ci: number, event: Event) => {
   if (airdrop.token_id && airdrop.serial_number) {
     routeManager.routeToSerial(airdrop.token_id, airdrop.serial_number, event)
   }

--- a/src/components/account/VerifiedContractsTable.vue
+++ b/src/components/account/VerifiedContractsTable.vue
@@ -93,7 +93,7 @@ const noDataMessage = computed(() =>
 onMounted(() => props.controller.mount())
 onBeforeUnmount(() => props.controller.unmount())
 
-const handleClick = (contract: Contract, c: unknown, i: number, ci: number, event: MouseEvent) => {
+const handleClick = (contract: Contract, c: unknown, i: number, ci: number, event: Event) => {
   routeManager.routeToContract(contract.contract_id!, event)
 }
 

--- a/src/components/block/BlockTable.vue
+++ b/src/components/block/BlockTable.vue
@@ -87,7 +87,7 @@ const props = defineProps({
   }
 })
 
-const handleClick = (block: Block, c: unknown, i: number, ci: number, event: MouseEvent) => {
+const handleClick = (block: Block, c: unknown, i: number, ci: number, event: Event) => {
   if (block.number) {
     routeManager.routeToBlock(block.number, event)
   }

--- a/src/components/block/BlockTransactionTable.vue
+++ b/src/components/block/BlockTransactionTable.vue
@@ -99,7 +99,7 @@ const props = defineProps({
 const DEFAULT_PAGE_SIZE = 15
 const perPage = ref(props.nbItems ?? DEFAULT_PAGE_SIZE)
 
-const handleClick = (t: Transaction, c: unknown, i: number, ci: number, event: MouseEvent) => {
+const handleClick = (t: Transaction, c: unknown, i: number, ci: number, event: Event) => {
   routeManager.routeToTransaction(t, event)
 }
 

--- a/src/components/contract/ContractResultTable.vue
+++ b/src/components/contract/ContractResultTable.vue
@@ -99,7 +99,7 @@ const props = defineProps({
 
 const isLargeScreen = inject('isLargeScreen', true)
 
-const handleClick = (result: ContractResult, c: unknown, i: number, ci: number, event: MouseEvent) => {
+const handleClick = (result: ContractResult, c: unknown, i: number, ci: number, event: Event) => {
   routeManager.routeToTransactionByTs(result.timestamp, event)
 }
 

--- a/src/components/contract/ContractTable.vue
+++ b/src/components/contract/ContractTable.vue
@@ -93,7 +93,7 @@ const props = defineProps({
 onMounted(() => props.controller.mount())
 onBeforeUnmount(() => props.controller.unmount())
 
-const handleClick = (contract: Contract, c: unknown, i: number, ci: number, event: MouseEvent) => {
+const handleClick = (contract: Contract, c: unknown, i: number, ci: number, event: Event) => {
   if (contract.contract_id) {
     routeManager.routeToContract(contract.contract_id, event)
   }

--- a/src/components/contract/ERC20ByNameTable.vue
+++ b/src/components/contract/ERC20ByNameTable.vue
@@ -90,7 +90,7 @@ const loader = new ERC20ByNameTableLoader(perPage, targetName)
 onMounted(() => loader.mount())
 onBeforeUnmount(() => loader.unmount())
 
-const handleClick = (t: ERC20Info, c: unknown, i: number, ci: number, event: MouseEvent) => {
+const handleClick = (t: ERC20Info, c: unknown, i: number, ci: number, event: Event) => {
   if (t.contractId !== null) {
     routeManager.routeToContract(t.contractId, event)
   }

--- a/src/components/contract/ERC721ByNameTable.vue
+++ b/src/components/contract/ERC721ByNameTable.vue
@@ -90,7 +90,7 @@ const loader = new ERC721ByNameTableLoader(perPage, targetName)
 onMounted(() => loader.mount())
 onBeforeUnmount(() => loader.unmount())
 
-const handleClick = (t: ERC20Info, c: unknown, i: number, ci: number, event: MouseEvent) => {
+const handleClick = (t: ERC20Info, c: unknown, i: number, ci: number, event: Event) => {
   if (t.contractId !== null) {
     routeManager.routeToContract(t.contractId, event)
   }

--- a/src/components/node/NodeTable.vue
+++ b/src/components/node/NodeTable.vue
@@ -153,7 +153,7 @@ const makeWeightPercentage = (node: NetworkNode) => {
   return node.stake && props.stakeTotal ? makeStakePercentage(node, props.stakeTotal) : "0"
 }
 
-const handleClick = (node: NetworkNode, c: unknown, i: number, ci: number, event: MouseEvent) => {
+const handleClick = (node: NetworkNode, c: unknown, i: number, ci: number, event: Event) => {
   if (node.node_id !== undefined) {
     routeManager.routeToNode(node.node_id, event)
   }

--- a/src/components/staking/StakingRewardsTable.vue
+++ b/src/components/staking/StakingRewardsTable.vue
@@ -84,7 +84,7 @@ const props = defineProps({
 onMounted(() => props.controller.mount())
 onBeforeUnmount(() => props.controller.unmount())
 
-const handleClick = (t: StakingReward, c: unknown, i: number, ci: number, event: MouseEvent) => {
+const handleClick = (t: StakingReward, c: unknown, i: number, ci: number, event: Event) => {
   if (t.timestamp) {
     routeManager.routeToTransactionByTs(t.timestamp, event)
   }

--- a/src/components/token/NftHolderTable.vue
+++ b/src/components/token/NftHolderTable.vue
@@ -115,7 +115,7 @@ const props = defineProps({
   },
 })
 
-const handleClick = (n: Nft, c: unknown, i: number, ci: number, event: MouseEvent,) => {
+const handleClick = (n: Nft, c: unknown, i: number, ci: number, event: Event,) => {
   if (n.token_id && n.serial_number) {
     routeManager.routeToSerial(n.token_id, n.serial_number, event);
   }

--- a/src/components/token/TokenBalanceTable.vue
+++ b/src/components/token/TokenBalanceTable.vue
@@ -86,7 +86,7 @@ const props = defineProps({
   },
 })
 
-const handleClick = (t: TokenDistribution, c: unknown, i: number, ci: number, event: MouseEvent) => {
+const handleClick = (t: TokenDistribution, c: unknown, i: number, ci: number, event: Event) => {
   if (t.account) {
     routeManager.routeToAccount(t.account, event)
   }

--- a/src/components/token/TokenTable.vue
+++ b/src/components/token/TokenTable.vue
@@ -86,7 +86,7 @@ const props = defineProps({
   }
 })
 
-const handleClick = (t: Token, c: unknown, i: number, ci: number, event: MouseEvent) => {
+const handleClick = (t: Token, c: unknown, i: number, ci: number, event: Event) => {
   if (t.token_id) {
     routeManager.routeToToken(t.token_id, event)
   }

--- a/src/components/token/TokensByNameTable.vue
+++ b/src/components/token/TokensByNameTable.vue
@@ -95,7 +95,7 @@ onBeforeUnmount(() => {
   loader.unmount()
 })
 
-const handleClick = (t: Token, c: unknown, i: number, ci: number, event: MouseEvent) => {
+const handleClick = (t: Token, c: unknown, i: number, ci: number, event: Event) => {
   if (t.token_id !== null) {
     routeManager.routeToToken(t.token_id, event)
   }

--- a/src/components/token/TokensByPopularityTable.vue
+++ b/src/components/token/TokensByPopularityTable.vue
@@ -95,7 +95,7 @@ onBeforeUnmount(() => {
   loader.unmount()
 })
 
-const handleClick = (t: Token, c: unknown, i: number, ci: number, event: MouseEvent) => {
+const handleClick = (t: Token, c: unknown, i: number, ci: number, event: Event) => {
   if (t.token_id !== null) {
     routeManager.routeToToken(t.token_id, event)
   }

--- a/src/components/topic/TopicMessageTable.vue
+++ b/src/components/topic/TopicMessageTable.vue
@@ -96,7 +96,7 @@ const isTouchDevice = inject('isTouchDevice', false)
 
 const formatChunk = (t: TopicMessage) => t.chunk_info ? `${t.chunk_info.number}/${t.chunk_info.total}` : ''
 
-const handleClick = (t: TopicMessage, c: unknown, i: number, ci: number, event: MouseEvent) => {
+const handleClick = (t: TopicMessage, c: unknown, i: number, ci: number, event: Event) => {
   const consensusTimestamp = t.consensus_timestamp
   if (consensusTimestamp) {
     routeManager.routeToTransactionByTs(consensusTimestamp, event)

--- a/src/components/topic/TopicTable.vue
+++ b/src/components/topic/TopicTable.vue
@@ -79,7 +79,7 @@ const props = defineProps({
   }
 })
 
-const handleClick = (t: Transaction, c: unknown, i: number, ci: number, event: MouseEvent) => {
+const handleClick = (t: Transaction, c: unknown, i: number, ci: number, event: Event) => {
   if (t.entity_id) {
     routeManager.routeToTopic(t.entity_id, event)
   }

--- a/src/components/transaction/NftTransactionTable.vue
+++ b/src/components/transaction/NftTransactionTable.vue
@@ -89,7 +89,7 @@ const showingEthereumTransactions = computed(() => {
   )
 })
 
-const handleClick = (t: Transaction, c: unknown, i: number, ci: number, event: MouseEvent,) => {
+const handleClick = (t: Transaction, c: unknown, i: number, ci: number, event: Event,) => {
   routeManager.routeToTransaction(t, event)
 }
 

--- a/src/components/transaction/TransactionBatchTable.vue
+++ b/src/components/transaction/TransactionBatchTable.vue
@@ -96,7 +96,7 @@ const paginationNeeded = computed(() => {
     }
 )
 
-const handleClick = (t: Transaction, c: unknown, i: number, ci: number, event: MouseEvent) => {
+const handleClick = (t: Transaction, c: unknown, i: number, ci: number, event: Event) => {
   routeManager.routeToTransaction(t, event)
 }
 

--- a/src/components/transaction/TransactionByIdTable.vue
+++ b/src/components/transaction/TransactionByIdTable.vue
@@ -93,7 +93,7 @@ const paginationNeeded = computed(() => {
 const showRelationship = computed(() => props.transactions.length >= 2 && makeRelationshipLabel(props.transactions[0]))
 const showNonce = computed(() => props.transactions.length >= 2 && !props.transactions[1].scheduled)
 
-const handleClick = (t: Transaction, c: unknown, i: number, ci: number, event: MouseEvent) => {
+const handleClick = (t: Transaction, c: unknown, i: number, ci: number, event: Event) => {
   routeManager.routeToTransaction(t, event)
 }
 

--- a/src/components/transaction/TransactionTable.vue
+++ b/src/components/transaction/TransactionTable.vue
@@ -110,7 +110,7 @@ const showingEthereumTransactions = computed(() => {
   return props.controller.transactionType.value === TransactionType.ETHEREUMTRANSACTION
 })
 
-const handleClick = (t: Transaction, c: unknown, i: number, ci: number, event: MouseEvent) => {
+const handleClick = (t: Transaction, c: unknown, i: number, ci: number, event: Event) => {
   routeManager.routeToTransaction(t, event)
 }
 

--- a/src/utils/RouteManager.ts
+++ b/src/utils/RouteManager.ts
@@ -199,9 +199,9 @@ export class RouteManager {
     // Transaction
     //
 
-    public routeToTransaction(t: Transaction, event: MouseEvent): Promise<NavigationFailure | void | undefined> {
+    public routeToTransaction(t: Transaction, event: Event): Promise<NavigationFailure | void | undefined> {
         let result: Promise<NavigationFailure | void | undefined>
-        if (event.ctrlKey || event.metaKey || event.button === 1) {
+        if (this.shouldOpenNewWindow(event)) {
             const routeData = this.router.resolve(this.makeRouteToTransaction(t.consensus_timestamp));
             window.open(routeData.href, '_blank');
             result = Promise.resolve()
@@ -211,9 +211,9 @@ export class RouteManager {
         return result
     }
 
-    public routeToTransactionByTs(consensusTimestamp: string | undefined, event: MouseEvent): Promise<NavigationFailure | void | undefined> {
+    public routeToTransactionByTs(consensusTimestamp: string | undefined, event: Event): Promise<NavigationFailure | void | undefined> {
         let result: Promise<NavigationFailure | void | undefined>
-        if (event.ctrlKey || event.metaKey || event.button === 1) {
+        if (this.shouldOpenNewWindow(event)) {
             const routeData = this.router.resolve(this.makeRouteToTransaction(consensusTimestamp));
             window.open(routeData.href, '_blank');
             result = Promise.resolve()
@@ -264,9 +264,9 @@ export class RouteManager {
         }
     }
 
-    public routeToAccount(accountId: string, event: MouseEvent): Promise<NavigationFailure | void | undefined> {
+    public routeToAccount(accountId: string, event: Event): Promise<NavigationFailure | void | undefined> {
         let result: Promise<NavigationFailure | void | undefined>
-        if (event.ctrlKey || event.metaKey || event.button === 1) {
+        if (this.shouldOpenNewWindow(event)) {
             const routeData = this.router.resolve(this.makeRouteToAccount(accountId));
             window.open(routeData.href, '_blank');
             result = Promise.resolve()
@@ -310,9 +310,9 @@ export class RouteManager {
         return {name: 'TokenDetails', params: {tokenId: tokenId, network: this.currentNetwork.value}}
     }
 
-    public routeToToken(tokenId: string, event: MouseEvent): Promise<NavigationFailure | void | undefined> {
+    public routeToToken(tokenId: string, event: Event): Promise<NavigationFailure | void | undefined> {
         let result: Promise<NavigationFailure | void | undefined>
-        if (event.ctrlKey || event.metaKey || event.button === 1) {
+        if (this.shouldOpenNewWindow(event)) {
             const routeData = this.router.resolve(this.makeRouteToToken(tokenId));
             window.open(routeData.href, '_blank');
             result = Promise.resolve()
@@ -336,9 +336,9 @@ export class RouteManager {
         }
     }
 
-    public routeToSerial(tokenId: string, serialNumber: number, event: MouseEvent): Promise<NavigationFailure | void | undefined> {
+    public routeToSerial(tokenId: string, serialNumber: number, event: Event): Promise<NavigationFailure | void | undefined> {
         let result: Promise<NavigationFailure | void | undefined>
-        if (event.ctrlKey || event.metaKey || event.button === 1) {
+        if (this.shouldOpenNewWindow(event)) {
             const routeData = this.router.resolve(this.makeRouteToSerial(tokenId, serialNumber))
             window.open(routeData.href, '_blank')
             result = Promise.resolve()
@@ -377,9 +377,9 @@ export class RouteManager {
         return {name: 'ContractDetails', params: {contractId: contractId, network: this.currentNetwork.value}}
     }
 
-    public routeToContract(contractId: string, event: MouseEvent): Promise<NavigationFailure | void | undefined> {
+    public routeToContract(contractId: string, event: Event): Promise<NavigationFailure | void | undefined> {
         let result: Promise<NavigationFailure | void | undefined>
-        if (event.ctrlKey || event.metaKey || event.button === 1) {
+        if (this.shouldOpenNewWindow(event)) {
             const routeData = this.router.resolve(this.makeRouteToContract(contractId));
             window.open(routeData.href, '_blank');
             result = Promise.resolve()
@@ -411,9 +411,9 @@ export class RouteManager {
         return {name: 'TopicDetails', params: {topicId: topicId, network: this.currentNetwork.value}}
     }
 
-    public routeToTopic(topicId: string, event: MouseEvent): Promise<NavigationFailure | void | undefined> {
+    public routeToTopic(topicId: string, event: Event): Promise<NavigationFailure | void | undefined> {
         let result: Promise<NavigationFailure | void | undefined>
-        if (event.ctrlKey || event.metaKey || event.button === 1) {
+        if (this.shouldOpenNewWindow(event)) {
             const routeData = this.router.resolve(this.makeRouteToTopic(topicId));
             window.open(routeData.href, '_blank');
             result = Promise.resolve()
@@ -431,9 +431,9 @@ export class RouteManager {
         return {name: 'BlockDetails', params: {blockHon: blockHon, network: this.currentNetwork.value}}
     }
 
-    public routeToBlock(blockHon: string | number, event: MouseEvent | null = null): Promise<NavigationFailure | void | undefined> {
+    public routeToBlock(blockHon: string | number, event: Event | null = null): Promise<NavigationFailure | void | undefined> {
         let result: Promise<NavigationFailure | void | undefined>
-        if (event && (event.ctrlKey || event.metaKey || event.button === 1)) {
+        if (this.shouldOpenNewWindow(event)) {
             const routeData = this.router.resolve(this.makeRouteToBlock(blockHon));
             window.open(routeData.href, '_blank');
             result = Promise.resolve()
@@ -451,9 +451,9 @@ export class RouteManager {
         return {name: 'NodeDetails', params: {nodeId: nodeId, network: this.currentNetwork.value}}
     }
 
-    public routeToNode(nodeId: number, event: MouseEvent): Promise<NavigationFailure | void | undefined> {
+    public routeToNode(nodeId: number, event: Event): Promise<NavigationFailure | void | undefined> {
         let result: Promise<NavigationFailure | void | undefined>
-        if (event.ctrlKey || event.metaKey || event.button === 1) {
+        if (this.shouldOpenNewWindow(event)) {
             const routeData = this.router.resolve(this.makeRouteToNode(nodeId));
             window.open(routeData.href, '_blank');
             result = Promise.resolve()
@@ -538,6 +538,10 @@ export class RouteManager {
     //
     // Private
     //
+
+    private shouldOpenNewWindow(e: Event|null): boolean {
+        return e instanceof MouseEvent && (e.ctrlKey || e.metaKey || e.button === 1)
+    }
 
     private readonly checkNetwork = (to: RouteLocationNormalized): boolean | string => {
         let result: boolean | string


### PR DESCRIPTION
**Description**:

Change below fix type declarations of `@cell-click` callbacks passed to `o-table` views.
These callbacks should expect an `Event` (not a `MouseEvent`).

This is preparatory work before re-enabling type checking in `oruga-ui` component (currently broken).

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
