### PR TITLE
chore: fix ContractNavigation e2e test.

### DIFF
--- a/tests/e2e/specs/ContractNavigation.cy.ts
+++ b/tests/e2e/specs/ContractNavigation.cy.ts
@@ -37,9 +37,6 @@ describe('Contract Navigation', () => {
         cy.contains('CONTRACT CALL')
         cy.contains(contractId)
 
-        cy.go('back')
-        cy.url().should('include', '/mainnet/contract/' + contractId)
-
         cy.get('#blockNumber')
             .find('a')
             .click()


### PR DESCRIPTION
**Description**:

Fix ContractNavigation.cy.ts e2e which is intermittently failing on CI. The test logic is in fact wrong and the surprising thing is actually that it was not always failing.
