### PR TITLE
fix: layout of ASSOCIATED TOKENS value in the details of a TOKEN ASSOCIATE transaction

### DIFF
--- a/src/pages/TransactionDetails.vue
+++ b/src/pages/TransactionDetails.vue
@@ -236,9 +236,7 @@
         <Property v-if="transaction?.scheduled===true && schedulingTransaction" id="scheduleCreateTransaction">
           <template #name>Schedule Create Transaction</template>
           <template #value>
-            <div class="multi-item-property-value">
-              <TransactionLink :transactionLoc="schedulingTransaction?.consensus_timestamp ?? undefined"/>
-            </div>
+            <TransactionLink :transactionLoc="schedulingTransaction?.consensus_timestamp ?? undefined"/>
           </template>
         </Property>
         <template v-if="batchKey">

--- a/src/pages/TransactionDetails.vue
+++ b/src/pages/TransactionDetails.vue
@@ -147,7 +147,9 @@
             Associated Token<span v-if="associatedTokens.length > 1">s</span>
           </template>
           <template #value>
-            <TokenLink v-for="t of associatedTokens" :key="t" :token-id="t" :show-extra="true"/>
+            <div class="multi-item-property-value" style="column-gap: 12px">
+              <TokenLink v-for="t of associatedTokens" :key="t" :token-id="t" :show-extra="true"/>
+            </div>
           </template>
         </Property>
         <Property v-if="systemContract" id="entityId">
@@ -553,8 +555,15 @@ const innerTransactions = transactionGroupAnalyzer.innerTransactions
 div.multi-item-property-value {
   align-items: center;
   display: flex;
-  gap: 8px;
   flex-wrap: wrap;
+  column-gap: 8px;
+  justify-content: flex-end;
+}
+
+@media (min-width: 768px) {
+  div.multi-item-property-value {
+    justify-content: flex-start;
+  }
 }
 
 </style>


### PR DESCRIPTION
**Description**:

Fix spacing between items when there are several tokens associated in the same transaction.

**Before**:
<img width="1163" alt="Screenshot 2025-05-27 at 10 44 02" src="https://github.com/user-attachments/assets/3f3dcc17-bc1f-4df2-84b1-1517bd817e60" />

**After**:
<img width="1163" alt="Screenshot 2025-05-27 at 11 22 32" src="https://github.com/user-attachments/assets/f3f835a8-a674-4a2f-b3b9-cb52492f7ee0" />