### PR TITLE
Fix: scrollbars in bytecode values

### DIFF
--- a/src/components/values/ByteCodeValue.vue
+++ b/src/components/values/ByteCodeValue.vue
@@ -7,7 +7,7 @@
 <template>
 
   <div v-if="nonNullValue" id="bytecode">
-    <HexaDumpValue :byte-string="textValue" :copyable="false" :scroll-bar="false"/>
+    <HexaDumpValue :byte-string="textValue" :copyable="false" :scroll-bar="props.scrollBar"/>
   </div>
 
   <span v-else-if="initialLoading"/>
@@ -28,6 +28,10 @@ import HexaDumpValue from "@/components/values/HexaDumpValue.vue";
 
 const props = defineProps({
   byteCode: String,
+  scrollBar: {
+    type: Boolean,
+    default: true
+  }
 })
 
 const textValue = ref(props.byteCode)

--- a/src/components/values/ByteCodeValue.vue
+++ b/src/components/values/ByteCodeValue.vue
@@ -20,34 +20,22 @@
 <!--                                                      SCRIPT                                                     -->
 <!-- --------------------------------------------------------------------------------------------------------------- -->
 
-<script lang="ts">
+<script setup lang="ts">
 
-import {computed, defineComponent, inject, ref, watch} from 'vue';
+import {computed, inject, ref, watch} from 'vue';
 import {initialLoadingKey} from "@/AppKeys";
 import HexaDumpValue from "@/components/values/HexaDumpValue.vue";
 
-export default defineComponent({
-  name: 'ByteCodeValue',
-  components: {HexaDumpValue},
+const props = defineProps({
+  byteCode: String,
+})
 
-  props: {
-    byteCode: String,
-  },
-
-  setup(props) {
-    const textValue = ref(props.byteCode)
-    watch(() => props.byteCode, () => {
-      textValue.value = props.byteCode
-    })
-    const nonNullValue = computed(() => props.byteCode != undefined && props.byteCode != '0x')
-    const initialLoading = inject(initialLoadingKey, ref(false))
-    return {
-      textValue,
-      nonNullValue,
-      initialLoading
-    }
-  }
-});
+const textValue = ref(props.byteCode)
+watch(() => props.byteCode, () => {
+  textValue.value = props.byteCode
+})
+const nonNullValue = computed(() => props.byteCode != undefined && props.byteCode != '0x')
+const initialLoading = inject(initialLoadingKey, ref(false))
 
 </script>
 

--- a/src/components/values/ContractByteCodeValue.vue
+++ b/src/components/values/ContractByteCodeValue.vue
@@ -13,6 +13,7 @@
       <ByteCodeValue
           class="h-code-box h-code-source"
           :byte-code="props.byteCode ?? undefined"
+          :scroll-bar="false"
       />
     </div>
 


### PR DESCRIPTION
**Description**:

Restore scrollbar by default in `BytecodeValue` such that scrollbars are present in all occurrences but the _Runtime Bytecode_ section, which already has one due to its `h-code-box` style.
