### PR TITLE
feat: Contract Details now decodes constructor when contract is verified

### DIFF
--- a/src/components/values/FunctionError.vue
+++ b/src/components/values/FunctionError.vue
@@ -20,7 +20,7 @@
       </Property>
 
       <template v-for="arg in errorInputs" :key="arg.name">
-        <Property :custom-nb-col-class="customNbColClass">
+        <Property :custom-nb-col-class="customNbColClass" :keep-case="true">
           <template #name>
             <span style="padding-left: 16px;">{{ arg.name != "" ? arg.name : "message" }}</span>
           </template>

--- a/src/components/values/FunctionInput.vue
+++ b/src/components/values/FunctionInput.vue
@@ -20,7 +20,7 @@
       <div class="h-sub-section">Input</div>
 
       <template v-for="arg in inputs" :key="arg.name">
-        <Property :custom-nb-col-class="customNbColClass">
+        <Property :custom-nb-col-class="customNbColClass" :keep-case="true">
           <template #name>
             <span style="padding-left: 16px;">{{ arg.name }}</span>
           </template>

--- a/src/components/values/FunctionResult.vue
+++ b/src/components/values/FunctionResult.vue
@@ -11,7 +11,7 @@
     <div class="h-sub-section">Output</div>
 
     <template v-for="result in outputs" :key="result.name">
-      <Property :custom-nb-col-class="customNbColClass">
+      <Property :custom-nb-col-class="customNbColClass" :keep-case="true">
         <template v-slot:name>
           <span style="padding-left: 16px;">{{ result.name }}</span>
         </template>

--- a/src/components/values/SignatureValue.vue
+++ b/src/components/values/SignatureValue.vue
@@ -5,8 +5,8 @@
 <!-- --------------------------------------------------------------------------------------------------------------- -->
 
 <template>
-  <div v-if="functionHash">
-    <HexaDumpValue :byte-string="functionHash" show-none/>
+  <div v-if="signature">
+    <HexaDumpValue v-if="functionHash" :byte-string="functionHash" show-none/>
     <div class="signature">
       <div class="h-is-extra-text h-should-wrap">{{ signature }}</div>
       <Tooltip v-if="is4byteSignature"

