### PR TITLE
fix: ability for sections to be non-collapsible

### DIFF
--- a/src/components/DashboardCardV2.vue
+++ b/src/components/DashboardCardV2.vue
@@ -15,8 +15,10 @@
         </div>
         <div v-if="isMediumScreen" class="right-header">
           <slot name="right-control" v-if="!isCollapsed"/>
-          <img v-if="isCollapsed" alt="Expand" @click="toggleCollapsed" :src="arrowDownURL">
-          <img v-else alt="Collapse" @click="toggleCollapsed" :src="arrowUpURL">
+          <template v-if="isCollapsible">
+            <img v-if="isCollapsed" id="expandIcon" alt="Expand" @click="toggleCollapsed" :src="arrowDownURL">
+            <img v-else id="collapseIcon" alt="Collapse" @click="toggleCollapsed" :src="arrowUpURL">
+          </template>
         </div>
       </div>
       <div v-if="!isMediumScreen && !isCollapsed" class="wrapped-controls">

--- a/tests/unit/values/DashboardCard.spec.ts
+++ b/tests/unit/values/DashboardCard.spec.ts
@@ -55,5 +55,46 @@ describe("DashboardCardV2.vue", () => {
         wrapper.unmount()
     })
 
+    it("should be collapsible", async () => {
+
+        const sampleTitle = "ZeTitle"
+        const sampleContent = "ZeContent"
+
+        const wrapper = mount(DashboardCardV2, {
+            slots: {
+                title: sampleTitle,
+                content: sampleContent,
+            },
+            props: {
+                collapsibleKey: 'ZeKey'
+            },
+        });
+
+        expect(wrapper.text()).toContain(sampleTitle)
+        expect(wrapper.text()).toContain(sampleContent)
+        expect(wrapper.find('#collapseIcon').exists()).toBe(true)
+        expect(wrapper.find('#expandIcon').exists()).toBe(false)
+        wrapper.unmount()
+    })
+
+    it("should not be collapsible", async () => {
+
+        const sampleTitle = "ZeTitle"
+        const sampleContent = "ZeContent"
+
+        const wrapper = mount(DashboardCardV2, {
+            slots: {
+                title: sampleTitle,
+                content: sampleContent,
+            },
+            props: {},
+        });
+
+        expect(wrapper.text()).toContain(sampleTitle)
+        expect(wrapper.text()).toContain(sampleContent)
+        expect(wrapper.find('#collapseIcon').exists()).toBe(false)
+        expect(wrapper.find('#expandIcon').exists()).toBe(false)
+        wrapper.unmount()
+    })
 })
 


### PR DESCRIPTION
**Description**:

- Restore ability for `DashboardCardV2` to be non-collapsible -- which is requested by the absence of prop `collapsibleKey`.
- Add unit test cases for this.
