### PR TITLE
chore: homogenise action buttons

### DIFF
--- a/src/components/allowances/AllowancesSection.vue
+++ b/src/components/allowances/AllowancesSection.vue
@@ -16,7 +16,6 @@
       <ButtonView
           v-if="isWalletConnected && isHieroWallet"
           id="approve-button"
-          :is-default="true"
           :size="ButtonSize.small"
           @action="onClick"
       >

--- a/src/components/contract/ContractByteCodeSection.vue
+++ b/src/components/contract/ContractByteCodeSection.vue
@@ -21,7 +21,6 @@
     <template #right-control>
       <ButtonView
           v-if="isVerificationAvailable && !isVerified"
-          :is-default="true"
           :size="ButtonSize.small"
           @action="showVerifyDialog = true"
       >
@@ -39,7 +38,6 @@
             <ButtonView
                 v-if="!isFullMatch"
                 id="verify-button"
-                :is-default="true"
                 :size="ButtonSize.small"
                 @action="showVerifyDialog = true"
             >

--- a/src/components/contract/ContractResultTrace.vue
+++ b/src/components/contract/ContractResultTrace.vue
@@ -16,7 +16,6 @@
           v-if="collapseAllVisible"
           id="collapseAllButton"
           :enabled="!collapseAllDisabled"
-          :is-default="true"
           :size="ButtonSize.small"
           @action="collapseAll"
       >
@@ -25,7 +24,6 @@
       <ButtonView
           v-else
           id="expandAllButton"
-          :is-default="true"
           :size="ButtonSize.small"
           @action="expandAll"
       >

--- a/src/components/token/TokensSection.vue
+++ b/src/components/token/TokensSection.vue
@@ -26,7 +26,6 @@
         <ButtonView
             id="reject-button"
             :enabled="rejectButtonEnabled"
-            :is-default="true"
             :size="ButtonSize.small"
             @action="onReject"
         >
@@ -40,7 +39,6 @@
         <ButtonView
             id="claim-button"
             :enabled="claimActionEnabled"
-            :is-default="true"
             :size="ButtonSize.small"
             @action="onClaim"
         >

--- a/src/pages/Staking.vue
+++ b/src/pages/Staking.vue
@@ -28,7 +28,6 @@
         <template v-if="accountId">
           <span> for account </span>
           <AccountLink :account-id="accountId"/>
-          <span class="checksum">-{{ accountChecksum }}</span>
         </template>
       </template>
 
@@ -241,10 +240,6 @@ p.staking-notice {
   font-size: 10px;
   font-weight: 400;
   height: 13px;
-}
-
-span.checksum {
-  color: var(--text-secondary);
 }
 
 p.connect-wallet-text {


### PR DESCRIPTION
**Description**:

Action buttons (in details pages) are no longer using network color (like default button in dialog).
The only remaining exception is on the Staking page.

Unrelated: remove display of checksum in title of MyStaking section (a label may be displayed in place of the ID here). Furthermore the checksum is useful here since this is by definition the account of the user (account from the connected wallet), so there is no ambiguity.