### PR TITLE
chore: enabling checkUnknownProps in vueCompilerOptions

### DIFF
--- a/src/components/account/AccountCreatedContractsTable.vue
+++ b/src/components/account/AccountCreatedContractsTable.vue
@@ -19,11 +19,6 @@
       :striped="true"
 
       :total="total"
-      aria-current-label="Current page"
-      aria-next-label="Next page"
-      aria-page-label="Page"
-
-      aria-previous-label="Previous page"
       backend-pagination
       customRowKey="consensus_timestamp"
       default-sort="consensus_timestamp"

--- a/src/components/account/AccountCreatedContractsTable.vue
+++ b/src/components/account/AccountCreatedContractsTable.vue
@@ -15,8 +15,6 @@
       :narrowed="true"
       :paginated="paginated"
       pagination-order="centered"
-      :range-before="1"
-      :range-after="1"
       :per-page="perPage"
       :striped="true"
 

--- a/src/components/account/AccountCreatedContractsTable.vue
+++ b/src/components/account/AccountCreatedContractsTable.vue
@@ -20,7 +20,7 @@
 
       :total="total"
       backend-pagination
-      customRowKey="consensus_timestamp"
+      row-key="consensus_timestamp"
       default-sort="consensus_timestamp"
       @page-change="onPageChange"
       @cell-click="handleClick"

--- a/src/components/account/AccountTable.vue
+++ b/src/components/account/AccountTable.vue
@@ -12,8 +12,6 @@
       :paginated="paginated"
       backend-pagination
       pagination-order="centered"
-      :range-before="1"
-      :range-after="1"
       :total="total"
       v-model:current-page="currentPage"
       :per-page="perPage"

--- a/src/components/account/AccountTable.vue
+++ b/src/components/account/AccountTable.vue
@@ -23,7 +23,7 @@
       :striped="true"
       :mobile-breakpoint="ORUGA_MOBILE_BREAKPOINT"
 
-      customRowKey="account"
+      row-key="account"
   >
     <o-table-column v-slot="props" field="account" label="ID">
       <AccountIOL class="account_id" :account-id="props.row.account"/>

--- a/src/components/account/AccountTable.vue
+++ b/src/components/account/AccountTable.vue
@@ -99,7 +99,6 @@ import EmptyTable from "@/components/EmptyTable.vue";
 import {AccountTableController} from "@/components/account/AccountTableController";
 import AccountIOL from "@/components/values/link/AccountIOL.vue";
 import TablePageSize from "@/components/transaction/TablePageSize.vue";
