### PR TITLE
chore: re-enabling type checking for oruga-ui components

### DIFF
--- a/src/components/InfoTooltip.vue
+++ b/src/components/InfoTooltip.vue
@@ -37,7 +37,7 @@ const props = defineProps({
     default: null
   },
   position: {
-    type: String as PropType<string | null>,
+    type: String as PropType<"auto" | "left" | "right" | "bottom" | "top" | "bottom-left" | "top-right" | "top-left" | "bottom-right">,
     default: 'auto'
   },
 })

--- a/src/components/Tooltip.vue
+++ b/src/components/Tooltip.vue
@@ -8,9 +8,9 @@
 
   <o-tooltip
       v-if="props.text || slots.content"
-      :label="props.text"
-      :position="position ?? 'auto'"
-      :delay="props.delay"
+      :label="props.text ?? undefined"
+      :position="props.position"
+      :delay="props.delay ?? undefined"
       multiline
   >
     <slot/>
@@ -30,6 +30,7 @@
 <script setup lang="ts">
 
 import {PropType, useSlots} from 'vue';
+import {OTooltip} from "@oruga-ui/oruga-next";
 
 const props = defineProps({
   text: {
@@ -37,7 +38,7 @@ const props = defineProps({
     default: null
   },
   position: {
-    type: String as PropType<string | null>,
+    type: String as PropType<"auto" | "left" | "right" | "bottom" | "top" | "bottom-left" | "top-right" | "top-left" | "bottom-right">,
     default: 'auto'
   },
   delay: {

--- a/src/components/account/AccountCreatedContractsTable.vue
+++ b/src/components/account/AccountCreatedContractsTable.vue
@@ -73,6 +73,7 @@
 <script setup lang="ts">
 
 import {onBeforeUnmount, onMounted, PropType} from 'vue';
+import {OTable, OTableColumn} from "@oruga-ui/oruga-next";
 import {Transaction} from "@/schemas/MirrorNodeSchemas";
 import TimestampValue from "@/components/values/TimestampValue.vue";
 import {routeManager} from "@/router";

--- a/src/components/account/AccountTable.vue
+++ b/src/components/account/AccountTable.vue
@@ -89,6 +89,7 @@
 <script setup lang="ts">
 
 import {PropType} from 'vue';
+import {OTable, OTableColumn} from "@oruga-ui/oruga-next";
 import {AccountInfo} from "@/schemas/MirrorNodeSchemas";
 import {routeManager} from "@/router";
 import HbarAmount from "@/components/values/HbarAmount.vue";

--- a/src/components/account/FungibleTable.vue
+++ b/src/components/account/FungibleTable.vue
@@ -82,6 +82,7 @@
 <script setup lang="ts">
 
 import {PropType, watch} from 'vue';
+import {OTable, OTableColumn} from "@oruga-ui/oruga-next";
 import {Nft, Token, TokenBalance} from "@/schemas/MirrorNodeSchemas";
 import {ORUGA_MOBILE_BREAKPOINT} from "@/BreakPoints";
 import EmptyTable from "@/components/EmptyTable.vue";

--- a/src/components/account/NftsTable.vue
+++ b/src/components/account/NftsTable.vue
@@ -95,6 +95,7 @@
 <script setup lang="ts">
 
 import {PropType, watch} from 'vue';
+import {OTable, OTableColumn} from "@oruga-ui/oruga-next";
 import {Nft, Token} from "@/schemas/MirrorNodeSchemas";
 import EmptyTable from "@/components/EmptyTable.vue";
 import {routeManager} from "@/router";
@@ -130,8 +131,8 @@ watch([props.controller.rows, () => props.checkEnabled], () =>
     checkedRows.value.splice(0)
 )
 
-const handleClick = (nft: Nft, c: unknown, i: number, ci: number, event: Event,) => {
-  if (nft.token_id && nft.serial_number) {
+const handleClick = (nft: Token | Nft, c: unknown, i: number, ci: number, event: Event,) => {
+  if (nft.token_id && "serial_number" in nft) {
     routeManager.routeToSerial(nft.token_id, nft.serial_number, event);
   }
 };

--- a/src/components/account/PendingFungibleAirdropTable.vue
+++ b/src/components/account/PendingFungibleAirdropTable.vue
@@ -92,6 +92,7 @@
 <script setup lang="ts">
 
 import {PropType, watch} from 'vue';
+import {OTable, OTableColumn} from "@oruga-ui/oruga-next";
 import {TokenAirdrop} from "@/schemas/MirrorNodeSchemas";
 import {ORUGA_MOBILE_BREAKPOINT} from "@/BreakPoints";
 import EmptyTable from "@/components/EmptyTable.vue";

--- a/src/components/account/PendingNftAirdropTable.vue
+++ b/src/components/account/PendingNftAirdropTable.vue
@@ -98,6 +98,7 @@
 <script setup lang="ts">
 
 import {PropType, watch} from 'vue';
+import {OTable, OTableColumn} from "@oruga-ui/oruga-next";
 import {TokenAirdrop} from "@/schemas/MirrorNodeSchemas";
 import {ORUGA_MOBILE_BREAKPOINT} from "@/BreakPoints";
 import EmptyTable from "@/components/EmptyTable.vue";

--- a/src/components/account/VerifiedContractsTable.vue
+++ b/src/components/account/VerifiedContractsTable.vue
@@ -65,6 +65,7 @@
 <script setup lang="ts">
 
 import {computed, onBeforeUnmount, onMounted, PropType} from 'vue';
+import {OTable, OTableColumn} from "@oruga-ui/oruga-next";
 import {Contract} from "@/schemas/MirrorNodeSchemas";
 import TimestampValue from "@/components/values/TimestampValue.vue";
 import {routeManager} from "@/router";

--- a/src/components/allowances/HbarAllowanceTable.vue
+++ b/src/components/allowances/HbarAllowanceTable.vue
@@ -71,6 +71,7 @@
 <script setup lang="ts">
 
 import {computed, PropType} from 'vue';
+import {OTable, OTableColumn} from "@oruga-ui/oruga-next";
 import {ORUGA_MOBILE_BREAKPOINT} from "@/BreakPoints";
 import {HbarAllowanceTableController} from "@/components/allowances/HbarAllowanceTableController";
 import TimestampValue from "@/components/values/TimestampValue.vue";

--- a/src/components/allowances/NftAllSerialsAllowanceTable.vue
+++ b/src/components/allowances/NftAllSerialsAllowanceTable.vue
@@ -76,6 +76,7 @@
 <script setup lang="ts">
 
 import {computed, PropType, ref, watch} from 'vue';
+import {OTable, OTableColumn} from "@oruga-ui/oruga-next";
 import {NftAllowance} from "@/schemas/MirrorNodeSchemas";
 import {ORUGA_MOBILE_BREAKPOINT} from "@/BreakPoints";
 import TimestampValue from "@/components/values/TimestampValue.vue";

--- a/src/components/allowances/NftAllowanceTable.vue
+++ b/src/components/allowances/NftAllowanceTable.vue
@@ -78,6 +78,7 @@
 <script setup lang="ts">
 
 import {computed, PropType} from 'vue';
+import {OTable, OTableColumn} from "@oruga-ui/oruga-next";
 import {ORUGA_MOBILE_BREAKPOINT} from "@/BreakPoints";
 import TimestampValue from "@/components/values/TimestampValue.vue";
 import EmptyTable from "@/components/EmptyTable.vue";

--- a/src/components/allowances/TokenAllowanceTable.vue
+++ b/src/components/allowances/TokenAllowanceTable.vue
@@ -80,6 +80,7 @@
 <script setup lang="ts">
 
 import {computed, PropType, ref, watch} from 'vue';
+import {OTable, OTableColumn} from "@oruga-ui/oruga-next";
 import {TokenAllowance} from "@/schemas/MirrorNodeSchemas";
 import {isValidAssociation} from "@/schemas/MirrorNodeUtils.ts";
 import {ORUGA_MOBILE_BREAKPOINT} from "@/BreakPoints";

--- a/src/components/block/BlockTable.vue
+++ b/src/components/block/BlockTable.vue
@@ -66,6 +66,7 @@
 <script setup lang="ts">
 
 import {PropType} from 'vue';
+import {OTable, OTableColumn} from "@oruga-ui/oruga-next";
 import {Block} from '@/schemas/MirrorNodeSchemas.ts';
 import {routeManager} from "@/router";
 import TimestampValue from "@/components/values/TimestampValue.vue";

--- a/src/components/block/BlockTransactionTable.vue
+++ b/src/components/block/BlockTransactionTable.vue
@@ -75,6 +75,7 @@
 <script setup lang="ts">
 
 import {computed, PropType, ref} from 'vue';
+import {OTable, OTableColumn} from "@oruga-ui/oruga-next";
 import {Transaction} from '@/schemas/MirrorNodeSchemas.ts';
 import {makeTypeLabel} from "@/utils/TransactionTools";
 import {routeManager} from "@/router";

--- a/src/components/contract/ContractActionsTable.vue
+++ b/src/components/contract/ContractActionsTable.vue
@@ -94,6 +94,7 @@
 <script setup lang="ts">
 
 import {computed, inject, PropType} from 'vue';
+import {OTable, OTableColumn} from "@oruga-ui/oruga-next";
 import {ContractAction} from "@/schemas/MirrorNodeSchemas";
 import {ORUGA_MOBILE_BREAKPOINT} from "@/BreakPoints";
 import EmptyTable from "@/components/EmptyTable.vue";

--- a/src/components/contract/ContractResultLogs.vue
+++ b/src/components/contract/ContractResultLogs.vue
@@ -58,6 +58,7 @@
 <script setup lang="ts">
 
 import {computed, onMounted, PropType, Ref, ref, watch} from "vue";
+import {OPagination} from "@oruga-ui/oruga-next";
 import ContractResultLogEntry from "@/components/contract/ContractResultLogEntry.vue";
 import {ContractLog} from "@/schemas/MirrorNodeSchemas";
 import {AppStorage} from "@/AppStorage";

--- a/src/components/contract/ContractResultStates.vue
+++ b/src/components/contract/ContractResultStates.vue
@@ -79,6 +79,7 @@
 <script lang="ts">
 
 import {computed, defineComponent, inject, onBeforeUnmount, onMounted, PropType, ref, Ref, watch} from 'vue';
+import {OPagination} from '@oruga-ui/oruga-next';
 import {ContractResultStateChange} from "@/schemas/MirrorNodeSchemas";
 import {ORUGA_MOBILE_BREAKPOINT} from "@/BreakPoints";
 import {TransactionByTsCache} from "@/utils/cache/TransactionByTsCache";
@@ -113,6 +114,7 @@ export default defineComponent({
     DashboardCardV2,
     SelectView,
     ContractResultStateChangeEntry,
+    OPagination
   },
 
   props: {

--- a/src/components/contract/ContractResultTable.vue
+++ b/src/components/contract/ContractResultTable.vue
@@ -76,6 +76,7 @@
 <script setup lang="ts">
 
 import {inject, PropType} from 'vue';
+import {OTable, OTableColumn} from "@oruga-ui/oruga-next";
 import {ContractResult} from "@/schemas/MirrorNodeSchemas";
 import {ORUGA_MOBILE_BREAKPOINT} from "@/BreakPoints";
 import {ContractResultTableController} from "@/components/contract/ContractResultTableController";

--- a/src/components/contract/ContractTable.vue
+++ b/src/components/contract/ContractTable.vue
@@ -67,6 +67,7 @@
 <script setup lang="ts">
 
 import {onBeforeUnmount, onMounted, PropType} from 'vue';
+import {OTable, OTableColumn} from "@oruga-ui/oruga-next";
 import {Contract} from "@/schemas/MirrorNodeSchemas";
 import {routeManager} from "@/router";
 import BlobValue from "@/components/values/BlobValue.vue";

--- a/src/components/contract/ERC20ByNameTable.vue
+++ b/src/components/contract/ERC20ByNameTable.vue
@@ -65,13 +65,14 @@
 <script setup lang="ts">
 
 import {computed, inject, onBeforeUnmount, onMounted, PropType, ref} from 'vue';
+import {OTable, OTableColumn} from "@oruga-ui/oruga-next";
 import {routeManager} from "@/router";
 import {ORUGA_MOBILE_BREAKPOINT} from "@/BreakPoints";
 import EmptyTable from "@/components/EmptyTable.vue";
 import TablePageSize from "@/components/transaction/TablePageSize.vue";
 import {AppStorage} from "@/AppStorage";
 import {ERC20ByNameTableLoader} from "@/components/contract/ERC20ByNameTableLoader.ts";
-import {ERC20Info} from "@/utils/cache/ERC20InfoCache.ts";
+import {ERC20Contract} from "@/utils/cache/ERC20Cache.ts";
 import ContractIOL from "@/components/values/link/ContractIOL.vue";
 
 const props = defineProps({
@@ -90,7 +91,7 @@ const loader = new ERC20ByNameTableLoader(perPage, targetName)
 onMounted(() => loader.mount())
 onBeforeUnmount(() => loader.unmount())
 
-const handleClick = (t: ERC20Info, c: unknown, i: number, ci: number, event: Event) => {
+const handleClick = (t: ERC20Contract, c: unknown, i: number, ci: number, event: Event) => {
   if (t.contractId !== null) {
     routeManager.routeToContract(t.contractId, event)
   }

--- a/src/components/contract/ERC721ByNameTable.vue
+++ b/src/components/contract/ERC721ByNameTable.vue
@@ -65,12 +65,13 @@
 <script setup lang="ts">
 
 import {computed, inject, onBeforeUnmount, onMounted, PropType, ref} from 'vue';
+import {OTable, OTableColumn} from "@oruga-ui/oruga-next";
 import {routeManager} from "@/router";
 import {ORUGA_MOBILE_BREAKPOINT} from "@/BreakPoints";
 import EmptyTable from "@/components/EmptyTable.vue";
 import TablePageSize from "@/components/transaction/TablePageSize.vue";
 import {AppStorage} from "@/AppStorage";
-import {ERC20Info} from "@/utils/cache/ERC20InfoCache.ts";
+import {ERC721Contract} from "@/utils/cache/ERC721Cache.ts";
 import ContractIOL from "@/components/values/link/ContractIOL.vue";
 import {ERC721ByNameTableLoader} from "@/components/contract/ERC721ByNameTableLoader.ts";
 
@@ -90,7 +91,7 @@ const loader = new ERC721ByNameTableLoader(perPage, targetName)
 onMounted(() => loader.mount())
 onBeforeUnmount(() => loader.unmount())
 
-const handleClick = (t: ERC20Info, c: unknown, i: number, ci: number, event: Event) => {
+const handleClick = (t: ERC721Contract, c: unknown, i: number, ci: number, event: Event) => {
   if (t.contractId !== null) {
     routeManager.routeToContract(t.contractId, event)
   }

--- a/src/components/node/NodeTable.vue
+++ b/src/components/node/NodeTable.vue
@@ -114,6 +114,7 @@
 <script setup lang="ts">
 
 import {onBeforeUnmount, onMounted, PropType} from 'vue';
+import {OTable, OTableColumn} from "@oruga-ui/oruga-next";
 import {NetworkNode} from "@/schemas/MirrorNodeSchemas";
 import {ORUGA_MOBILE_BREAKPOINT} from "@/BreakPoints";
 import EmptyTable from "@/components/EmptyTable.vue";

--- a/src/components/staking/StakingRewardsTable.vue
+++ b/src/components/staking/StakingRewardsTable.vue
@@ -64,6 +64,7 @@
 <script setup lang="ts">
 
 import {onBeforeUnmount, onMounted, PropType} from 'vue';
+import {OTable, OTableColumn} from "@oruga-ui/oruga-next";
 import {StakingReward} from '@/schemas/MirrorNodeSchemas.ts';
 import {routeManager} from "@/router";
 import TimestampValue from "@/components/values/TimestampValue.vue";

--- a/src/components/token/FixedFeeTable.vue
+++ b/src/components/token/FixedFeeTable.vue
@@ -40,6 +40,7 @@
 <script setup lang="ts">
 
 import {computed, PropType} from 'vue';
+import {OTable, OTableColumn} from "@oruga-ui/oruga-next";
 import AccountLink from "@/components/values/link/AccountLink.vue";
 import TokenLink from "@/components/values/link/TokenLink.vue";
 import {ORUGA_MOBILE_BREAKPOINT} from "@/BreakPoints";

--- a/src/components/token/FractionalFeeTable.vue
+++ b/src/components/token/FractionalFeeTable.vue
@@ -49,6 +49,7 @@
 <script setup lang="ts">
 
 import {PropType} from 'vue';
+import {OTable, OTableColumn} from "@oruga-ui/oruga-next";
 import AccountLink from "@/components/values/link/AccountLink.vue";
 import PlainAmount from "@/components/values/PlainAmount.vue";
 import TokenLink from "@/components/values/link/TokenLink.vue";

--- a/src/components/token/NftHolderTable.vue
+++ b/src/components/token/NftHolderTable.vue
@@ -98,6 +98,7 @@
 <script setup lang="ts">
 
 import {PropType} from 'vue';
+import {OTable, OTableColumn} from "@oruga-ui/oruga-next";
 import {Nft} from "@/schemas/MirrorNodeSchemas";
 import {ORUGA_MOBILE_BREAKPOINT} from "@/BreakPoints";
 import EmptyTable from "@/components/EmptyTable.vue";

--- a/src/components/token/RoyaltyFeeTable.vue
+++ b/src/components/token/RoyaltyFeeTable.vue
@@ -45,6 +45,7 @@
 <script setup lang="ts">
 
 import {PropType} from 'vue';
+import {OTable, OTableColumn} from "@oruga-ui/oruga-next";
 import AccountLink from "@/components/values/link/AccountLink.vue";
 import PlainAmount from "@/components/values/PlainAmount.vue";
 import {ORUGA_MOBILE_BREAKPOINT} from "@/BreakPoints";

--- a/src/components/token/TokenBalanceTable.vue
+++ b/src/components/token/TokenBalanceTable.vue
@@ -69,6 +69,7 @@
 <script setup lang="ts">
 
 import {PropType} from 'vue';
+import {OTable, OTableColumn} from "@oruga-ui/oruga-next";
 import {TokenDistribution} from "@/schemas/MirrorNodeSchemas";
 import {routeManager} from "@/router";
 import TokenAmount from "@/components/values/TokenAmount.vue";

--- a/src/components/token/TokenInfoAnalyzer.ts
+++ b/src/components/token/TokenInfoAnalyzer.ts
@@ -70,10 +70,10 @@ export class TokenInfoAnalyzer {
         () => this.hasFixedFees ? this.tokenInfo.value?.custom_fees?.fixed_fees : null)
 
     public readonly fractionalFees = computed(
-        () => this.hasFractionalFees ? this.tokenInfo.value?.custom_fees?.fractional_fees : null)
+        () => this.tokenInfo.value?.custom_fees?.fractional_fees ?? [])
 
     public readonly royaltyFees = computed(
-        () => this.hasRoyaltyFees ? this.tokenInfo.value?.custom_fees?.royalty_fees : null)
+        () => this.tokenInfo.value?.custom_fees?.royalty_fees ?? [])
 
     public readonly customFees = computed(() => this.tokenInfo.value?.custom_fees)
 

--- a/src/components/token/TokenTable.vue
+++ b/src/components/token/TokenTable.vue
@@ -66,6 +66,7 @@
 <script setup lang="ts">
 
 import {PropType} from 'vue';
+import {OTable, OTableColumn} from "@oruga-ui/oruga-next";
 import {routeManager} from "@/router";
 import {Token} from "@/schemas/MirrorNodeSchemas";
 import {ORUGA_MOBILE_BREAKPOINT} from "@/BreakPoints";

--- a/src/components/token/TokensByNameTable.vue
+++ b/src/components/token/TokensByNameTable.vue
@@ -65,6 +65,7 @@
 <script setup lang="ts">
 
 import {computed, inject, onBeforeUnmount, onMounted, PropType, ref} from 'vue';
+import {OTable, OTableColumn} from "@oruga-ui/oruga-next";
 import {Token} from '@/schemas/MirrorNodeSchemas.ts';
 import {routeManager} from "@/router";
 import {ORUGA_MOBILE_BREAKPOINT} from "@/BreakPoints";

--- a/src/components/token/TokensByPopularityTable.vue
+++ b/src/components/token/TokensByPopularityTable.vue
@@ -65,6 +65,7 @@
 <script setup lang="ts">
 
 import {computed, inject, onBeforeUnmount, onMounted, PropType, ref} from 'vue';
+import {OTable, OTableColumn} from "@oruga-ui/oruga-next";
 import {Token} from '@/schemas/MirrorNodeSchemas.ts';
 import {routeManager} from "@/router";
 import {ORUGA_MOBILE_BREAKPOINT} from "@/BreakPoints";

--- a/src/components/topic/TopicMessageTable.vue
+++ b/src/components/topic/TopicMessageTable.vue
@@ -75,6 +75,7 @@
 <script setup lang="ts">
 
 import {inject, PropType} from 'vue';
+import {OTable, OTableColumn} from "@oruga-ui/oruga-next";
 import {TopicMessageTableController} from "@/components/topic/TopicMessageTableController";
 import TimestampValue from "@/components/values/TimestampValue.vue";
 import BlobValue from "@/components/values/BlobValue.vue";

--- a/src/components/topic/TopicTable.vue
+++ b/src/components/topic/TopicTable.vue
@@ -61,6 +61,7 @@
 <script setup lang="ts">
 
 import {PropType} from 'vue';
+import {OTable, OTableColumn} from "@oruga-ui/oruga-next";
 import {Transaction} from "@/schemas/MirrorNodeSchemas";
 import TimestampValue from "@/components/values/TimestampValue.vue";
 import {routeManager} from "@/router";

--- a/src/components/transaction/NftTransactionTable.vue
+++ b/src/components/transaction/NftTransactionTable.vue
@@ -62,8 +62,9 @@
 <!-- --------------------------------------------------------------------------------------------------------------- -->
 
 <script setup lang="ts">
+import {OTable, OTableColumn} from "@oruga-ui/oruga-next";
 import {computed, PropType,} from "vue"
-import {Transaction, TransactionType,} from "@/schemas/MirrorNodeSchemas"
+import {NftTransactionTransfer, Transaction, TransactionType,} from "@/schemas/MirrorNodeSchemas"
 import NftTransactionSummary from "@/components/transaction/NftTransactionSummary.vue"
 import TimestampValue from "@/components/values/TimestampValue.vue"
 import TransactionLabel from "@/components/values/TransactionLabel.vue"
@@ -89,8 +90,8 @@ const showingEthereumTransactions = computed(() => {
   )
 })
 
-const handleClick = (t: Transaction, c: unknown, i: number, ci: number, event: Event,) => {
-  routeManager.routeToTransaction(t, event)
+const handleClick = (t: NftTransactionTransfer, c: unknown, i: number, ci: number, event: Event,) => {
+  routeManager.routeToTransactionByTs(t.consensus_timestamp, event)
 }
 
 const transactions = computed(() => {

--- a/src/components/transaction/TransactionBatchTable.vue
+++ b/src/components/transaction/TransactionBatchTable.vue
@@ -67,6 +67,7 @@
 <script setup lang="ts">
 
 import {computed, inject, PropType, ref} from 'vue';
+import {OTable, OTableColumn} from "@oruga-ui/oruga-next";
 import {Transaction} from '@/schemas/MirrorNodeSchemas.ts';
 import {makeTypeLabel} from "@/utils/TransactionTools";
 import {routeManager} from "@/router";

--- a/src/components/transaction/TransactionByIdTable.vue
+++ b/src/components/transaction/TransactionByIdTable.vue
@@ -63,6 +63,7 @@
 <script setup lang="ts">
 
 import {computed, inject, PropType, ref} from 'vue';
+import {OTable, OTableColumn} from "@oruga-ui/oruga-next";
 import {Transaction, TransactionType} from '@/schemas/MirrorNodeSchemas.ts';
 import {makeTypeLabel} from "@/utils/TransactionTools";
 import {routeManager} from "@/router";

--- a/src/components/transaction/TransactionTable.vue
+++ b/src/components/transaction/TransactionTable.vue
@@ -83,6 +83,7 @@
 <script setup lang="ts">
 
 import {computed, onBeforeUnmount, onMounted, PropType} from "vue";
+import {OTable, OTableColumn} from "@oruga-ui/oruga-next";
 import {Transaction, TransactionType} from "@/schemas/MirrorNodeSchemas";
 import TransactionSummary from "@/components/transaction/TransactionSummary.vue";
 import TimestampValue from "@/components/values/TimestampValue.vue";

--- a/src/dialogs/verification/FileList.vue
+++ b/src/dialogs/verification/FileList.vue
@@ -86,6 +86,7 @@
 <script setup lang="ts">
 
 import {computed, PropType, ref} from "vue";
+import {OTable, OTableColumn} from "@oruga-ui/oruga-next";
 import {ContractSourceAnalyzerItem} from "@/utils/analyzer/ContractSourceAnalyzer.ts";
 import {FileJson} from 'lucide-vue-next';
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,7 +4,7 @@ import {createApp} from 'vue'
 import Root from './Root.vue'
 import router, {routeManager} from './router'
 import axios from 'axios'
-import Oruga from '@oruga-ui/oruga-next'
+import {OrugaConfig} from '@oruga-ui/oruga-next'
 import {FontAwesomeIcon} from "@fortawesome/vue-fontawesome";
 import {library} from "@fortawesome/fontawesome-svg-core";
 import {faForward} from "@fortawesome/free-solid-svg-icons";
@@ -61,7 +61,7 @@ const createAndMount = async () => {
     const app = createApp(Root, {coreConfig, networkConfig})
     app.component("font-awesome-icon", FontAwesomeIcon)
     app.use(router)
-    app.use(Oruga, {iconPack: 'fas'})
+    app.use(OrugaConfig, {iconPack: 'fas'})
     app.mount('#app')
 }
 


### PR DESCRIPTION
**Description**:

Changes below update `oruga-ui` setup in `vuejs` to fix warnings related `o-xxx` components:
- `oruga` is no longer registered globally in `main.ts`
- explicit `imports` are specified in each view that uses `oruga` components

=> this fixes warnings reported everywhere `oruga` components where used
=> this re-enables some level of type checking in matching *`.vue` files
=> some additional changes are required to satisfy re-enabled type checks.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
