### PR TITLE
fix: preserve casing of parameter names in ContractResult and Call Trace sections

### DIFF
--- a/src/components/values/FunctionError.vue
+++ b/src/components/values/FunctionError.vue
@@ -20,7 +20,7 @@
       </Property>
 
       <template v-for="arg in errorInputs" :key="arg.name">
-        <Property :custom-nb-col-class="customNbColClass">
+        <Property :custom-nb-col-class="customNbColClass" :keep-case="true">
           <template #name>
             <span style="padding-left: 16px;">{{ arg.name != "" ? arg.name : "message" }}</span>
           </template>

--- a/src/components/values/FunctionInput.vue
+++ b/src/components/values/FunctionInput.vue
@@ -20,7 +20,7 @@
       <div class="h-sub-section">Input</div>
 
       <template v-for="arg in inputs" :key="arg.name">
-        <Property :custom-nb-col-class="customNbColClass">
+        <Property :custom-nb-col-class="customNbColClass" :keep-case="true">
           <template #name>
             <span style="padding-left: 16px;">{{ arg.name }}</span>
           </template>

--- a/src/components/values/FunctionResult.vue
+++ b/src/components/values/FunctionResult.vue
@@ -11,7 +11,7 @@
     <div class="h-sub-section">Output</div>
 
     <template v-for="result in outputs" :key="result.name">
-      <Property :custom-nb-col-class="customNbColClass">
+      <Property :custom-nb-col-class="customNbColClass" :keep-case="true">
         <template v-slot:name>
           <span style="padding-left: 16px;">{{ result.name }}</span>
         </template>


### PR DESCRIPTION
**Description**:

Changes below preserve casing of parameters displayed in `ContractResult` and `Call Trace` sections of `Contract Details` page.

Before:
<img width="548" alt="Capture d’écran 2025-05-23 à 18 50 32" src="https://github.com/user-attachments/assets/3d951b3a-cc33-43b4-9318-f51d95f959fe" />

After:
<img width="570" alt="image" src="https://github.com/user-attachments/assets/86923110-40c7-415e-a6f8-9beb4f7e5cd5" />


**Related issue(s)**:

Fixes #

**Notes for reviewer**:
Use transaction testnet [https://hashscan.io/testnet/transaction/1708535267.539829003](1708535267.539829003)

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