-import {AppStorage} from "@/AppStorage";
 
 const props = defineProps({
   controller: {

--- a/src/components/account/AccountTable.vue
+++ b/src/components/account/AccountTable.vue
@@ -23,10 +23,6 @@
       :striped="true"
       :mobile-breakpoint="ORUGA_MOBILE_BREAKPOINT"
 
-      aria-current-label="Current page"
-      aria-next-label="Next page"
-      aria-page-label="Page"
-      aria-previous-label="Previous page"
       customRowKey="account"
   >
     <o-table-column v-slot="props" field="account" label="ID">

--- a/src/components/account/FungibleTable.vue
+++ b/src/components/account/FungibleTable.vue
@@ -25,7 +25,7 @@
       :striped="true"
       :mobile-breakpoint="ORUGA_MOBILE_BREAKPOINT"
 
-      customRowKey="token_id"
+      row-key="token_id"
   >
     <o-table-column v-slot="{ row }" field="token_id" label="TOKEN ID">
       <TokenIOL class="token-id-label" :token-id="row.token_id"/>

--- a/src/components/account/FungibleTable.vue
+++ b/src/components/account/FungibleTable.vue
@@ -12,8 +12,6 @@
       :paginated="props.controller.paginated.value && props.fullPage"
       backend-pagination
       pagination-order="centered"
-      :range-before="1"
-      :range-after="1"
       :total="props.controller.totalRowCount.value"
       v-model:current-page="props.controller.currentPage.value"
       :per-page="props.controller.pageSize.value"

--- a/src/components/account/FungibleTable.vue
+++ b/src/components/account/FungibleTable.vue
@@ -25,10 +25,6 @@
       :striped="true"
       :mobile-breakpoint="ORUGA_MOBILE_BREAKPOINT"
 
-      aria-current-label="Current page"
-      aria-next-label="Next page"
-      aria-page-label="Page"
-      aria-previous-label="Previous page"
       customRowKey="token_id"
   >
     <o-table-column v-slot="{ row }" field="token_id" label="TOKEN ID">

--- a/src/components/account/NftsTable.vue
+++ b/src/components/account/NftsTable.vue
@@ -25,10 +25,6 @@
       :striped="true"
       :mobile-breakpoint="ORUGA_MOBILE_BREAKPOINT"
 
-      aria-current-label="Current page"
-      aria-next-label="Next page"
-      aria-page-label="Page"
-      aria-previous-label="Previous page"
   >
 
     <o-table-column v-slot="{ row }" field="image" label="IMAGE">

--- a/src/components/account/NftsTable.vue
+++ b/src/components/account/NftsTable.vue
@@ -12,8 +12,6 @@
       :paginated="props.controller.paginated.value && props.fullPage"
       backend-pagination
       pagination-order="centered"
-      :range-before="1"
-      :range-after="1"
       :total="props.controller.totalRowCount.value"
       v-model:current-page="props.controller.currentPage.value"
       :per-page="props.controller.pageSize.value"

--- a/src/components/account/NftsTable.vue
+++ b/src/components/account/NftsTable.vue
@@ -100,7 +100,6 @@ import {routeManager} from "@/router";
 import NftCell, {NftCellItem} from "@/components/token/NftCell.vue";
 import {NftsTableController} from "@/components/account/NftsTableController";
 import TokenCell, {TokenCellItem} from "@/components/token/TokenCell.vue";
-import {AppStorage} from "@/AppStorage";
 import TablePageSize from "@/components/transaction/TablePageSize.vue";
 import TokenIOL from "@/components/values/link/TokenIOL.vue";
 import {ORUGA_MOBILE_BREAKPOINT} from "@/BreakPoints";

--- a/src/components/account/PendingFungibleAirdropTable.vue
+++ b/src/components/account/PendingFungibleAirdropTable.vue
@@ -12,8 +12,6 @@
       :paginated="props.controller.paginated.value ?? props.fullPage"
       backend-pagination
       pagination-order="centered"
-      :range-before="1"
-      :range-after="1"
       :total="props.controller.totalRowCount.value"
       :current-page="props.controller.currentPage.value"
       :per-page="props.controller.pageSize.value"

--- a/src/components/account/PendingFungibleAirdropTable.vue
+++ b/src/components/account/PendingFungibleAirdropTable.vue
@@ -26,10 +26,6 @@
       v-model:checked-rows="checkedRows"
       :checkable="props.checkEnabled"
 
-      aria-current-label="Current page"
-      aria-next-label="Next page"
-      aria-page-label="Page"
-      aria-previous-label="Previous page"
   >
     <o-table-column v-slot="{ row }" field="token_id" label="TOKEN ID">
       <TokenIOL class="token-id-label" :token-id="row.token_id"/>

--- a/src/components/account/PendingNftAirdropTable.vue
+++ b/src/components/account/PendingNftAirdropTable.vue
@@ -26,10 +26,6 @@
       v-model:checked-rows="checkedRows"
       :checkable="props.checkEnabled"
 
-      aria-current-label="Current page"
-      aria-next-label="Next page"
-      aria-page-label="Page"
-      aria-previous-label="Previous page"
   >
 
     <o-table-column v-slot="{ row }" field="image" label="IMAGE">

--- a/src/components/account/PendingNftAirdropTable.vue
+++ b/src/components/account/PendingNftAirdropTable.vue
@@ -12,8 +12,6 @@
       :paginated="props.controller.paginated.value && props.fullPage"
       backend-pagination
       pagination-order="centered"
-      :range-before="1"
-      :range-after="1"
       :total="props.controller.totalRowCount.value"
       :current-page="props.controller.currentPage.value"
       :per-page="props.controller.pageSize.value"

--- a/src/components/account/VerifiedContractsTable.vue
+++ b/src/components/account/VerifiedContractsTable.vue
@@ -17,7 +17,7 @@
       :per-page="perPage"
       :striped="true"
 
-      customRowKey="contract_id"
+      row-key="contract_id"
       @cell-click="handleClick"
   >
 

--- a/src/components/account/VerifiedContractsTable.vue
+++ b/src/components/account/VerifiedContractsTable.vue
@@ -16,11 +16,7 @@
 
       :per-page="perPage"
       :striped="true"
-      aria-current-label="Current page"
 
-      aria-next-label="Next page"
-      aria-page-label="Page"
-      aria-previous-label="Previous page"
       customRowKey="contract_id"
       @cell-click="handleClick"
   >

--- a/src/components/account/VerifiedContractsTable.vue
+++ b/src/components/account/VerifiedContractsTable.vue
@@ -13,8 +13,6 @@
       :narrowed="true"
       :paginated="contracts.length > perPage"
       pagination-order="centered"
-      :range-before="1"
-      :range-after="1"
 
       :per-page="perPage"
       :striped="true"

--- a/src/components/allowances/HbarAllowanceTable.vue
+++ b/src/components/allowances/HbarAllowanceTable.vue
@@ -20,7 +20,7 @@
 
       :total="total"
       backend-pagination
-      customRowKey="spender"
+      row-key="spender"
       default-sort="spender"
       @page-change="onPageChange">
 

--- a/src/components/allowances/HbarAllowanceTable.vue
+++ b/src/components/allowances/HbarAllowanceTable.vue
@@ -78,7 +78,6 @@ import AccountLink from "@/components/values/link/AccountLink.vue";
 import HbarAmount from "@/components/values/HbarAmount.vue";
 import {walletManager} from "@/router";
 import TablePageSize from "@/components/transaction/TablePageSize.vue";
-import {AppStorage} from "@/AppStorage";
 
 const emit = defineEmits(["editAllowance"])
 

--- a/src/components/allowances/HbarAllowanceTable.vue
+++ b/src/components/allowances/HbarAllowanceTable.vue
@@ -15,8 +15,6 @@
       :narrowed="true"
       :paginated="paginated"
       pagination-order="centered"
-      :range-before="1"
-      :range-after="1"
       :per-page="perPage"
       :striped="true"
 

--- a/src/components/allowances/HbarAllowanceTable.vue
+++ b/src/components/allowances/HbarAllowanceTable.vue
@@ -19,11 +19,6 @@
       :striped="true"
 
       :total="total"
-      aria-current-label="Current page"
-      aria-next-label="Next page"
-      aria-page-label="Page"
-
-      aria-previous-label="Previous page"
       backend-pagination
       customRowKey="spender"
       default-sort="spender"

--- a/src/components/allowances/NftAllSerialsAllowanceTable.vue
+++ b/src/components/allowances/NftAllSerialsAllowanceTable.vue
@@ -20,7 +20,7 @@
 
       :total="total"
       backend-pagination
-      customRowKey="spender"
+      row-key="spender"
       default-sort="spender"
       @page-change="onPageChange">
 

--- a/src/components/allowances/NftAllSerialsAllowanceTable.vue
+++ b/src/components/allowances/NftAllSerialsAllowanceTable.vue
@@ -15,8 +15,6 @@
       :narrowed="true"
       :paginated="paginated"
       pagination-order="centered"
-      :range-before="1"
-      :range-after="1"
       :per-page="perPage"
       :striped="true"
 

--- a/src/components/allowances/NftAllSerialsAllowanceTable.vue
+++ b/src/components/allowances/NftAllSerialsAllowanceTable.vue
@@ -86,7 +86,6 @@ import InfoTooltip from "@/components/InfoTooltip.vue";
 import {NftAllSerialsAllowanceTableController} from "@/components/allowances/NftAllSerialsAllowanceTableController";
 import {isValidAssociation} from "@/schemas/MirrorNodeUtils.ts";
 import TablePageSize from "@/components/transaction/TablePageSize.vue";
-import {AppStorage} from "@/AppStorage";
 
 interface DisplayedNftAllowance extends NftAllowance {
   isEditable: boolean

--- a/src/components/allowances/NftAllSerialsAllowanceTable.vue
+++ b/src/components/allowances/NftAllSerialsAllowanceTable.vue
@@ -19,11 +19,6 @@
       :striped="true"
 
       :total="total"
-      aria-current-label="Current page"
-      aria-next-label="Next page"
-      aria-page-label="Page"
-
-      aria-previous-label="Previous page"
       backend-pagination
       customRowKey="spender"
       default-sort="spender"

--- a/src/components/allowances/NftAllowanceTable.vue
+++ b/src/components/allowances/NftAllowanceTable.vue
@@ -20,7 +20,7 @@
 
       :total="total"
       backend-pagination
-      customRowKey="spender"
+      row-key="spender"
       default-sort="spender"
       @page-change="onPageChange">
 

--- a/src/components/allowances/NftAllowanceTable.vue
+++ b/src/components/allowances/NftAllowanceTable.vue
@@ -15,8 +15,6 @@
       :narrowed="true"
       :paginated="paginated"
       pagination-order="centered"
-      :range-before="1"
-      :range-after="1"
       :per-page="perPage"
       :striped="true"
 

--- a/src/components/allowances/NftAllowanceTable.vue
+++ b/src/components/allowances/NftAllowanceTable.vue
@@ -85,7 +85,6 @@ import TokenLink from "@/components/values/link/TokenLink.vue";
 import {walletManager} from "@/router";
 import {NftAllowanceTableController} from "@/components/allowances/NftAllowanceTableController";
 import TablePageSize from "@/components/transaction/TablePageSize.vue";
-import {AppStorage} from "@/AppStorage";
 
 const emit = defineEmits(["deleteAllowance"])
 

--- a/src/components/allowances/NftAllowanceTable.vue
+++ b/src/components/allowances/NftAllowanceTable.vue
@@ -19,11 +19,6 @@
       :striped="true"
 
       :total="total"
-      aria-current-label="Current page"
-      aria-next-label="Next page"
-      aria-page-label="Page"
-
-      aria-previous-label="Previous page"
       backend-pagination
       customRowKey="spender"
       default-sort="spender"

--- a/src/components/allowances/TokenAllowanceTable.vue
+++ b/src/components/allowances/TokenAllowanceTable.vue
@@ -91,7 +91,6 @@ import TokenLink from "@/components/values/link/TokenLink.vue";
 import {walletManager} from "@/router";
 import InfoTooltip from "@/components/InfoTooltip.vue";
 import TablePageSize from "@/components/transaction/TablePageSize.vue";
-import {AppStorage} from "@/AppStorage";
 
 interface DisplayedTokenAllowance extends TokenAllowance {
   isEditable: boolean

--- a/src/components/allowances/TokenAllowanceTable.vue
+++ b/src/components/allowances/TokenAllowanceTable.vue
@@ -20,7 +20,7 @@
 
       :total="total"
       backend-pagination
-      customRowKey="spender"
+      row-key="spender"
       default-sort="spender"
       @page-change="onPageChange">
 

--- a/src/components/allowances/TokenAllowanceTable.vue
+++ b/src/components/allowances/TokenAllowanceTable.vue
@@ -15,8 +15,6 @@
       :narrowed="true"
       :paginated="paginated"
       pagination-order="centered"
-      :range-before="1"
-      :range-after="1"
       :per-page="perPage"
       :striped="true"
 

--- a/src/components/allowances/TokenAllowanceTable.vue
+++ b/src/components/allowances/TokenAllowanceTable.vue
@@ -19,11 +19,6 @@
       :striped="true"
 
       :total="total"
-      aria-current-label="Current page"
-      aria-next-label="Next page"
-      aria-page-label="Page"
-
-      aria-previous-label="Previous page"
       backend-pagination
       customRowKey="spender"
       default-sort="spender"

--- a/src/components/block/BlockTable.vue
+++ b/src/components/block/BlockTable.vue
@@ -12,8 +12,6 @@
       paginated
       backend-pagination
       pagination-order="centered"
-      :range-before="1"
-      :range-after="1"
       :total="total"
       v-model:current-page="currentPage"
       :per-page="perPage"

--- a/src/components/block/BlockTable.vue
+++ b/src/components/block/BlockTable.vue
@@ -23,7 +23,7 @@
       :striped="true"
       :mobile-breakpoint="ORUGA_MOBILE_BREAKPOINT"
 
-      customRowKey="number"
+      row-key="number"
   >
     <o-table-column v-slot="props" field="number" label="NUMBER">
       <p class="block_number">{{ props.row.number }}</p>

--- a/src/components/block/BlockTable.vue
+++ b/src/components/block/BlockTable.vue
@@ -23,10 +23,6 @@
       :striped="true"
       :mobile-breakpoint="ORUGA_MOBILE_BREAKPOINT"
 
-      aria-current-label="Current page"
-      aria-next-label="Next page"
-      aria-page-label="Page"
-      aria-previous-label="Previous page"
       customRowKey="number"
   >
     <o-table-column v-slot="props" field="number" label="NUMBER">

--- a/src/components/block/BlockTransactionTable.vue
+++ b/src/components/block/BlockTransactionTable.vue
@@ -17,7 +17,7 @@
       :per-page="perPage"
       :striped="true"
       :mobile-breakpoint="ORUGA_MOBILE_BREAKPOINT"
-      customRowKey="consensus_timestamp"
+      row-key="consensus_timestamp"
       @cell-click="handleClick"
   >
     <o-table-column v-slot="props" field="transaction_id" label="ID">

--- a/src/components/block/BlockTransactionTable.vue
+++ b/src/components/block/BlockTransactionTable.vue
@@ -17,10 +17,6 @@
       :per-page="perPage"
       :striped="true"
       :mobile-breakpoint="ORUGA_MOBILE_BREAKPOINT"
-      aria-current-label="Current page"
-      aria-next-label="Next page"
-      aria-page-label="Page"
-      aria-previous-label="Previous page"
       customRowKey="consensus_timestamp"
       @cell-click="handleClick"
   >

--- a/src/components/block/BlockTransactionTable.vue
+++ b/src/components/block/BlockTransactionTable.vue
@@ -14,8 +14,6 @@
       :narrowed="narrowed"
       :paginated="paginated"
       pagination-order="centered"
-      :range-before="1"
-      :range-after="1"
       :per-page="perPage"
       :striped="true"
       :mobile-breakpoint="ORUGA_MOBILE_BREAKPOINT"

--- a/src/components/contract/ContractActionsTable.vue
+++ b/src/components/contract/ContractActionsTable.vue
@@ -23,10 +23,6 @@
         :striped="false"
         :mobile-breakpoint="ORUGA_MOBILE_BREAKPOINT"
 
-        aria-current-label="Current page"
-        aria-next-label="Next page"
-        aria-page-label="Page"
-        aria-previous-label="Previous page"
     >
 
       <o-table-column v-slot="props" field="call_type" label="CALL TYPE">

--- a/src/components/contract/ContractActionsTable.vue
+++ b/src/components/contract/ContractActionsTable.vue
@@ -12,8 +12,6 @@
         :data="props.actions ?? []"
         :paginated="isPaginated"
         pagination-order="centered"
-        :range-before="1"
-        :range-after="1"
         :per-page="NB_ACTIONS_PER_PAGE"
 
         :detailed="isMediumScreen"

--- a/src/components/contract/ContractResultLogs.vue
+++ b/src/components/contract/ContractResultLogs.vue
@@ -37,10 +37,6 @@
             :range-before="1"
             :range-after="1"
             :per-page="pageSize"
-            aria-next-label="Next page"
-            aria-previous-label="Previous page"
-            aria-page-label="Page"
-            aria-current-label="Current page"
         >
         </o-pagination>
       </div>

--- a/src/components/contract/ContractResultStates.vue
+++ b/src/components/contract/ContractResultStates.vue
@@ -48,10 +48,6 @@
             :range-before="1"
             :range-after="1"
             :per-page="pageSize"
-            aria-next-label="Next page"
-            aria-previous-label="Previous page"
-            aria-page-label="Page"
-            aria-current-label="Current page"
         >
         </o-pagination>
       </div>

--- a/src/components/contract/ContractResultTable.vue
+++ b/src/components/contract/ContractResultTable.vue
@@ -19,11 +19,6 @@
       :striped="true"
 
       :total="total"
-      aria-current-label="Current page"
-      aria-next-label="Next page"
-      aria-page-label="Page"
-
-      aria-previous-label="Previous page"
       backend-pagination
       customRowKey="consensus_timestamp"
       default-sort="consensus_timestamp"

--- a/src/components/contract/ContractResultTable.vue
+++ b/src/components/contract/ContractResultTable.vue
@@ -15,8 +15,6 @@
       :narrowed="true"
       :paginated="paginated"
       pagination-order="centered"
-      :range-before="1"
-      :range-after="1"
       :per-page="perPage"
       :striped="true"
 

--- a/src/components/contract/ContractResultTable.vue
+++ b/src/components/contract/ContractResultTable.vue
@@ -20,7 +20,7 @@
 
       :total="total"
       backend-pagination
-      customRowKey="consensus_timestamp"
+      row-key="consensus_timestamp"
       default-sort="consensus_timestamp"
       @cell-click="handleClick"
       @page-change="onPageChange">

--- a/src/components/contract/ContractResultTable.vue
+++ b/src/components/contract/ContractResultTable.vue
@@ -86,7 +86,6 @@ import EVMAddress from "@/components/values/EVMAddress.vue";
 import {decodeSolidityErrorMessage} from "@/schemas/MirrorNodeUtils.ts";
 import HbarAmount from "@/components/values/HbarAmount.vue";
 import TablePageSize from "@/components/transaction/TablePageSize.vue";
-import {AppStorage} from "@/AppStorage";
 import {TriangleAlert} from 'lucide-vue-next';
 
 const props = defineProps({

--- a/src/components/contract/ContractTable.vue
+++ b/src/components/contract/ContractTable.vue
@@ -76,7 +76,6 @@ import {ContractTableController} from "@/components/contract/ContractTableContro
 import ContractName from "@/components/values/ContractName.vue";
 import ContractIOL from "@/components/values/link/ContractIOL.vue";
 import TablePageSize from "@/components/transaction/TablePageSize.vue";
-import {AppStorage} from "@/AppStorage";
 
 const props = defineProps({
   controller: {

--- a/src/components/contract/ContractTable.vue
+++ b/src/components/contract/ContractTable.vue
@@ -12,8 +12,6 @@
       paginated
       backend-pagination
       pagination-order="centered"
-      :range-before="1"
-      :range-after="1"
       :total="total"
       v-model:current-page="currentPage"
       :per-page="perPage"

--- a/src/components/contract/ContractTable.vue
+++ b/src/components/contract/ContractTable.vue
@@ -23,7 +23,7 @@
       :striped="true"
       :mobile-breakpoint="ORUGA_MOBILE_BREAKPOINT"
 
-      customRowKey="contract_id"
+      row-key="contract_id"
   >
     <o-table-column v-slot="props" field="contract_id" label="ID">
       <ContractIOL class="contract_id" :contract-id="props.row.contract_id"/>

--- a/src/components/contract/ContractTable.vue
+++ b/src/components/contract/ContractTable.vue
@@ -23,10 +23,6 @@
       :striped="true"
       :mobile-breakpoint="ORUGA_MOBILE_BREAKPOINT"
 
-      aria-current-label="Current page"
-      aria-next-label="Next page"
-      aria-page-label="Page"
-      aria-previous-label="Previous page"
       customRowKey="contract_id"
   >
     <o-table-column v-slot="props" field="contract_id" label="ID">

--- a/src/components/contract/ERC20ByNameTable.vue
+++ b/src/components/contract/ERC20ByNameTable.vue
@@ -22,10 +22,6 @@
       :striped="true"
       :mobile-breakpoint="ORUGA_MOBILE_BREAKPOINT"
 
-      aria-current-label="Current page"
-      aria-next-label="Next page"
-      aria-page-label="Page"
-      aria-previous-label="Previous page"
       customRowKey="token_id"
   >
     <o-table-column v-slot="props" field="contract_id" label="CONTRACT ID">

--- a/src/components/contract/ERC20ByNameTable.vue
+++ b/src/components/contract/ERC20ByNameTable.vue
@@ -22,7 +22,7 @@
       :striped="true"
       :mobile-breakpoint="ORUGA_MOBILE_BREAKPOINT"
 
-      customRowKey="token_id"
+      row-key="token_id"
   >
     <o-table-column v-slot="props" field="contract_id" label="CONTRACT ID">
       <ContractIOL class="h-is-bold" :contract-id="props.row.contractId"/>

--- a/src/components/contract/ERC20ByNameTable.vue
+++ b/src/components/contract/ERC20ByNameTable.vue
@@ -12,8 +12,6 @@
       paginated
       backend-pagination
       pagination-order="centered"
-      :range-before="1"
-      :range-after="1"
       :total="total"
       v-model:current-page="currentPage"
       :per-page="pageSize"

--- a/src/components/contract/ERC721ByNameTable.vue
+++ b/src/components/contract/ERC721ByNameTable.vue
@@ -22,10 +22,6 @@
       :striped="true"
       :mobile-breakpoint="ORUGA_MOBILE_BREAKPOINT"
 
-      aria-current-label="Current page"
-      aria-next-label="Next page"
-      aria-page-label="Page"
-      aria-previous-label="Previous page"
       customRowKey="token_id"
   >
     <o-table-column v-slot="props" field="contract_id" label="CONTRACT ID">

--- a/src/components/contract/ERC721ByNameTable.vue
+++ b/src/components/contract/ERC721ByNameTable.vue
@@ -22,7 +22,7 @@
       :striped="true"
       :mobile-breakpoint="ORUGA_MOBILE_BREAKPOINT"
 
-      customRowKey="token_id"
+      row-key="token_id"
   >
     <o-table-column v-slot="props" field="contract_id" label="CONTRACT ID">
       <ContractIOL class="h-is-bold" :contract-id="props.row.contractId"/>

--- a/src/components/contract/ERC721ByNameTable.vue
+++ b/src/components/contract/ERC721ByNameTable.vue
@@ -12,8 +12,6 @@
       paginated
       backend-pagination
       pagination-order="centered"
-      :range-before="1"
-      :range-after="1"
       :total="total"
       v-model:current-page="currentPage"
       :per-page="pageSize"

--- a/src/components/staking/StakingRewardsTable.vue
+++ b/src/components/staking/StakingRewardsTable.vue
@@ -24,10 +24,6 @@
       :striped="true"
       :mobile-breakpoint="ORUGA_MOBILE_BREAKPOINT"
 
-      aria-current-label="Current page"
-      aria-next-label="Next page"
-      aria-page-label="Page"
-      aria-previous-label="Previous page"
       customRowKey="consensus_timestamp"
   >
     <o-table-column v-slot="props" field="timestamp" label="TIME">

--- a/src/components/staking/StakingRewardsTable.vue
+++ b/src/components/staking/StakingRewardsTable.vue
@@ -24,7 +24,7 @@
       :striped="true"
       :mobile-breakpoint="ORUGA_MOBILE_BREAKPOINT"
 
-      customRowKey="consensus_timestamp"
+      row-key="consensus_timestamp"
   >
     <o-table-column v-slot="props" field="timestamp" label="TIME">
       <TimestampValue class="timestamp-value" :timestamp="props.row.timestamp"/>

--- a/src/components/staking/StakingRewardsTable.vue
+++ b/src/components/staking/StakingRewardsTable.vue
@@ -13,8 +13,6 @@
       :paginated="paginated"
       backend-pagination
       pagination-order="centered"
-      :range-before="1"
-      :range-after="1"
       :total="total"
       v-model:current-page="currentPage"
       :per-page="perPage"

--- a/src/components/token/NftHolderTable.vue
+++ b/src/components/token/NftHolderTable.vue
@@ -13,8 +13,6 @@
         :paginated="paginated"
         backend-pagination
         pagination-order="centered"
-        :range-before="1"
-        :range-after="1"
         :total="total"
         v-model:current-page="currentPage"
         :per-page="perPage"

--- a/src/components/token/NftHolderTable.vue
+++ b/src/components/token/NftHolderTable.vue
@@ -24,7 +24,7 @@
         :striped="true"
         :mobile-breakpoint="ORUGA_MOBILE_BREAKPOINT"
 
-        customRowKey="serial_number"
+        row-key="serial_number"
     >
       <o-table-column v-slot="props" field="image" label="PREVIEW">
         <NftCell

--- a/src/components/token/NftHolderTable.vue
+++ b/src/components/token/NftHolderTable.vue
@@ -24,10 +24,6 @@
         :striped="true"
         :mobile-breakpoint="ORUGA_MOBILE_BREAKPOINT"
 
-        aria-current-label="Current page"
-        aria-next-label="Next page"
-        aria-page-label="Page"
-        aria-previous-label="Previous page"
         customRowKey="serial_number"
     >
       <o-table-column v-slot="props" field="image" label="PREVIEW">

--- a/src/components/token/TokenBalanceTable.vue
+++ b/src/components/token/TokenBalanceTable.vue
@@ -25,7 +25,7 @@
         :striped="true"
         :mobile-breakpoint="ORUGA_MOBILE_BREAKPOINT"
 
-        customRowKey="account"
+        row-key="account"
     >
       <o-table-column v-slot="props" field="account" label="ACCOUNT ID">
         <AccountIOL class="account-id" :account-id="props.row.account"/>

--- a/src/components/token/TokenBalanceTable.vue
+++ b/src/components/token/TokenBalanceTable.vue
@@ -25,10 +25,6 @@
         :striped="true"
         :mobile-breakpoint="ORUGA_MOBILE_BREAKPOINT"
 
-        aria-current-label="Current page"
-        aria-next-label="Next page"
-        aria-page-label="Page"
-        aria-previous-label="Previous page"
         customRowKey="account"
     >
       <o-table-column v-slot="props" field="account" label="ACCOUNT ID">

--- a/src/components/token/TokenBalanceTable.vue
+++ b/src/components/token/TokenBalanceTable.vue
@@ -14,8 +14,6 @@
         :paginated="paginated"
         backend-pagination
         pagination-order="centered"
-        :range-before="1"
-        :range-after="1"
         :total="total"
         v-model:current-page="currentPage"
         :per-page="perPage"

--- a/src/components/token/TokenTable.vue
+++ b/src/components/token/TokenTable.vue
@@ -12,8 +12,6 @@
       paginated
       backend-pagination
       pagination-order="centered"
-      :range-before="1"
-      :range-after="1"
       :total="total"
       v-model:current-page="currentPage"
       :per-page="perPage"

--- a/src/components/token/TokenTable.vue
+++ b/src/components/token/TokenTable.vue
@@ -23,7 +23,7 @@
       :striped="true"
       :mobile-breakpoint="ORUGA_MOBILE_BREAKPOINT"
 
-      customRowKey="token_id"
+      row-key="token_id"
   >
     <o-table-column v-slot="props" field="token_id" label="TOKEN">
       <TokenIOL class="token_id" :token-id="props.row.token_id"/>

--- a/src/components/token/TokenTable.vue
+++ b/src/components/token/TokenTable.vue
@@ -23,10 +23,6 @@
       :striped="true"
       :mobile-breakpoint="ORUGA_MOBILE_BREAKPOINT"
 
-      aria-current-label="Current page"
-      aria-next-label="Next page"
-      aria-page-label="Page"
-      aria-previous-label="Previous page"
       customRowKey="token_id"
   >
     <o-table-column v-slot="props" field="token_id" label="TOKEN">

--- a/src/components/token/TokensByNameTable.vue
+++ b/src/components/token/TokensByNameTable.vue
@@ -22,7 +22,7 @@
       :striped="true"
       :mobile-breakpoint="ORUGA_MOBILE_BREAKPOINT"
 
-      customRowKey="token_id"
+      row-key="token_id"
   >
     <o-table-column v-slot="props" field="token_id" label="TOKEN">
       <TokenIOL class="h-is-bold" :token-id="props.row.token_id"/>

--- a/src/components/token/TokensByNameTable.vue
+++ b/src/components/token/TokensByNameTable.vue
@@ -12,8 +12,6 @@
       paginated
       backend-pagination
       pagination-order="centered"
-      :range-before="1"
-      :range-after="1"
       :total="total"
       v-model:current-page="currentPage"
       :per-page="perPage"

--- a/src/components/token/TokensByNameTable.vue
+++ b/src/components/token/TokensByNameTable.vue
@@ -22,10 +22,6 @@
       :striped="true"
       :mobile-breakpoint="ORUGA_MOBILE_BREAKPOINT"
 
-      aria-current-label="Current page"
-      aria-next-label="Next page"
-      aria-page-label="Page"
-      aria-previous-label="Previous page"
       customRowKey="token_id"
   >
     <o-table-column v-slot="props" field="token_id" label="TOKEN">

--- a/src/components/token/TokensByPopularityTable.vue
+++ b/src/components/token/TokensByPopularityTable.vue
@@ -22,7 +22,7 @@
       :striped="true"
       :mobile-breakpoint="ORUGA_MOBILE_BREAKPOINT"
 
-      customRowKey="token_id"
+      row-key="token_id"
   >
     <o-table-column v-slot="props" field="token_id" label="TOKEN">
       <TokenIOL class="h-is-bold" :token-id="props.row.token_id"/>

--- a/src/components/token/TokensByPopularityTable.vue
+++ b/src/components/token/TokensByPopularityTable.vue
@@ -12,8 +12,6 @@
       paginated
       backend-pagination
       pagination-order="centered"
-      :range-before="1"
-      :range-after="1"
       :total="total"
       v-model:current-page="currentPage"
       :per-page="perPage"

--- a/src/components/token/TokensByPopularityTable.vue
+++ b/src/components/token/TokensByPopularityTable.vue
@@ -22,10 +22,6 @@
       :striped="true"
       :mobile-breakpoint="ORUGA_MOBILE_BREAKPOINT"
 
-      aria-current-label="Current page"
-      aria-next-label="Next page"
-      aria-page-label="Page"
-      aria-previous-label="Previous page"
       customRowKey="token_id"
   >
     <o-table-column v-slot="props" field="token_id" label="TOKEN">

--- a/src/components/topic/TopicMessageTable.vue
+++ b/src/components/topic/TopicMessageTable.vue
@@ -21,7 +21,7 @@
 
         :mobile-breakpoint="ORUGA_MOBILE_BREAKPOINT"
 
-        customRowKey="consensus_timestamp"
+        row-key="consensus_timestamp"
     >
       <o-table-column v-slot="props" field="sequence_number" label="SEQ.#">
         {{ props.row.sequence_number != null ? props.row.sequence_number : "" }}

--- a/src/components/topic/TopicMessageTable.vue
+++ b/src/components/topic/TopicMessageTable.vue
@@ -13,8 +13,6 @@
         :paginated="!isTouchDevice && paginated"
         backend-pagination
         pagination-order="centered"
-        :range-before="1"
-        :range-after="1"
         :total="total"
         v-model:current-page="currentPage"
         :per-page="perPage"

--- a/src/components/topic/TopicMessageTable.vue
+++ b/src/components/topic/TopicMessageTable.vue
@@ -16,7 +16,6 @@
         :total="total"
         v-model:current-page="currentPage"
         :per-page="perPage"
-        focusable
         @page-change="onPageChange"
         @cell-click="handleClick"
 

--- a/src/components/topic/TopicMessageTable.vue
+++ b/src/components/topic/TopicMessageTable.vue
@@ -21,10 +21,6 @@
 
         :mobile-breakpoint="ORUGA_MOBILE_BREAKPOINT"
 
-        aria-current-label="Current page"
-        aria-next-label="Next page"
-        aria-page-label="Page"
-        aria-previous-label="Previous page"
         customRowKey="consensus_timestamp"
     >
       <o-table-column v-slot="props" field="sequence_number" label="SEQ.#">

--- a/src/components/topic/TopicTable.vue
+++ b/src/components/topic/TopicTable.vue
@@ -22,7 +22,7 @@
       :striped="true"
       :mobile-breakpoint="ORUGA_MOBILE_BREAKPOINT"
 
-      customRowKey="consensus_timestamp"
+      row-key="consensus_timestamp"
   >
     <o-table-column v-slot="props" field="topic_id" label="TOPIC">
       <TopicIOL class="topic_id" :topic-id="props.row.entity_id"/>

--- a/src/components/topic/TopicTable.vue
+++ b/src/components/topic/TopicTable.vue
@@ -22,10 +22,6 @@
       :striped="true"
       :mobile-breakpoint="ORUGA_MOBILE_BREAKPOINT"
 
-      aria-current-label="Current page"
-      aria-next-label="Next page"
-      aria-page-label="Page"
-      aria-previous-label="Previous page"
       customRowKey="consensus_timestamp"
   >
     <o-table-column v-slot="props" field="topic_id" label="TOPIC">

--- a/src/components/topic/TopicTable.vue
+++ b/src/components/topic/TopicTable.vue
@@ -12,8 +12,6 @@
       paginated
       backend-pagination
       pagination-order="centered"
-      :range-before="1"
-      :range-after="1"
       :total="total"
       v-model:current-page="currentPage"
       :per-page="perPage"

--- a/src/components/transaction/NftTransactionTable.vue
+++ b/src/components/transaction/NftTransactionTable.vue
@@ -20,10 +20,6 @@
       :narrowed="narrowed"
       :striped="true"
       :mobile-breakpoint="ORUGA_MOBILE_BREAKPOINT"
-      aria-current-label="Current page"
-      aria-next-label="Next page"
-      aria-page-label="Page"
-      aria-previous-label="Previous page"
       customRowKey="consensus_timestamp"
   >
     <o-table-column v-slot="props" field="timestamp" label="ID">

--- a/src/components/transaction/NftTransactionTable.vue
+++ b/src/components/transaction/NftTransactionTable.vue
@@ -20,7 +20,7 @@
       :narrowed="narrowed"
       :striped="true"
       :mobile-breakpoint="ORUGA_MOBILE_BREAKPOINT"
-      customRowKey="consensus_timestamp"
+      row-key="consensus_timestamp"
   >
     <o-table-column v-slot="props" field="timestamp" label="ID">
       <TransactionLabel

--- a/src/components/transaction/NftTransactionTable.vue
+++ b/src/components/transaction/NftTransactionTable.vue
@@ -11,8 +11,6 @@
       paginated
       backend-pagination
       pagination-order="centered"
-      :range-before="1"
-      :range-after="1"
       :total="total"
       v-model:current-page="currentPage"
       :per-page="perPage"

--- a/src/components/transaction/NftTransactionTable.vue
+++ b/src/components/transaction/NftTransactionTable.vue
@@ -62,7 +62,7 @@
 <script setup lang="ts">
 import {OTable, OTableColumn} from "@oruga-ui/oruga-next";
 import {computed, PropType,} from "vue"
-import {NftTransactionTransfer, Transaction, TransactionType,} from "@/schemas/MirrorNodeSchemas"
+import {NftTransactionTransfer, TransactionType,} from "@/schemas/MirrorNodeSchemas"
 import NftTransactionSummary from "@/components/transaction/NftTransactionSummary.vue"
 import TimestampValue from "@/components/values/TimestampValue.vue"
 import TransactionLabel from "@/components/values/TransactionLabel.vue"

--- a/src/components/transaction/TransactionBatchTable.vue
+++ b/src/components/transaction/TransactionBatchTable.vue
@@ -16,7 +16,7 @@
       :per-page="isMediumScreen ? pageSize : 5"
       :striped="true"
       :mobile-breakpoint="ORUGA_MOBILE_BREAKPOINT"
-      customRowKey="transaction_id"
+      row-key="transaction_id"
       @cell-click="handleClick"
   >
     <o-table-column v-slot="props" field="transaction_id" label="ID">

--- a/src/components/transaction/TransactionBatchTable.vue
+++ b/src/components/transaction/TransactionBatchTable.vue
@@ -16,10 +16,6 @@
       :per-page="isMediumScreen ? pageSize : 5"
       :striped="true"
       :mobile-breakpoint="ORUGA_MOBILE_BREAKPOINT"
-      aria-current-label="Current page"
-      aria-next-label="Next page"
-      aria-page-label="Page"
-      aria-previous-label="Previous page"
       customRowKey="transaction_id"
       @cell-click="handleClick"
   >

--- a/src/components/transaction/TransactionBatchTable.vue
+++ b/src/components/transaction/TransactionBatchTable.vue
@@ -13,8 +13,6 @@
       :narrowed="props.narrowed"
       :paginated="!isTouchDevice && paginationNeeded"
       pagination-order="centered"
-      :range-before="1"
-      :range-after="1"
       :per-page="isMediumScreen ? pageSize : 5"
       :striped="true"
       :mobile-breakpoint="ORUGA_MOBILE_BREAKPOINT"

--- a/src/components/transaction/TransactionByIdTable.vue
+++ b/src/components/transaction/TransactionByIdTable.vue
@@ -16,7 +16,7 @@
       :per-page="isMediumScreen ? pageSize : 5"
       :striped="true"
       :mobile-breakpoint="ORUGA_MOBILE_BREAKPOINT"
-      customRowKey="consensus_timestamp"
+      row-key="consensus_timestamp"
       @cell-click="handleClick"
   >
     <o-table-column v-slot="props" field="timestamp" label="TIME">

--- a/src/components/transaction/TransactionByIdTable.vue
+++ b/src/components/transaction/TransactionByIdTable.vue
@@ -13,8 +13,6 @@
       :narrowed="props.narrowed"
       :paginated="!isTouchDevice && paginationNeeded"
       pagination-order="centered"
-      :range-before="1"
-      :range-after="1"
       :per-page="isMediumScreen ? pageSize : 5"
       :striped="true"
       :mobile-breakpoint="ORUGA_MOBILE_BREAKPOINT"

--- a/src/components/transaction/TransactionByIdTable.vue
+++ b/src/components/transaction/TransactionByIdTable.vue
@@ -16,10 +16,6 @@
       :per-page="isMediumScreen ? pageSize : 5"
       :striped="true"
       :mobile-breakpoint="ORUGA_MOBILE_BREAKPOINT"
-      aria-current-label="Current page"
-      aria-next-label="Next page"
-      aria-page-label="Page"
-      aria-previous-label="Previous page"
       customRowKey="consensus_timestamp"
       @cell-click="handleClick"
   >

--- a/src/components/transaction/TransactionTable.vue
+++ b/src/components/transaction/TransactionTable.vue
@@ -24,10 +24,6 @@
       :striped="true"
       :mobile-breakpoint="ORUGA_MOBILE_BREAKPOINT"
 
-      aria-current-label="Current page"
-      aria-next-label="Next page"
-      aria-page-label="Page"
-      aria-previous-label="Previous page"
       customRowKey="consensus_timestamp"
   >
     <o-table-column v-slot="props" field="timestamp" label="ID">

--- a/src/components/transaction/TransactionTable.vue
+++ b/src/components/transaction/TransactionTable.vue
@@ -24,7 +24,7 @@
       :striped="true"
       :mobile-breakpoint="ORUGA_MOBILE_BREAKPOINT"
 
-      customRowKey="consensus_timestamp"
+      row-key="consensus_timestamp"
   >
     <o-table-column v-slot="props" field="timestamp" label="ID">
       <TransactionLabel

--- a/src/components/transaction/TransactionTable.vue
+++ b/src/components/transaction/TransactionTable.vue
@@ -13,8 +13,6 @@
       :paginated="paginated"
       backend-pagination
       pagination-order="centered"
-      :range-before="1"
-      :range-after="1"
       :total="total"
       v-model:current-page="currentPage"
       :per-page="perPage"

--- a/src/dialogs/verification/FileList.vue
+++ b/src/dialogs/verification/FileList.vue
@@ -36,10 +36,7 @@
         :paginated="isPaginated"
         pagination-order="centered"
         :per-page="perPage"
-        aria-current-label="Current page"
-        aria-next-label="Next page"
-        aria-page-label="Page"
-        aria-previous-label="Previous page">
+    >
 
       <o-table-column v-slot="props" field="type_and_name">
         <div class="table-row ">

--- a/src/dialogs/verification/FileList.vue
+++ b/src/dialogs/verification/FileList.vue
@@ -35,8 +35,6 @@
         :data="displayedAuditItems"
         :paginated="isPaginated"
         pagination-order="centered"
-        :range-before="0"
-        :range-after="0"
         :per-page="perPage"
         aria-current-label="Current page"
         aria-next-label="Next page"

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -13,7 +13,6 @@
   "vueCompilerOptions": {
     "strictTemplates": true,
     "fallthroughAttributes": true,
-    "dataAttributes": ["data-cy"],
-    "checkUnknownProps": false
+    "dataAttributes": ["id","data-cy","customRowKey"]
   }
 }

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -13,6 +13,6 @@
   "vueCompilerOptions": {
     "strictTemplates": true,
     "fallthroughAttributes": true,
-    "dataAttributes": ["id","data-cy","customRowKey"]
+    "dataAttributes": ["id","data-cy"]
   }
 }


### PR DESCRIPTION
**Description**:

Changes below re-enable unknown props checking in `vueCompilerOptions`.
They also remove reported unknown props and rename `customRowKey` as `rowKey` (see [Oruga 0.9.0 change log](https://github.com/oruga-ui/oruga/blob/develop/CHANGELOG.md#090-2024-11-11)).

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
