### PR TITLE
fix: double scroll bar in Contract Bytecode section

### DIFF
--- a/src/components/values/ByteCodeValue.vue
+++ b/src/components/values/ByteCodeValue.vue
@@ -7,7 +7,7 @@
 <template>
 
   <div v-if="nonNullValue" id="bytecode">
-    <HexaDumpValue :byte-string="textValue" :copyable="false"/>
+    <HexaDumpValue :byte-string="textValue" :copyable="false" :scroll-bar="false"/>
   </div>
 
   <span v-else-if="initialLoading"/>

--- a/src/components/values/HexaDumpValue.vue
+++ b/src/components/values/HexaDumpValue.vue
@@ -8,7 +8,7 @@
   <Copyable v-if="normByteString"
             :content-to-copy="'0x' + normByteString" :enable-copy="isCopyEnabled">
     <template #content>
-      <div class="hexa-dump-value">
+      <div class="hexa-dump-value" :class="{'scrollbar': props.scrollBar}">
         {{ flow(isMediumScreen ? wordWrapMedium : wordWrapSmall) }}
       </div>
     </template>
@@ -49,6 +49,10 @@ const props = defineProps({
     default: null
   },
   copyable: {
+    type: Boolean,
+    default: true
+  },
+  scrollBar: {
     type: Boolean,
     default: true
   }
@@ -104,8 +108,11 @@ div.hexa-dump-value {
   color: var(--text-secondary);
   font-family: var(--font-family-monospace), sans-serif;
   max-height: 400px;
-  overflow-y: auto;
   word-break: break-word;
+}
+
+div.hexa-dump-value.scrollbar {
+  overflow-y: auto;
 }
 
 </style>


### PR DESCRIPTION
**Description**:

Add prop to HexaDumpValue allowing to suppress its scrollbar when used in a code box context which already provides one.

**Related issue(s)**:

Fixes #1939 