--- a/tests/unit/contract/ContractResult.spec.ts
+++ b/tests/unit/contract/ContractResult.spec.ts
@@ -63,11 +63,11 @@ describe("ContractResult.vue", () => {
 
         expect(fetchGetURLs(mock)).toStrictEqual([
             "api/v1/contracts/results",
+            "api/v1/transactions",
             "api/v1/network/fees",
             "api/v1/contracts/" + SAMPLE_CONTRACT_RESULT_DETAILS.contract_id + "/results/1646025151.667604000",
             "api/v1/contracts/0.0.846260",
             "api/v1/contracts/" + SAMPLE_CONTRACT_RESULT_DETAILS.contract_id,
-            "api/v1/transactions",
             "api/v1/contracts/" + SAMPLE_CONTRACT_RESULT_DETAILS.logs[1].contract_id,
             "api/v1/contracts/" + SAMPLE_CONTRACT_RESULT_DETAILS.from,
             "api/v1/contracts/" + SAMPLE_CONTRACT_RESULT_DETAILS.to,
@@ -132,11 +132,11 @@ describe("ContractResult.vue", () => {
 
         expect(fetchGetURLs(mock)).toStrictEqual([
             "api/v1/contracts/results",
+            "api/v1/transactions",
             "api/v1/network/fees",
             "api/v1/contracts/" + SAMPLE_REVERT_CONTRACT_RESULT_DETAILS.contract_id + "/results/1677085141.263832358",
             "api/v1/contracts/0.0.1466",
             "api/v1/contracts/" + SAMPLE_REVERT_CONTRACT_RESULT_DETAILS.contract_id,
-            "api/v1/transactions",
             "api/v1/contracts/" + SAMPLE_REVERT_CONTRACT_RESULT_DETAILS.from,
             "api/v1/contracts/" + SAMPLE_REVERT_CONTRACT_RESULT_DETAILS.to,
             "api/v1/tokens/0.0.1466",
@@ -192,11 +192,11 @@ describe("ContractResult.vue", () => {
 
         expect(fetchGetURLs(mock)).toStrictEqual([
             "api/v1/contracts/results",
+            "api/v1/transactions",
             "api/v1/network/fees",
             "api/v1/contracts/" + SAMPLE_REVERT_CONTRACT_RESULT_DETAILS_WITH_TRACES.contract_id + "/results/1677504382.107973330",
             "api/v1/contracts/0.0.8942",
             "api/v1/contracts/results/" + SAMPLE_REVERT_CONTRACT_RESULT_DETAILS_WITH_TRACES.hash + "/actions?limit=100",
-            "api/v1/transactions",
             "api/v1/contracts/" + SAMPLE_REVERT_CONTRACT_RESULT_DETAILS_WITH_TRACES.state_changes[0].contract_id,
             "api/v1/contracts/" + SAMPLE_REVERT_CONTRACT_RESULT_DETAILS_WITH_TRACES.state_changes[3].contract_id,
             // "api/v1/contracts/" + SAMPLE_REVERT_CONTRACT_RESULT_DETAILS_WITH_TRACES.state_changes[9].contract_id,

--- a/tests/unit/transaction/TransactionDetails.spec.ts
+++ b/tests/unit/transaction/TransactionDetails.spec.ts
@@ -361,6 +361,7 @@ describe("TransactionDetails.vue", () => {
             "api/v1/contracts/results/" + SAMPLE_TRANSACTION.transaction_id,
             "api/v1/contracts/" + SAMPLE_TRANSACTION.transfers[0].account,
             "api/v1/contracts/results",
+            "api/v1/transactions",
             "api/v1/network/fees",
             "api/v1/contracts/" + SAMPLE_TRANSACTION.transfers[2].account,
             "api/v1/contracts/" + SAMPLE_TRANSACTION.transfers[1].account,

--- a/tests/unit/utils/analyzer/ContractResultAnalyzer.spec.ts
+++ b/tests/unit/utils/analyzer/ContractResultAnalyzer.spec.ts
@@ -101,6 +101,7 @@ describe("ContractResultAnalyzer.spec.ts", () => {
         // console.log(JSON.stringify(fetchGetURLs(mock), null, "  "))
         expect(fetchGetURLs(mock)).toStrictEqual([
             "api/v1/contracts/results",
+            "api/v1/transactions",
             "api/v1/contracts/0.0.6810663/results/1704186823.658538003",
             "api/v1/contracts/0.0.6810663",
             sourcifyURL + "files/any/295/0x06a50d1f642cA50284EFb59988AF9b60683FAD3F",
@@ -198,6 +199,7 @@ describe("ContractResultAnalyzer.spec.ts", () => {
         // console.log(JSON.stringify(fetchGetURLs(mock), null, "  "))
         expect(fetchGetURLs(mock)).toStrictEqual([
             "api/v1/contracts/results",
+            "api/v1/transactions",
             "api/v1/contracts/0.0.6810663/results/1704186823.658538003",
             "api/v1/contracts/0.0.6810663",
             sourcifyURL + "files/any/295/0x06a50d1f642cA50284EFb59988AF9b60683FAD3F",
@@ -271,7 +273,7 @@ describe("ContractResultAnalyzer.spec.ts", () => {
         expect(analyzer.contractType.value).toBeNull()
         expect(analyzer.contractResult.value).toStrictEqual(CONTRACT_RESULT_DETAILS_HTS)
         expect(analyzer.functionCallAnalyzer.functionHash.value).toBe("0x49146bde")
-        expect(analyzer.functionCallAnalyzer.signature.value).toBe("associateToken(address,address)")
+        expect(analyzer.functionCallAnalyzer.signature.value).toBe("function associateToken(address account, address token) returns (int64 responseCode)")
         expect(analyzer.functionCallAnalyzer.is4byteSignature.value).toBe(false)
 
         // 4) unmount
@@ -292,6 +294,7 @@ describe("ContractResultAnalyzer.spec.ts", () => {
         // 5) check history
         expect(fetchGetURLs(mock)).toStrictEqual([
             "api/v1/contracts/results",
+            "api/v1/transactions",
             "api/v1/contracts/results/0x4f0887dcc3c3f23ce2e80a2e3c3bfa246d488698d5e0cc17c76ef13262580d73",
         ])
 

--- a/tests/unit/utils/analyzer/FunctionCallAnalyzer.spec.ts
+++ b/tests/unit/utils/analyzer/FunctionCallAnalyzer.spec.ts
@@ -66,7 +66,7 @@ describe("FunctionCallAnalyzer.spec.ts", () => {
         await vi.dynamicImportSettled()
         expect(fetchGetURLs(mock)).toStrictEqual([])
         expect(functionCallAnalyzer.functionHash.value).toBe("0x49146bde")
-        expect(functionCallAnalyzer.signature.value).toBe("associateToken(address,address)")
+        expect(functionCallAnalyzer.signature.value).toBe("function associateToken(address account, address token) returns (int64 responseCode)")
         expect(functionCallAnalyzer.inputs.value).toStrictEqual([
             new NameTypeValue("account", "address", "0x845b706151aEd537b1FD81c1Ea4EA03920097ABD", null, null),
             new NameTypeValue("token", "address", "0x0000000000000000000000000000000002E6Ae09", null, null),
@@ -90,7 +90,7 @@ describe("FunctionCallAnalyzer.spec.ts", () => {
         await flushPromises()
         expect(fetchGetURLs(mock)).toStrictEqual([])
         expect(functionCallAnalyzer.functionHash.value).toBe("0x618dc65e")
-        expect(functionCallAnalyzer.signature.value).toBe("redirectForToken(address,bytes)")
+        expect(functionCallAnalyzer.signature.value).toBe("function redirectForToken(address token, bytes encodedFunctionSelector) returns (uint256 balanceOf)")
         expect(functionCallAnalyzer.inputs.value).toEqual([
             {
                 name: 'token',
@@ -133,7 +133,7 @@ describe("FunctionCallAnalyzer.spec.ts", () => {
         await flushPromises()
         expect(fetchGetURLs(mock)).toStrictEqual([])
         expect(functionCallAnalyzer.functionHash.value).toBe("0x49146bde")
-        expect(functionCallAnalyzer.signature.value).toBe("associateToken(address,address)")
+        expect(functionCallAnalyzer.signature.value).toBe("function associateToken(address account, address token) returns (int64 responseCode)")
         expect(functionCallAnalyzer.inputs.value).toStrictEqual([
             new NameTypeValue("account", "address", "0x845b706151aEd537b1FD81c1Ea4EA03920097ABD", null, null),
             new NameTypeValue("token", "address", "0x0000000000000000000000000000000002E6Ae09", null, null),
@@ -230,7 +230,7 @@ describe("FunctionCallAnalyzer.spec.ts", () => {
             "http://localhost:3000/files/any/295/0x00000000000000000000000000000000002E7A5D",
         ])
         expect(functionCallAnalyzer.functionHash.value).toBe("0xf305d719")
-        expect(functionCallAnalyzer.signature.value).toBe("addLiquidityETH(address,uint256,uint256,uint256,address,uint256)")
+        expect(functionCallAnalyzer.signature.value).toBe("function addLiquidityETH(address token, uint256 amountTokenDesired, uint256 amountTokenMin, uint256 amountETHMin, address to, uint256 deadline) payable returns (uint256 amountToken, uint256 amountETH, uint256 liquidity)")
         expect(functionCallAnalyzer.inputs.value).toStrictEqual([
             new NameTypeValue("token", "address", "0x000000000000000000000000000000000022D6de", null, null),
             new NameTypeValue("amountTokenDesired", "uint256", 1445100000000n, null, null),
@@ -338,7 +338,7 @@ describe("FunctionCallAnalyzer.spec.ts", () => {
             "http://localhost:3000/files/any/295/0x00000000000000000000000000000000002E7A5D",
         ])
         expect(functionCallAnalyzer.functionHash.value).toBe("0xf305d719")
-        expect(functionCallAnalyzer.signature.value).toBe("addLiquidityETH(address,uint256,uint256,uint256,address,uint256)")
+        expect(functionCallAnalyzer.signature.value).toBe("function addLiquidityETH(address token, uint256 amountTokenDesired, uint256 amountTokenMin, uint256 amountETHMin, address to, uint256 deadline) payable returns (uint256 amountToken, uint256 amountETH, uint256 liquidity)")
         expect(functionCallAnalyzer.inputs.value).toStrictEqual([
             new NameTypeValue("token", "address", "0x000000000000000000000000000000000022D6de", null, null),
             new NameTypeValue("amountTokenDesired", "uint256", 1445100000000n, null, null),
@@ -443,7 +443,7 @@ describe("FunctionCallAnalyzer.spec.ts", () => {
             "https://www.4byte.directory/api/v1/signatures/?format=json&hex_signature=0xf305d719",
         ])
         expect(functionCallAnalyzer.functionHash.value).toBe("0xf305d719")
-        expect(functionCallAnalyzer.signature.value).toBe("addLiquidityETH(address,uint256,uint256,uint256,address,uint256)")
+        expect(functionCallAnalyzer.signature.value).toBe("function addLiquidityETH(address, uint256, uint256, uint256, address, uint256)")
         expect(functionCallAnalyzer.inputs.value).toStrictEqual([
             new NameTypeValue("", "address", "0x000000000000000000000000000000000022D6de", null, null),
             new NameTypeValue("", "uint256", 1445100000000n, null, null),
@@ -542,7 +542,7 @@ describe("FunctionCallAnalyzer.spec.ts", () => {
         await vi.dynamicImportSettled()
         expect(fetchGetURLs(mock)).toStrictEqual([])
         expect(functionCallAnalyzer.functionHash.value).toBe("0x618dc65e")
-        expect(functionCallAnalyzer.signature.value).toBe("redirectForToken(address,bytes)")
+        expect(functionCallAnalyzer.signature.value).toBe("function redirectForToken(address token, bytes encodedFunctionSelector) returns (bool approve)")
         expect(functionCallAnalyzer.inputs.value).toStrictEqual([
             new NameTypeValue("token", "address", "0x0000000000000000000000000000000000163b5a", null, null),
             new NameTypeValue("encodedFunctionSelector", "bytes", "0x095ea7b300000000000000000000000000000000000000000000000000000000003c437a0000000000000000000000000000000000000000000000008ac7230489e80000", null, null)


### PR DESCRIPTION
**Description**:

Changes below enhance contract decoding logic to decode constructors parameters (when contract is verified).
They also include unit test updates.

Before:
<img width="720" alt="image" src="https://github.com/user-attachments/assets/07138d8f-2b17-4a1a-ba18-06efcf839df5" />

After:
<img width="709" alt="image" src="https://github.com/user-attachments/assets/12ca57a5-a714-46fc-8d0d-502b3ee92757" />

**Notes for reviewer**:

Use testnet transaction [1708535265.079646164](https://hashscan.io/testnet/transaction/1708535265.079646164).

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
