### PR TITLE
chore: swapping some declarations between router.ts and RouteManager.ts

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -30,8 +30,8 @@ import {AppStorage} from "@/AppStorage";
 import {LARGE_BREAKPOINT, MEDIUM_BREAKPOINT, SMALL_BREAKPOINT, XLARGE_BREAKPOINT} from "@/BreakPoints";
 import {CoreConfig} from "@/config/CoreConfig";
 import {NetworkConfig} from "@/config/NetworkConfig";
-import {walletManager} from "@/router.ts";
 import {ThemeController} from "@/components/ThemeController.ts";
+import {walletManager} from "@/utils/RouteManager.ts";
 
 const props = defineProps({
   "coreConfig": {

--- a/src/components/MirrorLink.vue
+++ b/src/components/MirrorLink.vue
@@ -21,7 +21,8 @@
 <script setup lang="ts">
 import {ArrowRight} from "lucide-vue-next";
 import {computed, inject, PropType} from "vue";
-import {routeManager} from "@/router.ts";
+
+import {routeManager} from "@/utils/RouteManager.ts";
 
 const props = defineProps({
   network: String,

--- a/src/components/account/AccountCreatedContractsTable.vue
+++ b/src/components/account/AccountCreatedContractsTable.vue
@@ -68,12 +68,12 @@ import {onBeforeUnmount, onMounted, PropType} from 'vue';
 import {OTable, OTableColumn} from "@oruga-ui/oruga-next";
 import {Transaction} from "@/schemas/MirrorNodeSchemas";
 import TimestampValue from "@/components/values/TimestampValue.vue";
-import {routeManager} from "@/router";
 import {ORUGA_MOBILE_BREAKPOINT} from "@/BreakPoints";
 import EmptyTable from "@/components/EmptyTable.vue";
 import {TransactionTableController} from "@/components/transaction/TransactionTableController";
 import ContractName from "@/components/values/ContractName.vue";
 import TablePageSize from "@/components/transaction/TablePageSize.vue";
+import {routeManager} from "@/utils/RouteManager.ts";
 
 const props = defineProps({
   controller: {

--- a/src/components/account/AccountTable.vue
+++ b/src/components/account/AccountTable.vue
@@ -85,7 +85,6 @@
 import {PropType} from 'vue';
 import {OTable, OTableColumn} from "@oruga-ui/oruga-next";
 import {AccountInfo} from "@/schemas/MirrorNodeSchemas";
-import {routeManager} from "@/router";
 import HbarAmount from "@/components/values/HbarAmount.vue";
 import BlobValue from "@/components/values/BlobValue.vue";
 import TimestampValue from "@/components/values/TimestampValue.vue";
@@ -95,6 +94,7 @@ import EmptyTable from "@/components/EmptyTable.vue";
 import {AccountTableController} from "@/components/account/AccountTableController";
 import AccountIOL from "@/components/values/link/AccountIOL.vue";
 import TablePageSize from "@/components/transaction/TablePageSize.vue";
+import {routeManager} from "@/utils/RouteManager.ts";
 
 const props = defineProps({
   controller: {

--- a/src/components/account/FungibleTable.vue
+++ b/src/components/account/FungibleTable.vue
@@ -80,11 +80,11 @@ import {OTable, OTableColumn} from "@oruga-ui/oruga-next";
 import {Nft, Token} from "@/schemas/MirrorNodeSchemas";
 import {ORUGA_MOBILE_BREAKPOINT} from "@/BreakPoints";
 import EmptyTable from "@/components/EmptyTable.vue";
-import {routeManager} from "@/router";
 import TokenCell, {TokenCellItem} from "@/components/token/TokenCell.vue";
 import TablePageSize from "@/components/transaction/TablePageSize.vue";
 import {FungibleTableController} from "@/components/account/FungibleTableController";
 import TokenIOL from "@/components/values/link/TokenIOL.vue";
+import {routeManager} from "@/utils/RouteManager.ts";
 
 const props = defineProps({
   controller: {

--- a/src/components/account/NftsTable.vue
+++ b/src/components/account/NftsTable.vue
@@ -92,13 +92,13 @@ import {PropType, watch} from 'vue';
 import {OTable, OTableColumn} from "@oruga-ui/oruga-next";
 import {Nft, Token} from "@/schemas/MirrorNodeSchemas";
 import EmptyTable from "@/components/EmptyTable.vue";
-import {routeManager} from "@/router";
 import NftCell, {NftCellItem} from "@/components/token/NftCell.vue";
 import {NftsTableController} from "@/components/account/NftsTableController";
 import TokenCell, {TokenCellItem} from "@/components/token/TokenCell.vue";
 import TablePageSize from "@/components/transaction/TablePageSize.vue";
 import TokenIOL from "@/components/values/link/TokenIOL.vue";
 import {ORUGA_MOBILE_BREAKPOINT} from "@/BreakPoints";
+import {routeManager} from "@/utils/RouteManager.ts";
 
 const props = defineProps({
   controller: {

--- a/src/components/account/PendingFungibleAirdropTable.vue
+++ b/src/components/account/PendingFungibleAirdropTable.vue
@@ -88,13 +88,13 @@ import {OTable, OTableColumn} from "@oruga-ui/oruga-next";
 import {TokenAirdrop} from "@/schemas/MirrorNodeSchemas";
 import {ORUGA_MOBILE_BREAKPOINT} from "@/BreakPoints";
 import EmptyTable from "@/components/EmptyTable.vue";
-import {routeManager} from "@/router";
 import TokenCell, {TokenCellItem} from "@/components/token/TokenCell.vue";
 import TablePageSize from "@/components/transaction/TablePageSize.vue";
 import {PendingAirdropTableController} from "@/components/account/PendingAirdropTableController";
 import TokenAmount from "@/components/values/TokenAmount.vue";
 import TokenIOL from "@/components/values/link/TokenIOL.vue";
 import TimestampValue from "@/components/values/TimestampValue.vue";
+import {routeManager} from "@/utils/RouteManager.ts";
 
 const props = defineProps({
   controller: {

--- a/src/components/account/PendingNftAirdropTable.vue
+++ b/src/components/account/PendingNftAirdropTable.vue
@@ -94,13 +94,13 @@ import {OTable, OTableColumn} from "@oruga-ui/oruga-next";
 import {TokenAirdrop} from "@/schemas/MirrorNodeSchemas";
 import {ORUGA_MOBILE_BREAKPOINT} from "@/BreakPoints";
 import EmptyTable from "@/components/EmptyTable.vue";
-import {routeManager} from "@/router";
 import TokenCell, {TokenCellItem} from "@/components/token/TokenCell.vue";
 import TablePageSize from "@/components/transaction/TablePageSize.vue";
 import {PendingAirdropTableController} from "@/components/account/PendingAirdropTableController";
 import NftCell, {NftCellItem} from "@/components/token/NftCell.vue";
 import TokenIOL from "@/components/values/link/TokenIOL.vue";
 import TimestampValue from "@/components/values/TimestampValue.vue";
+import {routeManager} from "@/utils/RouteManager.ts";
 
 const props = defineProps({
   controller: {

--- a/src/components/account/VerifiedContractsTable.vue
+++ b/src/components/account/VerifiedContractsTable.vue
@@ -60,13 +60,13 @@ import {computed, onBeforeUnmount, onMounted, PropType} from 'vue';
 import {OTable, OTableColumn} from "@oruga-ui/oruga-next";
 import {Contract} from "@/schemas/MirrorNodeSchemas";
 import TimestampValue from "@/components/values/TimestampValue.vue";
-import {routeManager} from "@/router";
 import {ORUGA_MOBILE_BREAKPOINT} from "@/BreakPoints";
 import EmptyTable from "@/components/EmptyTable.vue";
 import ContractName from "@/components/values/ContractName.vue";
 import {VerifiedContractsController} from "@/components/contract/VerifiedContractsController";
 import TablePageSize from "@/components/transaction/TablePageSize.vue";
 import ContractIOL from "@/components/values/link/ContractIOL.vue";
+import {routeManager} from "@/utils/RouteManager.ts";
 
 const props = defineProps({
   controller: {

--- a/src/components/allowances/AllowancesSection.vue
+++ b/src/components/allowances/AllowancesSection.vue
@@ -97,7 +97,6 @@
 <script setup lang="ts">
 
 import {computed, inject, onBeforeUnmount, onMounted, ref, watch} from 'vue';
-import router, {walletManager} from "@/router";
 import {HbarAllowanceTableController} from "@/components/allowances/HbarAllowanceTableController";
 import {TokenAllowanceTableController} from "@/components/allowances/TokenAllowanceTableController";
 import HbarAllowanceTable from "@/components/allowances/HbarAllowanceTable.vue";
@@ -117,6 +116,7 @@ import {ButtonSize} from "@/dialogs/core/DialogUtils.ts";
 import UpdateCryptoAllowanceDialog from "@/dialogs/allowance/UpdateCryptoAllowanceDialog.vue";
 import UpdateTokenAllowanceDialog from "@/dialogs/allowance/UpdateTokenAllowanceDialog.vue";
 import DeleteNftAllowanceDialog from "@/dialogs/allowance/DeleteNftAllowanceDialog.vue";
+import router, {walletManager} from "@/utils/RouteManager.ts";
 
 const props = defineProps({
   accountId: String,

--- a/src/components/allowances/HbarAllowanceTable.vue
+++ b/src/components/allowances/HbarAllowanceTable.vue
@@ -71,8 +71,8 @@ import TimestampValue from "@/components/values/TimestampValue.vue";
 import EmptyTable from "@/components/EmptyTable.vue";
 import AccountLink from "@/components/values/link/AccountLink.vue";
 import HbarAmount from "@/components/values/HbarAmount.vue";
-import {walletManager} from "@/router";
 import TablePageSize from "@/components/transaction/TablePageSize.vue";
+import {walletManager} from "@/utils/RouteManager.ts";
 
 const emit = defineEmits(["editAllowance"])
 

--- a/src/components/allowances/NftAllSerialsAllowanceTable.vue
+++ b/src/components/allowances/NftAllSerialsAllowanceTable.vue
@@ -76,11 +76,11 @@ import TimestampValue from "@/components/values/TimestampValue.vue";
 import EmptyTable from "@/components/EmptyTable.vue";
 import AccountLink from "@/components/values/link/AccountLink.vue";
 import TokenLink from "@/components/values/link/TokenLink.vue";
-import {walletManager} from "@/router";
 import InfoTooltip from "@/components/InfoTooltip.vue";
 import {NftAllSerialsAllowanceTableController} from "@/components/allowances/NftAllSerialsAllowanceTableController";
 import {isValidAssociation} from "@/schemas/MirrorNodeUtils.ts";
 import TablePageSize from "@/components/transaction/TablePageSize.vue";
+import {walletManager} from "@/utils/RouteManager.ts";
 
 interface DisplayedNftAllowance extends NftAllowance {
   isEditable: boolean

--- a/src/components/allowances/NftAllowanceTable.vue
+++ b/src/components/allowances/NftAllowanceTable.vue
@@ -77,9 +77,9 @@ import TimestampValue from "@/components/values/TimestampValue.vue";
 import EmptyTable from "@/components/EmptyTable.vue";
 import AccountLink from "@/components/values/link/AccountLink.vue";
 import TokenLink from "@/components/values/link/TokenLink.vue";
-import {walletManager} from "@/router";
 import {NftAllowanceTableController} from "@/components/allowances/NftAllowanceTableController";
 import TablePageSize from "@/components/transaction/TablePageSize.vue";
+import {walletManager} from "@/utils/RouteManager.ts";
 
 const emit = defineEmits(["deleteAllowance"])
 

--- a/src/components/allowances/TokenAllowanceTable.vue
+++ b/src/components/allowances/TokenAllowanceTable.vue
@@ -83,9 +83,9 @@ import AccountLink from "@/components/values/link/AccountLink.vue";
 import {TokenAllowanceTableController} from "@/components/allowances/TokenAllowanceTableController";
 import TokenAmount from "@/components/values/TokenAmount.vue";
 import TokenLink from "@/components/values/link/TokenLink.vue";
-import {walletManager} from "@/router";
 import InfoTooltip from "@/components/InfoTooltip.vue";
 import TablePageSize from "@/components/transaction/TablePageSize.vue";
+import {walletManager} from "@/utils/RouteManager.ts";
 
 interface DisplayedTokenAllowance extends TokenAllowance {
   isEditable: boolean

--- a/src/components/block/BlockTable.vue
+++ b/src/components/block/BlockTable.vue
@@ -61,13 +61,13 @@
 import {PropType} from 'vue';
 import {OTable, OTableColumn} from "@oruga-ui/oruga-next";
 import {Block} from '@/schemas/MirrorNodeSchemas.ts';
-import {routeManager} from "@/router";
 import TimestampValue from "@/components/values/TimestampValue.vue";
 import {ORUGA_MOBILE_BREAKPOINT} from "@/BreakPoints";
 import EmptyTable from "@/components/EmptyTable.vue";
 import PlainAmount from "@/components/values/PlainAmount.vue";
 import {BlockTableController} from "@/components/block/BlockTableController";
 import TablePageSize from "@/components/transaction/TablePageSize.vue";
+import {routeManager} from "@/utils/RouteManager.ts";
 
 const props = defineProps({
   controller: {

--- a/src/components/block/BlockTransactionTable.vue
+++ b/src/components/block/BlockTransactionTable.vue
@@ -70,13 +70,13 @@ import {computed, PropType, ref} from 'vue';
 import {OTable, OTableColumn} from "@oruga-ui/oruga-next";
 import {Transaction} from '@/schemas/MirrorNodeSchemas.ts';
 import {makeTypeLabel} from "@/utils/TransactionTools";
-import {routeManager} from "@/router";
 import TimestampValue from "@/components/values/TimestampValue.vue";
 import TransactionLabel from "@/components/values/TransactionLabel.vue";
 import {ORUGA_MOBILE_BREAKPOINT} from "@/BreakPoints";
 import EmptyTable from "@/components/EmptyTable.vue";
 import TransactionSummary from "@/components/transaction/TransactionSummary.vue";
 import TablePageSize from "@/components/transaction/TablePageSize.vue";
+import {routeManager} from "@/utils/RouteManager.ts";
 
 const props = defineProps({
   narrowed: Boolean,

--- a/src/components/contract/ContractByteCodeSection.vue
+++ b/src/components/contract/ContractByteCodeSection.vue
@@ -157,7 +157,6 @@ import {computed, ComputedRef, onBeforeUnmount, onMounted, PropType, ref, watch}
 import StringValue from "@/components/values/StringValue.vue";
 import Property from "@/components/Property.vue";
 import {ContractAnalyzer} from "@/utils/analyzer/ContractAnalyzer";
-import {routeManager} from "@/router";
 import InfoTooltip from "@/components/InfoTooltip.vue";
 import ContractVerificationDialog from "@/dialogs/verification/ContractVerificationDialog.vue";
 import {AppStorage} from "@/AppStorage";
@@ -178,6 +177,7 @@ import DashboardCardV2 from "@/components/DashboardCardV2.vue";
 import ButtonView from "@/elements/ButtonView.vue";
 import ContractByteCodeValue from "@/components/values/ContractByteCodeValue.vue";
 import {ButtonSize} from "@/dialogs/core/DialogUtils.ts";
+import {routeManager} from "@/utils/RouteManager.ts";
 
 const FULL_MATCH_TOOLTIP = `A Full Match indicates that the bytecode of the deployed contract is byte-by-byte the same as the compilation output of the given source code files with the settings defined in the metadata file. This means the contents of the source code files and the compilation settings are exactly the same as when the contract author compiled and deployed the contract.`
 const PARTIAL_MATCH_TOOLTIP = `A Partial Match indicates that the bytecode of the deployed contract is the same as the compilation output of the given source code files except for the metadata hash. This means the deployed contract and the given source code + metadata function in the same way but there are differences in source code comments, variable names, or other metadata fields such as source paths.`

--- a/src/components/contract/ContractResultTable.vue
+++ b/src/components/contract/ContractResultTable.vue
@@ -75,13 +75,13 @@ import {ORUGA_MOBILE_BREAKPOINT} from "@/BreakPoints";
 import {ContractResultTableController} from "@/components/contract/ContractResultTableController";
 import TimestampValue from "@/components/values/TimestampValue.vue";
 import EmptyTable from "@/components/EmptyTable.vue";
-import {routeManager} from "@/router";
 import StringValue from "@/components/values/StringValue.vue";
 import EVMAddress from "@/components/values/EVMAddress.vue";
 import {decodeSolidityErrorMessage} from "@/schemas/MirrorNodeUtils.ts";
 import HbarAmount from "@/components/values/HbarAmount.vue";
 import TablePageSize from "@/components/transaction/TablePageSize.vue";
 import {TriangleAlert} from 'lucide-vue-next';
+import {routeManager} from "@/utils/RouteManager.ts";
 
 const props = defineProps({
   controller: {

--- a/src/components/contract/ContractResultsSection.vue
+++ b/src/components/contract/ContractResultsSection.vue
@@ -31,11 +31,11 @@
 <script setup lang="ts">
 
 import {computed, inject, onBeforeUnmount, onMounted} from 'vue';
-import router from "@/router";
 import {ContractResultTableController} from "@/components/contract/ContractResultTableController";
 import ContractResultTable from "@/components/contract/ContractResultTable.vue";
 import DashboardCardV2 from "@/components/DashboardCardV2.vue";
 import PlayPauseButton from "@/components/PlayPauseButton.vue";
+import router from "@/utils/RouteManager.ts";
 
 const props = defineProps({
   contractId: String,

--- a/src/components/contract/ContractTable.vue
+++ b/src/components/contract/ContractTable.vue
@@ -63,7 +63,6 @@
 import {onBeforeUnmount, onMounted, PropType} from 'vue';
 import {OTable, OTableColumn} from "@oruga-ui/oruga-next";
 import {Contract} from "@/schemas/MirrorNodeSchemas";
-import {routeManager} from "@/router";
 import BlobValue from "@/components/values/BlobValue.vue";
 import TimestampValue from "@/components/values/TimestampValue.vue";
 import {ORUGA_MOBILE_BREAKPOINT} from "@/BreakPoints";
@@ -72,6 +71,7 @@ import {ContractTableController} from "@/components/contract/ContractTableContro
 import ContractName from "@/components/values/ContractName.vue";
 import ContractIOL from "@/components/values/link/ContractIOL.vue";
 import TablePageSize from "@/components/transaction/TablePageSize.vue";
+import {routeManager} from "@/utils/RouteManager.ts";
 
 const props = defineProps({
   controller: {

--- a/src/components/contract/ERC20ByNameTable.vue
+++ b/src/components/contract/ERC20ByNameTable.vue
@@ -59,13 +59,13 @@
 
 import {computed, inject, onBeforeUnmount, onMounted, PropType, ref} from 'vue';
 import {OTable, OTableColumn} from "@oruga-ui/oruga-next";
-import {routeManager} from "@/router";
 import {ORUGA_MOBILE_BREAKPOINT} from "@/BreakPoints";
 import EmptyTable from "@/components/EmptyTable.vue";
 import TablePageSize from "@/components/transaction/TablePageSize.vue";
 import {ERC20ByNameTableLoader} from "@/components/contract/ERC20ByNameTableLoader.ts";
 import {ERC20Contract} from "@/utils/cache/ERC20Cache.ts";
 import ContractIOL from "@/components/values/link/ContractIOL.vue";
+import {routeManager} from "@/utils/RouteManager.ts";
 
 const props = defineProps({
   narrowed: Boolean,

--- a/src/components/contract/ERC721ByNameTable.vue
+++ b/src/components/contract/ERC721ByNameTable.vue
@@ -59,13 +59,13 @@
 
 import {computed, inject, onBeforeUnmount, onMounted, PropType, ref} from 'vue';
 import {OTable, OTableColumn} from "@oruga-ui/oruga-next";
-import {routeManager} from "@/router";
 import {ORUGA_MOBILE_BREAKPOINT} from "@/BreakPoints";
 import EmptyTable from "@/components/EmptyTable.vue";
 import TablePageSize from "@/components/transaction/TablePageSize.vue";
 import {ERC721Contract} from "@/utils/cache/ERC721Cache.ts";
 import ContractIOL from "@/components/values/link/ContractIOL.vue";
 import {ERC721ByNameTableLoader} from "@/components/contract/ERC721ByNameTableLoader.ts";
+import {routeManager} from "@/utils/RouteManager.ts";
 
 const props = defineProps({
   narrowed: Boolean,

--- a/src/components/node/NodeTable.vue
+++ b/src/components/node/NodeTable.vue
@@ -120,7 +120,6 @@ import {ORUGA_MOBILE_BREAKPOINT} from "@/BreakPoints";
 import EmptyTable from "@/components/EmptyTable.vue";
 import HbarAmount from "@/components/values/HbarAmount.vue";
 import StakeRange from "@/components/node/StakeRange.vue";
-import {routeManager} from "@/router";
 import StringValue from "@/components/values/StringValue.vue";
 import {
   makeAnnualizedRate,
@@ -130,6 +129,7 @@ import {
 } from "@/schemas/MirrorNodeUtils.ts";
 import {NetworkAnalyzer} from "@/utils/analyzer/NetworkAnalyzer";
 import Tooltip from "@/components/Tooltip.vue";
+import {routeManager} from "@/utils/RouteManager.ts";
 
 const props = defineProps({
   nodes: {

--- a/src/components/page/header/MainDashboardHeader.vue
+++ b/src/components/page/header/MainDashboardHeader.vue
@@ -66,11 +66,11 @@ import TabBar from "@/components/page/header/TabBar.vue";
 import SearchBar from "@/components/search/SearchBar.vue";
 import ConnectWalletButton from "@/components/page/header/wallet/ConnectWalletButton.vue";
 import {computed, inject} from "vue";
-import {routeManager, walletManager} from "@/router.ts";
 import {WalletManagerStatus} from "@/utils/wallet/WalletManagerV4.ts";
 import WalletStatusButton from "@/components/page/header/wallet/WalletStatusButton.vue";
 import MobileMenuButton from "@/components/page/header/MobileMenuButton.vue";
 import MarketDashboard from "@/components/dashboard/MarketDashboard.vue";
+import {routeManager, walletManager} from "@/utils/RouteManager.ts";
 
 const props = defineProps({
   fullPage: {

--- a/src/components/page/header/MobileMenuButton.vue
+++ b/src/components/page/header/MobileMenuButton.vue
@@ -47,8 +47,8 @@ import {computed, ref, watch} from "vue";
 import TabBar from "@/components/page/header/TabBar.vue";
 import NetworkSelector from "@/components/page/header/NetworkSelector.vue";
 import ThemeSwitch from "@/components/ThemeSwitch.vue";
-import {routeManager} from "@/router.ts";
 import NetworkMenu from "@/components/page/header/NetworkMenu.vue";
+import {routeManager} from "@/utils/RouteManager.ts";
 
 const MAX_ITEMS_IN_NETWORK_MENU = 5
 

--- a/src/components/page/header/NetworkMenu.vue
+++ b/src/components/page/header/NetworkMenu.vue
@@ -20,9 +20,9 @@
 <script setup lang="ts">
 
 import {ref, watch} from "vue";
-import {routeManager} from "@/router.ts";
 import {NetworkConfig} from "@/config/NetworkConfig.ts";
 import {Check} from 'lucide-vue-next';
+import {routeManager} from "@/utils/RouteManager.ts";
 
 const networkEntries = NetworkConfig.inject().entries
 

--- a/src/components/page/header/NetworkSelector.vue
+++ b/src/components/page/header/NetworkSelector.vue
@@ -19,9 +19,9 @@
 <script setup lang="ts">
 
 import {ref, watch} from "vue";
-import {routeManager} from "@/router.ts";
 import {NetworkConfig} from "@/config/NetworkConfig.ts";
 import SelectView from "@/elements/SelectView.vue";
+import {routeManager} from "@/utils/RouteManager.ts";
 
 const networkEntries = NetworkConfig.inject().entries
 

--- a/src/components/page/header/PageHeader.vue
+++ b/src/components/page/header/PageHeader.vue
@@ -85,11 +85,11 @@ import TabBar from "@/components/page/header/TabBar.vue";
 import SearchBar from "@/components/search/SearchBar.vue";
 import ConnectWalletButton from "@/components/page/header/wallet/ConnectWalletButton.vue";
 import {computed, inject, PropType, ref, useSlots} from "vue";
-import {routeManager, walletManager} from "@/router.ts";
 import {WalletManagerStatus} from "@/utils/wallet/WalletManagerV4.ts";
 import WalletStatusButton from "@/components/page/header/wallet/WalletStatusButton.vue";
 import MobileMenuButton from "@/components/page/header/MobileMenuButton.vue";
 import {Search} from "lucide-vue-next";
+import {routeManager, walletManager} from "@/utils/RouteManager.ts";
 
 const props = defineProps({
   pageTitle: {

--- a/src/components/page/header/ProductLogo.vue
+++ b/src/components/page/header/ProductLogo.vue
@@ -19,9 +19,9 @@
 
 <script setup lang="ts">
 
-import {routeManager} from "@/router.ts"
 import {ThemeController} from "@/components/ThemeController.ts";
 import {inject} from "vue";
+import {routeManager} from "@/utils/RouteManager.ts";
 
 const productLogoURL = ThemeController.inject().productLogoURL
 const productMiniLogoURL = ThemeController.inject().productMiniLogoURL

--- a/src/components/page/header/TabBar.vue
+++ b/src/components/page/header/TabBar.vue
@@ -35,8 +35,7 @@
 
 <script setup lang="ts">
 
-import {routeManager} from "@/router.ts"
-import {TabId} from "@/utils/RouteManager.ts"
+import {routeManager, TabId} from "@/utils/RouteManager.ts"
 import TabItem from "@/components/page/header/TabItem.vue";
 
 const props = defineProps({

--- a/src/components/page/header/TabItem.vue
+++ b/src/components/page/header/TabItem.vue
@@ -18,7 +18,8 @@
 
 import {computed, PropType} from "vue";
 import {RouteLocationRaw} from "vue-router";
-import {routeManager} from "@/router.ts";
+
+import {routeManager} from "@/utils/RouteManager.ts";
 
 const props = defineProps({
   tabId: {

--- a/src/components/page/header/wallet/ConnectWalletButton.vue
+++ b/src/components/page/header/wallet/ConnectWalletButton.vue
@@ -32,7 +32,6 @@
 <script setup lang="ts">
 
 import {computed, inject, ref} from "vue";
-import router, {routeManager, walletManager} from "@/router.ts";
 import {WalletManagerStatus} from "@/utils/wallet/WalletManagerV4.ts";
 import {WalletClientError, WalletClientRejectError} from "@/utils/wallet/client/WalletClient.ts";
 import WalletChooserDialog, {WalletItem} from "@/dialogs/wallet_chooser/WalletChooserDialog.vue";
@@ -40,6 +39,7 @@ import AlertDialog from "@/dialogs/AlertDialog.vue";
 import ButtonView from "@/elements/ButtonView.vue";
 import {ButtonSize} from "@/dialogs/core/DialogUtils.ts";
 import {gtagWalletConnect, gtagWalletConnectionFailure} from "@/gtag.ts";
+import router, {routeManager, walletManager} from "@/utils/RouteManager.ts";
 
 const isLargeScreen = inject('isLargeScreen', true)
 

--- a/src/components/page/header/wallet/WalletOptions.vue
+++ b/src/components/page/header/wallet/WalletOptions.vue
@@ -103,7 +103,6 @@
 <script setup lang="ts">
 
 import {computed, onBeforeUnmount, onMounted, ref} from "vue";
-import router, {routeManager, walletManager} from "@/router.ts";
 import GroupBoxView from "@/elements/GroupBoxView.vue";
 import ButtonView from "@/elements/ButtonView.vue";
 import LabelView from "@/elements/LabelView.vue";
@@ -118,6 +117,7 @@ import ApproveAllowanceDialog from "@/dialogs/allowance/ApproveAllowanceDialog.v
 import {CheckCheck, UserRoundPen} from 'lucide-vue-next';
 import HbarAmount from "@/components/values/HbarAmount.vue";
 import AccountSelector from "@/components/page/header/wallet/AccountSelector.vue";
+import router, {routeManager, walletManager} from "@/utils/RouteManager.ts";
 
 const showWalletOptions = defineModel("showWalletOptions", {
   type: Boolean,

--- a/src/components/page/header/wallet/WalletStatusButton.vue
+++ b/src/components/page/header/wallet/WalletStatusButton.vue
@@ -39,11 +39,11 @@
 <script setup lang="ts">
 
 import {ref} from "vue";
-import {walletManager} from "@/router.ts";
 import DropdownPanel from "@/components/DropdownPanel.vue";
 import ButtonView from "@/elements/ButtonView.vue";
 import {ButtonSize} from "@/dialogs/core/DialogUtils.ts";
 import WalletOptions from "@/components/page/header/wallet/WalletOptions.vue";
+import {walletManager} from "@/utils/RouteManager.ts";
 
 const accountId = walletManager.accountId
 const walletIconURL = walletManager.walletIconURL

--- a/src/components/search/SearchAgent.ts
+++ b/src/components/search/SearchAgent.ts
@@ -21,7 +21,6 @@ import {drainAccounts} from "@/schemas/MirrorNodeUtils.ts";
 import {aliasToBase32, byteToHex, paddedBytes} from "@/utils/B64Utils";
 import axios from "axios";
 import {RouteLocationRaw} from "vue-router";
-import {routeManager} from "@/router";
 import {TransactionID} from "@/utils/TransactionID";
 import {Timestamp} from "@/utils/Timestamp";
 import {NameRecord, NameService} from "@/utils/name_service/NameService";
@@ -32,6 +31,7 @@ import {SelectedTokensCache} from "@/utils/cache/SelectedTokensCache";
 import {ERC20Cache} from "@/utils/cache/ERC20Cache.ts";
 import {ERC721Cache} from "@/utils/cache/ERC721Cache.ts";
 import {PublicLabelsCache} from "@/utils/cache/PublicLabelsCache.ts";
+import {routeManager} from "@/utils/RouteManager.ts";
 
 export abstract class SearchAgent<L, E> {
 

--- a/src/components/search/SearchBar.vue
+++ b/src/components/search/SearchBar.vue
@@ -40,11 +40,11 @@
 
 import {computed, inject, ref, watch} from "vue";
 import {SearchController} from "@/components/search/SearchController";
-import router from "@/router";
 import {SearchAgent, SearchCandidate} from "@/components/search/SearchAgent";
 import DropdownPanel from "@/components/DropdownPanel.vue";
 import SearchDropdown from "@/components/search/SearchDropdown.vue";
 import {Search} from "lucide-vue-next";
+import router from "@/utils/RouteManager.ts";
 
 const props = defineProps({
   size: {

--- a/src/components/search/SearchController.ts
+++ b/src/components/search/SearchController.ts
@@ -23,8 +23,8 @@ import {
 } from "@/components/search/SearchAgent";
 import {nameServiceProviders} from "@/utils/name_service/provider/AllProviders";
 import {InputChangeController} from "@/components/utils/InputChangeController.ts";
-import {routeManager} from "@/router.ts";
 import {PublicLabelsCache} from "@/utils/cache/PublicLabelsCache.ts";
+import {routeManager} from "@/utils/RouteManager.ts";
 
 export class SearchController {
 

--- a/src/components/search/SearchDropdown.vue
+++ b/src/components/search/SearchDropdown.vue
@@ -36,10 +36,10 @@
 
 import {computed, PropType} from "vue";
 import {SearchController} from "@/components/search/SearchController";
-import router, {routeManager} from "@/router";
 import SearchTabs from "@/components/search/SearchTabs.vue";
 import SearchSection from "@/components/search/SearchSection.vue";
 import {SearchAgent} from "@/components/search/SearchAgent";
+import router, {routeManager} from "@/utils/RouteManager.ts";
 
 const props = defineProps({
   "searchController": {

--- a/src/components/search/SearchSection.vue
+++ b/src/components/search/SearchSection.vue
@@ -26,7 +26,7 @@
 
 import {PropType} from "vue";
 import {SearchAgent, SearchCandidate} from "@/components/search/SearchAgent";
-import router from "@/router";
+import router from "@/utils/RouteManager.ts";
 import {SearchController} from "@/components/search/SearchController";
 
 const props = defineProps({

--- a/src/components/staking/RecentRewardsSection.vue
+++ b/src/components/staking/RecentRewardsSection.vue
@@ -34,13 +34,13 @@
 
 import {onBeforeUnmount, onMounted, ref} from 'vue';
 import DashboardCardV2 from "@/components/DashboardCardV2.vue";
-import {walletManager} from "@/router.ts";
 import DownloadButton from "@/components/DownloadButton.vue";
 import StakingRewardsTable from "@/components/staking/StakingRewardsTable.vue";
 import {StakingRewardsTableController} from "@/components/staking/StakingRewardsTableController.ts";
 import {AppStorage} from "@/AppStorage.ts";
 import RewardDownloadDialog from "@/dialogs/download/RewardDownloadDialog.vue";
 import {useRouter} from "vue-router";
+import {walletManager} from "@/utils/RouteManager.ts";
 
 const router = useRouter()
 const showDownloadDialog = ref(false)

--- a/src/components/staking/StakingRewardsTable.vue
+++ b/src/components/staking/StakingRewardsTable.vue
@@ -60,13 +60,13 @@
 import {onBeforeUnmount, onMounted, PropType} from 'vue';
 import {OTable, OTableColumn} from "@oruga-ui/oruga-next";
 import {StakingReward} from '@/schemas/MirrorNodeSchemas.ts';
-import {routeManager} from "@/router";
 import TimestampValue from "@/components/values/TimestampValue.vue";
 import {ORUGA_MOBILE_BREAKPOINT} from "@/BreakPoints";
 import EmptyTable from "@/components/EmptyTable.vue";
 import HbarAmount from "@/components/values/HbarAmount.vue";
 import {StakingRewardsTableController} from "@/components/staking/StakingRewardsTableController";
 import TablePageSize from "@/components/transaction/TablePageSize.vue";
+import {routeManager} from "@/utils/RouteManager.ts";
 
 const props = defineProps({
   narrowed: Boolean,

--- a/src/components/token/NftHolderTable.vue
+++ b/src/components/token/NftHolderTable.vue
@@ -96,10 +96,10 @@ import {Nft} from "@/schemas/MirrorNodeSchemas";
 import {ORUGA_MOBILE_BREAKPOINT} from "@/BreakPoints";
 import EmptyTable from "@/components/EmptyTable.vue";
 import {NftHolderTableController} from "@/components/token/NftHolderTableController";
-import {routeManager} from "@/router";
 import AccountIOL from "@/components/values/link/AccountIOL.vue";
 import NftCell, {NftCellItem} from "@/components/token/NftCell.vue";
 import TablePageSize from "@/components/transaction/TablePageSize.vue";
+import {routeManager} from "@/utils/RouteManager.ts";
 
 const props = defineProps({
   controller: {

--- a/src/components/token/TokenActions.vue
+++ b/src/components/token/TokenActions.vue
@@ -82,7 +82,6 @@
 <script setup lang="ts">
 
 import {computed, PropType, ref} from "vue";
-import {walletManager} from "@/router.ts";
 import {TokenAssociationStatus, TokenInfoAnalyzer} from "@/components/token/TokenInfoAnalyzer.ts";
 import ButtonView from "@/elements/ButtonView.vue";
 import AssociateTokenDialog from "@/dialogs/token/AssociateTokenDialog.vue";
@@ -91,6 +90,7 @@ import {ButtonSize} from "@/dialogs/core/DialogUtils.ts";
 import RejectTokenDialog from "@/dialogs/token/RejectTokenDialog.vue";
 import ClaimTokenDialog from "@/dialogs/token/ClaimTokenDialog.vue";
 import WatchTokenDialog from "@/dialogs/token/WatchTokenDialog.vue";
+import {walletManager} from "@/utils/RouteManager.ts";
 
 const props = defineProps({
   analyzer: {

--- a/src/components/token/TokenBalanceTable.vue
+++ b/src/components/token/TokenBalanceTable.vue
@@ -63,13 +63,13 @@
 import {PropType} from 'vue';
 import {OTable, OTableColumn} from "@oruga-ui/oruga-next";
 import {TokenDistribution} from "@/schemas/MirrorNodeSchemas";
-import {routeManager} from "@/router";
 import TokenAmount from "@/components/values/TokenAmount.vue";
 import {ORUGA_MOBILE_BREAKPOINT} from "@/BreakPoints";
 import EmptyTable from "@/components/EmptyTable.vue";
 import {TokenBalanceTableController} from "@/components/token/TokenBalanceTableController";
 import AccountIOL from "@/components/values/link/AccountIOL.vue";
 import TablePageSize from "@/components/transaction/TablePageSize.vue";
+import {routeManager} from "@/utils/RouteManager.ts";
 
 const props = defineProps({
   controller: {

--- a/src/components/token/TokenInfoAnalyzer.ts
+++ b/src/components/token/TokenInfoAnalyzer.ts
@@ -4,9 +4,9 @@ import {computed, Ref} from "vue";
 import {makeEthAddressForToken, makeTokenSymbol} from "@/schemas/MirrorNodeUtils.ts";
 import {TokenInfo, TokenType} from "@/schemas/MirrorNodeSchemas";
 import {NetworkConfig} from "@/config/NetworkConfig";
-import {routeManager, walletManager} from "@/router";
 import {TokenAssociationCache} from "@/utils/cache/TokenAssociationCache";
 import {PendingAirdropCache} from "@/utils/cache/PendingAirdropCache.ts";
+import {routeManager, walletManager} from "@/utils/RouteManager.ts";
 
 export class TokenInfoAnalyzer {
 

--- a/src/components/token/TokenTable.vue
+++ b/src/components/token/TokenTable.vue
@@ -60,13 +60,13 @@
 
 import {PropType} from 'vue';
 import {OTable, OTableColumn} from "@oruga-ui/oruga-next";
-import {routeManager} from "@/router";
 import {Token} from "@/schemas/MirrorNodeSchemas";
 import {ORUGA_MOBILE_BREAKPOINT} from "@/BreakPoints";
 import EmptyTable from "@/components/EmptyTable.vue";
 import {TokenTableController} from "@/components/token/TokenTableController";
 import TokenIOL from "@/components/values/link/TokenIOL.vue";
 import TablePageSize from "@/components/transaction/TablePageSize.vue";
+import {routeManager} from "@/utils/RouteManager.ts";
 
 const props = defineProps({
   controller: {

--- a/src/components/token/TokensByNameTable.vue
+++ b/src/components/token/TokensByNameTable.vue
@@ -60,12 +60,12 @@
 import {computed, inject, onBeforeUnmount, onMounted, PropType, ref} from 'vue';
 import {OTable, OTableColumn} from "@oruga-ui/oruga-next";
 import {Token} from '@/schemas/MirrorNodeSchemas.ts';
-import {routeManager} from "@/router";
 import {ORUGA_MOBILE_BREAKPOINT} from "@/BreakPoints";
 import EmptyTable from "@/components/EmptyTable.vue";
 import TablePageSize from "@/components/transaction/TablePageSize.vue";
 import TokenIOL from "@/components/values/link/TokenIOL.vue";
 import {TokensByNameTableLoader} from "@/components/token/TokensByNameTableLoader";
+import {routeManager} from "@/utils/RouteManager.ts";
 
 const props = defineProps({
   narrowed: Boolean,

--- a/src/components/token/TokensByPopularityTable.vue
+++ b/src/components/token/TokensByPopularityTable.vue
@@ -60,12 +60,12 @@
 import {computed, inject, onBeforeUnmount, onMounted, PropType, ref} from 'vue';
 import {OTable, OTableColumn} from "@oruga-ui/oruga-next";
 import {Token} from '@/schemas/MirrorNodeSchemas.ts';
-import {routeManager} from "@/router";
 import {ORUGA_MOBILE_BREAKPOINT} from "@/BreakPoints";
 import EmptyTable from "@/components/EmptyTable.vue";
 import TablePageSize from "@/components/transaction/TablePageSize.vue";
 import TokenIOL from "@/components/values/link/TokenIOL.vue";
 import {TokensByPopulariyTableLoader} from "@/components/token/TokensByPopularityTableLoader";
+import {routeManager} from "@/utils/RouteManager.ts";
 
 const props = defineProps({
   narrowed: Boolean,

--- a/src/components/token/TokensSection.vue
+++ b/src/components/token/TokensSection.vue
@@ -142,7 +142,6 @@ import {NftsTableController} from "@/components/account/NftsTableController";
 import NftsTable from "@/components/account/NftsTable.vue";
 import FungibleTable from "@/components/account/FungibleTable.vue";
 import {FungibleTableController} from "@/components/account/FungibleTableController";
-import {routeManager, walletManager} from "@/router";
 import {Nft, Token, TokenAirdrop, TokenType} from "@/schemas/MirrorNodeSchemas";
 import RejectTokenGroupDialog from "@/dialogs/token/RejectTokenGroupDialog.vue";
 import ClaimTokenGroupDialog from "@/dialogs/token/ClaimTokenGroupDialog.vue";
@@ -154,6 +153,7 @@ import DashboardCardV2 from "@/components/DashboardCardV2.vue";
 import ButtonView from "@/elements/ButtonView.vue";
 import ArrowLink from "@/components/ArrowLink.vue";
 import {ButtonSize} from "@/dialogs/core/DialogUtils.ts";
+import {routeManager, walletManager} from "@/utils/RouteManager.ts";
 
 const props = defineProps({
   accountId: {

--- a/src/components/topic/TopicMessageTable.vue
+++ b/src/components/topic/TopicMessageTable.vue
@@ -74,8 +74,8 @@ import BlobValue from "@/components/values/BlobValue.vue";
 import {ORUGA_MOBILE_BREAKPOINT} from "@/BreakPoints";
 import EmptyTable from "@/components/EmptyTable.vue";
 import {TopicMessage} from "@/schemas/MirrorNodeSchemas";
-import {routeManager} from "@/router";
 import TablePageSize from "@/components/transaction/TablePageSize.vue";
+import {routeManager} from "@/utils/RouteManager.ts";
 
 const props = defineProps({
   controller: {

--- a/src/components/topic/TopicTable.vue
+++ b/src/components/topic/TopicTable.vue
@@ -57,13 +57,13 @@ import {PropType} from 'vue';
 import {OTable, OTableColumn} from "@oruga-ui/oruga-next";
 import {Transaction} from "@/schemas/MirrorNodeSchemas";
 import TimestampValue from "@/components/values/TimestampValue.vue";
-import {routeManager} from "@/router";
 import BlobValue from "@/components/values/BlobValue.vue";
 import {ORUGA_MOBILE_BREAKPOINT} from "@/BreakPoints";
 import EmptyTable from "@/components/EmptyTable.vue";
 import {TransactionTableController} from "@/components/transaction/TransactionTableController";
 import TopicIOL from "@/components/values/link/TopicIOL.vue";
 import TablePageSize from "@/components/transaction/TablePageSize.vue";
+import {routeManager} from "@/utils/RouteManager.ts";
 
 const props = defineProps({
   controller: {

--- a/src/components/transaction/NftTransactionTable.vue
+++ b/src/components/transaction/NftTransactionTable.vue
@@ -63,11 +63,11 @@ import NftTransactionSummary from "@/components/transaction/NftTransactionSummar
 import TimestampValue from "@/components/values/TimestampValue.vue"
 import TransactionLabel from "@/components/values/TransactionLabel.vue"
 import {makeTypeLabel} from "@/utils/TransactionTools"
-import {routeManager} from "@/router"
 import {ORUGA_MOBILE_BREAKPOINT} from "@/BreakPoints";
 import EmptyTable from "@/components/EmptyTable.vue"
 import InnerSenderEVMAddress from "@/components/values/InnerSenderEVMAddress.vue"
 import {NftTransactionTableController} from "./NftTransactionTableController"
+import {routeManager} from "@/utils/RouteManager.ts";
 
 const props = defineProps({
   narrowed: Boolean,

--- a/src/components/transaction/TransactionBatchTable.vue
+++ b/src/components/transaction/TransactionBatchTable.vue
@@ -64,13 +64,13 @@ import {computed, inject, PropType, ref} from 'vue';
 import {OTable, OTableColumn} from "@oruga-ui/oruga-next";
 import {Transaction} from '@/schemas/MirrorNodeSchemas.ts';
 import {makeTypeLabel} from "@/utils/TransactionTools";
-import {routeManager} from "@/router";
 import TimestampValue from "@/components/values/TimestampValue.vue";
 import TransactionSummary from "@/components/transaction/TransactionSummary.vue";
 import {ORUGA_MOBILE_BREAKPOINT} from "@/BreakPoints";
 import EmptyTable from "@/components/EmptyTable.vue";
 import {TriangleAlert} from "lucide-vue-next";
 import TransactionLabel from "@/components/values/TransactionLabel.vue";
+import {routeManager} from "@/utils/RouteManager.ts";
 
 const props = defineProps({
   narrowed: Boolean,

--- a/src/components/transaction/TransactionByIdTable.vue
+++ b/src/components/transaction/TransactionByIdTable.vue
@@ -60,12 +60,12 @@ import {computed, inject, PropType, ref} from 'vue';
 import {OTable, OTableColumn} from "@oruga-ui/oruga-next";
 import {Transaction, TransactionType} from '@/schemas/MirrorNodeSchemas.ts';
 import {makeTypeLabel} from "@/utils/TransactionTools";
-import {routeManager} from "@/router";
 import TimestampValue from "@/components/values/TimestampValue.vue";
 import TransactionSummary from "@/components/transaction/TransactionSummary.vue";
 import {ORUGA_MOBILE_BREAKPOINT} from "@/BreakPoints";
 import EmptyTable from "@/components/EmptyTable.vue";
 import {TriangleAlert} from "lucide-vue-next";
+import {routeManager} from "@/utils/RouteManager.ts";
 
 const props = defineProps({
   narrowed: Boolean,

--- a/src/components/transaction/TransactionTable.vue
+++ b/src/components/transaction/TransactionTable.vue
@@ -83,12 +83,12 @@ import TransactionSummary from "@/components/transaction/TransactionSummary.vue"
 import TimestampValue from "@/components/values/TimestampValue.vue";
 import TransactionLabel from "@/components/values/TransactionLabel.vue";
 import {makeTypeLabel} from "@/utils/TransactionTools";
-import {routeManager} from "@/router";
 import {ORUGA_MOBILE_BREAKPOINT} from "@/BreakPoints";
 import {TransactionTableControllerXL} from "@/components/transaction/TransactionTableControllerXL";
 import EmptyTable from "@/components/EmptyTable.vue";
 import InnerSenderEVMAddress from "@/components/values/InnerSenderEVMAddress.vue";
 import TablePageSize from "@/components/transaction/TablePageSize.vue";
+import {routeManager} from "@/utils/RouteManager.ts";
 
 const props = defineProps({
   narrowed: Boolean,

--- a/src/components/values/BlobValue.vue
+++ b/src/components/values/BlobValue.vue
@@ -65,9 +65,9 @@ import {initialLoadingKey} from "@/AppKeys";
 import {CoreConfig} from "@/config/CoreConfig";
 import {blob2URL} from "@/utils/URLUtils.ts";
 import {HCSURI} from "@/utils/HCSURI.ts";
-import {routeManager} from "@/router.ts";
 import EntityLink from "@/components/values/link/EntityLink.vue";
 import {base64Decode, utf8Encode} from "@/utils/B64Utils.ts";
+import {routeManager} from "@/utils/RouteManager.ts";
 
 const props = defineProps({
   blobValue: {

--- a/src/components/values/BlockLink.vue
+++ b/src/components/values/BlockLink.vue
@@ -19,7 +19,8 @@
 <script lang="ts">
 
 import {computed, defineComponent} from "vue";
-import {routeManager} from "@/router";
+
+import {routeManager} from "@/utils/RouteManager.ts";
 
 export default defineComponent({
   name: "BlockLink",

--- a/src/components/values/ComplexKeyValue.vue
+++ b/src/components/values/ComplexKeyValue.vue
@@ -64,7 +64,8 @@ import * as hashgraph from "@hashgraph/proto";
 import HexaDumpValue from "@/components/values/HexaDumpValue.vue";
 import ContractLink from "@/components/values/link/ContractLink.vue";
 import {initialLoadingKey} from "@/AppKeys";
-import {routeManager} from "@/router";
+
+import {routeManager} from "@/utils/RouteManager.ts";
 
 const MAX_INLINE_LEVEL = 1
 

--- a/src/components/values/EVMAddress.vue
+++ b/src/components/values/EVMAddress.vue
@@ -66,11 +66,11 @@ import {EthereumAddress} from "@/utils/EthereumAddress";
 import Copyable from "@/elements/Copyable.vue";
 import {ContractByAddressCache} from "@/utils/cache/ContractByAddressCache";
 import {ContractAnalyzer, GlobalState} from "@/utils/analyzer/ContractAnalyzer";
-import {routeManager} from "@/router";
 import ContractLink from "@/components/values/link/ContractLink.vue";
 import AccountLink from "@/components/values/link/AccountLink.vue";
 import TokenLink from "@/components/values/link/TokenLink.vue";
 import {CircleCheckBig} from 'lucide-vue-next';
+import {routeManager} from "@/utils/RouteManager.ts";
 
 enum ExtendedEntityType { UNDEFINED, ACCOUNT, CONTRACT, TOKEN }
 

--- a/src/components/values/TokenAmount.vue
+++ b/src/components/values/TokenAmount.vue
@@ -51,7 +51,8 @@ import TokenExtra from "@/components/values/link/TokenExtra.vue";
 import {initialLoadingKey} from "@/AppKeys";
 import InfoTooltip from "@/components/InfoTooltip.vue";
 import {formatTokenAmount} from "@/schemas/MirrorNodeUtils.ts";
-import {routeManager} from "@/router";
+
+import {routeManager} from "@/utils/RouteManager.ts";
 
 export const MAX_DECIMALS = 20
 

--- a/src/components/values/TransactionLink.vue
+++ b/src/components/values/TransactionLink.vue
@@ -28,7 +28,6 @@
 
 import {computed, onMounted, PropType, ref, watch} from "vue";
 import {TransactionID} from "@/utils/TransactionID";
-import {routeManager} from "@/router";
 import {Transaction} from "@/schemas/MirrorNodeSchemas";
 import {PathParam} from "@/utils/PathParam";
 import {Timestamp} from "@/utils/Timestamp";
@@ -36,6 +35,7 @@ import {TransactionHash} from "@/utils/TransactionHash";
 import {TransactionByHashCache} from "@/utils/cache/TransactionByHashCache";
 import {TransactionByTsCache} from "@/utils/cache/TransactionByTsCache";
 import TransactionIdValue from "@/components/values/TransactionIdValue.vue";
+import {routeManager} from "@/utils/RouteManager.ts";
 
 const props = defineProps({
   transactionLoc: String as PropType<string | undefined>,

--- a/src/components/values/link/AccountLink.vue
+++ b/src/components/values/link/AccountLink.vue
@@ -29,13 +29,13 @@
 <script lang="ts">
 
 import {computed, defineComponent, onBeforeUnmount, onMounted, PropType, ref, watch} from "vue";
-import {routeManager} from "@/router";
 import {NetworkCache} from "@/utils/cache/NetworkCache";
 import {ContractByIdCache} from "@/utils/cache/ContractByIdCache";
 import {RouteLocationRaw} from "vue-router";
 import EntityLink from "@/components/values/link/EntityLink.vue";
 import AccountIOL from "@/components/values/link/AccountIOL.vue";
 import {makeOperatorDescription} from "@/schemas/MirrorNodeUtils.ts";
+import {routeManager} from "@/utils/RouteManager.ts";
 
 export default defineComponent({
   name: "AccountLink",

--- a/src/components/values/link/ContractLink.vue
+++ b/src/components/values/link/ContractLink.vue
@@ -23,9 +23,9 @@
 <script lang="ts">
 
 import {computed, defineComponent, PropType} from "vue";
-import {routeManager} from "@/router";
 import EntityLink from "@/components/values/link/EntityLink.vue";
 import ContractIOL from "@/components/values/link/ContractIOL.vue";
+import {routeManager} from "@/utils/RouteManager.ts";
 
 export default defineComponent({
   name: "ContractLink",

--- a/src/components/values/link/ScheduleLink.vue
+++ b/src/components/values/link/ScheduleLink.vue
@@ -23,9 +23,9 @@
 <script setup lang="ts">
 
 import {computed} from "vue";
-import {routeManager} from "@/router";
 import EntityLink from "@/components/values/link/EntityLink.vue";
 import EntityIOL from "@/components/values/link/EntityIOL.vue";
+import {routeManager} from "@/utils/RouteManager.ts";
 
 const props = defineProps({
   scheduleId: String,

--- a/src/components/values/link/TokenExtra.vue
+++ b/src/components/values/link/TokenExtra.vue
@@ -27,7 +27,8 @@ import {computed, defineComponent, onMounted, ref, watch} from "vue";
 import {TokenInfo} from "@/schemas/MirrorNodeSchemas";
 import {TokenInfoCache} from "@/utils/cache/TokenInfoCache";
 import {makeTokenSymbol} from "@/schemas/MirrorNodeUtils.ts";
-import {routeManager} from "@/router";
+
+import {routeManager} from "@/utils/RouteManager.ts";
 
 export default defineComponent({
   name: "TokenExtra",

--- a/src/components/values/link/TokenLink.vue
+++ b/src/components/values/link/TokenLink.vue
@@ -33,9 +33,9 @@
 
 import {computed, defineComponent} from "vue";
 import TokenExtra from "@/components/values/link/TokenExtra.vue";
-import {routeManager} from "@/router";
 import TokenIOL from "@/components/values/link/TokenIOL.vue";
 import EntityLink from "@/components/values/link/EntityLink.vue";
+import {routeManager} from "@/utils/RouteManager.ts";
 
 export default defineComponent({
   name: "TokenLink",

--- a/src/components/values/link/TopicLink.vue
+++ b/src/components/values/link/TopicLink.vue
@@ -23,9 +23,9 @@
 <script lang="ts">
 
 import {computed, defineComponent} from "vue";
-import {routeManager} from "@/router";
 import TopicIOL from "@/components/values/link/TopicIOL.vue";
 import EntityLink from "@/components/values/link/EntityLink.vue";
+import {routeManager} from "@/utils/RouteManager.ts";
 
 export default defineComponent({
   name: "TopicLink",

--- a/src/dialogs/UpdateAccountController.ts
+++ b/src/dialogs/UpdateAccountController.ts
@@ -5,10 +5,10 @@ import {TransactionController} from "@/dialogs/core/transaction/TransactionContr
 import {AccountTextFieldController, AccountTextFieldState} from "@/dialogs/common/AccountTextFieldController.ts";
 import {NetworkAnalyzer} from "@/utils/analyzer/NetworkAnalyzer.ts";
 import {NetworkConfig} from "@/config/NetworkConfig.ts"
-import {walletManager} from "@/router.ts";
 import {AccountByIdCache} from "@/utils/cache/AccountByIdCache.ts";
 import {TokenRelationshipCache} from "@/utils/cache/TokenRelationshipCache.ts";
 import {AccountUpdateTransaction} from "@hashgraph/sdk";
+import {walletManager} from "@/utils/RouteManager.ts";
 
 export enum PeriodUnit {
     Seconds = "seconds",

--- a/src/dialogs/UpdateAccountDialog.vue
+++ b/src/dialogs/UpdateAccountDialog.vue
@@ -226,9 +226,9 @@ import InfoTooltip from "@/components/InfoTooltip.vue";
 import SelectView from "@/elements/SelectView.vue";
 import SwitchView from "@/elements/SwitchView.vue";
 import RabioBoxView from "@/elements/RabioBoxView.vue";
-import {routeManager} from "@/router.ts";
 import StackView from "@/elements/StackView.vue";
 import {NetworkConfig} from "@/config/NetworkConfig.ts";
+import {routeManager} from "@/utils/RouteManager.ts";
 
 const showDialog = defineModel("showDialog", {
   type: Boolean,

--- a/src/dialogs/abi/ContractAbiDialog.vue
+++ b/src/dialogs/abi/ContractAbiDialog.vue
@@ -68,7 +68,6 @@
 <script setup lang="ts">
 
 import {computed, PropType} from "vue";
-import {walletManager} from "@/router.ts";
 import TaskDialog from "@/dialogs/core/task/TaskDialog.vue";
 import {ContractCallBuilder} from "@/dialogs/abi/ContractCallBuilder.ts";
 import {ContractAbiController} from "@/dialogs/abi/ContractAbiController.ts";
@@ -76,6 +75,7 @@ import ParamTypeEditor from "@/dialogs/abi/ParamTypeEditor.vue";
 import {TaskPanelMode} from "@/dialogs/core/DialogUtils.ts";
 import TaskPanel from "@/dialogs/core/task/TaskPanel.vue";
 import ParamHbarEditor from "@/dialogs/abi/ParamHbarEditor.vue";
+import {walletManager} from "@/utils/RouteManager.ts";
 
 const showDialog = defineModel("showDialog", {
   type: Boolean,

--- a/src/dialogs/abi/ContractCallBuilder.ts
+++ b/src/dialogs/abi/ContractCallBuilder.ts
@@ -4,10 +4,10 @@ import {computed, ref, watch} from "vue";
 import {ethers} from "ethers";
 import {AppStorage} from "@/AppStorage.ts";
 import {ContractCallRequest, ContractCallResponse, extractMessageFromErrorBody} from "@/schemas/MirrorNodeSchemas.ts";
-import {walletManager} from "@/router.ts";
 import axios from "axios";
 import {ABIController} from "@/components/contract/ABIController.ts";
 import {ContractByIdCache} from "@/utils/cache/ContractByIdCache.ts";
+import {walletManager} from "@/utils/RouteManager.ts";
 
 export class ContractCallBuilder {
 

--- a/src/dialogs/allowance/ApproveAllowanceController.ts
+++ b/src/dialogs/allowance/ApproveAllowanceController.ts
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {computed, ref, Ref} from "vue";
-import {walletManager} from "@/router.ts";
 import {TransactionController} from "@/dialogs/core/transaction/TransactionController.ts";
 import {AccountTextFieldController, AccountTextFieldState} from "@/dialogs/common/AccountTextFieldController.ts";
 import {TokenTextFieldController, TokenTextFieldState} from "@/dialogs/common/TokenTextFieldController.ts";
@@ -15,6 +14,7 @@ import {
     NftSerialsTextFieldController,
     NftSerialsTextFieldState
 } from "@/dialogs/common/NftSerialsTextFieldController.ts";
+import {walletManager} from "@/utils/RouteManager.ts";
 
 export class ApproveAllowanceController extends TransactionController {
 

--- a/src/dialogs/allowance/DeleteNftAllowanceController.ts
+++ b/src/dialogs/allowance/DeleteNftAllowanceController.ts
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {computed, Ref} from "vue";
-import {walletManager} from "@/router.ts";
 import {TransactionController} from "@/dialogs/core/transaction/TransactionController.ts";
 import {TokenInfo} from "@/schemas/MirrorNodeSchemas.ts";
 import {EntityLookup} from "@/utils/cache/base/EntityCache.ts";
 import {TokenInfoCache} from "@/utils/cache/TokenInfoCache.ts";
+import {walletManager} from "@/utils/RouteManager.ts";
 
 export class DeleteNftAllowanceController extends TransactionController {
 

--- a/src/dialogs/allowance/UpdateCryptoAllowanceController.ts
+++ b/src/dialogs/allowance/UpdateCryptoAllowanceController.ts
@@ -4,7 +4,8 @@ import {computed, Ref} from "vue";
 import {CryptoTextFieldController, HbarTextFieldState} from "@/dialogs/common/CryptoTextFieldController.ts";
 import {CryptoAllowance} from "@/schemas/MirrorNodeSchemas.ts";
 import {TransactionController} from "@/dialogs/core/transaction/TransactionController.ts";
-import {walletManager} from "@/router.ts";
+
+import {walletManager} from "@/utils/RouteManager.ts";
 
 export class UpdateCryptoAllowanceController extends TransactionController {
 

--- a/src/dialogs/allowance/UpdateTokenAllowanceController.ts
+++ b/src/dialogs/allowance/UpdateTokenAllowanceController.ts
@@ -8,7 +8,8 @@ import {
     TokenAmountTextFieldState
 } from "@/dialogs/common/TokenAmountTextFieldController.ts";
 import {TokenAllowance} from "@/schemas/MirrorNodeSchemas.ts";
-import {walletManager} from "@/router.ts";
+
+import {walletManager} from "@/utils/RouteManager.ts";
 
 export class UpdateTokenAllowanceController extends TransactionController {
 

--- a/src/dialogs/common/EntityTextFieldController.ts
+++ b/src/dialogs/common/EntityTextFieldController.ts
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {computed, Ref, watch} from "vue";
-import {routeManager} from "@/router.ts";
 import {NetworkConfig} from "@/config/NetworkConfig.ts";
 import {EntityID} from "@/utils/EntityID.ts";
 import {BaseTextFieldController} from "@/dialogs/common/BaseTextFieldController.ts"
 import {extractChecksum, stripChecksum} from "@/schemas/MirrorNodeUtils.ts";
+import {routeManager} from "@/utils/RouteManager.ts";
 
 export class EntityTextFieldController {
 

--- a/src/dialogs/common/NftSerialsTextFieldController.ts
+++ b/src/dialogs/common/NftSerialsTextFieldController.ts
@@ -4,8 +4,8 @@ import {computed, ref, Ref} from "vue";
 import {EntityLookup} from "@/utils/cache/base/EntityCache.ts";
 import {InputChangeController} from "@/components/utils/InputChangeController.ts";
 import {EntityID} from "@/utils/EntityID.ts";
-import {walletManager} from "@/router.ts";
 import {NftCollectionCache, NftCollectionInfo} from "@/utils/cache/NftCollectionCache.ts";
+import {walletManager} from "@/utils/RouteManager.ts";
 
 export class NftSerialsTextFieldController {
 

--- a/src/dialogs/core/transaction/TransactionDialog.vue
+++ b/src/dialogs/core/transaction/TransactionDialog.vue
@@ -78,9 +78,9 @@
 import {computed, PropType, useSlots} from "vue";
 import TaskDialog from "@/dialogs/core/task/TaskDialog.vue";
 import {TransactionController} from "@/dialogs/core/transaction/TransactionController.ts";
-import {walletManager} from "@/router.ts";
 import TaskPanel from "@/dialogs/core/task/TaskPanel.vue";
 import {TaskPanelMode} from "@/dialogs/core/DialogUtils.ts";
+import {walletManager} from "@/utils/RouteManager.ts";
 
 const props = defineProps({
   controller: {

--- a/src/dialogs/core/transaction/TransactionGroupDialog.vue
+++ b/src/dialogs/core/transaction/TransactionGroupDialog.vue
@@ -83,11 +83,11 @@
 import {computed, PropType} from "vue";
 import TaskDialog from "@/dialogs/core/task/TaskDialog.vue";
 import {TransactionGroupController} from "@/dialogs/core/transaction/TransactionGroupController.ts";
-import {walletManager} from "@/router.ts";
 import TaskPanel from "@/dialogs/core/task/TaskPanel.vue";
 import {TaskPanelMode} from "@/dialogs/core/DialogUtils.ts";
 import {TransactionID} from "@/utils/TransactionID.ts";
 import {isSuccessfulResult} from "@/utils/TransactionTools.ts";
+import {walletManager} from "@/utils/RouteManager.ts";
 
 
 const props = defineProps({

--- a/src/dialogs/staking/StopStackingController.ts
+++ b/src/dialogs/staking/StopStackingController.ts
@@ -2,13 +2,13 @@
 
 import {computed, Ref} from "vue";
 import {TransactionController} from "@/dialogs/core/transaction/TransactionController.ts";
-import {walletManager} from "@/router.ts";
 import {AccountBalanceTransactions} from "@/schemas/MirrorNodeSchemas.ts";
 import {NodeAnalyzer} from "@/utils/analyzer/NodeAnalyzer.ts";
 import {AccountByIdCache} from "@/utils/cache/AccountByIdCache.ts";
 import {EntityLookup} from "@/utils/cache/base/EntityCache.ts";
 import {AccountByAliasCache} from "@/utils/cache/AccountByAliasCache.ts";
 import {AccountByAddressCache} from "@/utils/cache/AccountByAddressCache.ts";
+import {walletManager} from "@/utils/RouteManager.ts";
 
 export class StopStackingController extends TransactionController {
 

--- a/src/dialogs/token/AssociateTokenController.ts
+++ b/src/dialogs/token/AssociateTokenController.ts
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {computed, ref, Ref} from "vue";
-import {walletManager} from "@/router.ts";
 import {TransactionController} from "@/dialogs/core/transaction/TransactionController.ts";
 import {TokenAssociationStatus, TokenInfoAnalyzer} from "@/components/token/TokenInfoAnalyzer.ts";
 import {Transaction} from "@/schemas/MirrorNodeSchemas.ts";
 import {waitForTransactionRefresh} from "@/schemas/MirrorNodeUtils.ts";
+import {walletManager} from "@/utils/RouteManager.ts";
 
 export class AssociateTokenController extends TransactionController {
 

--- a/src/dialogs/token/AssociateTokenDialog.vue
+++ b/src/dialogs/token/AssociateTokenDialog.vue
@@ -40,9 +40,9 @@ import TransactionDialog from "@/dialogs/core/transaction/TransactionDialog.vue"
 import {computed, PropType} from "vue";
 import {TokenInfoAnalyzer} from "@/components/token/TokenInfoAnalyzer.ts";
 import {AssociateTokenController} from "@/dialogs/token/AssociateTokenController.ts";
-import {walletManager} from "@/router.ts";
 import {TaskPanelMode} from "@/dialogs/core/DialogUtils.ts";
 import TaskPanel from "@/dialogs/core/task/TaskPanel.vue";
+import {walletManager} from "@/utils/RouteManager.ts";
 
 const showDialog = defineModel("showDialog", {
   type: Boolean,

--- a/src/dialogs/token/ClaimTokenController.ts
+++ b/src/dialogs/token/ClaimTokenController.ts
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {computed, Ref} from "vue";
-import {walletManager} from "@/router.ts";
 import {TransactionController} from "@/dialogs/core/transaction/TransactionController.ts";
 import {TokenInfoAnalyzer} from "@/components/token/TokenInfoAnalyzer.ts";
 import {Transaction} from "@/schemas/MirrorNodeSchemas.ts";
 import {waitForTransactionRefresh} from "@/schemas/MirrorNodeUtils.ts";
+import {walletManager} from "@/utils/RouteManager.ts";
 
 export class ClaimTokenController extends TransactionController {
 

--- a/src/dialogs/token/ClaimTokenDialog.vue
+++ b/src/dialogs/token/ClaimTokenDialog.vue
@@ -32,12 +32,12 @@
 <script setup lang="ts">
 
 import {computed, PropType} from "vue";
-import {walletManager} from "@/router.ts";
 import TransactionDialog from "@/dialogs/core/transaction/TransactionDialog.vue";
 import {TokenInfoAnalyzer} from "@/components/token/TokenInfoAnalyzer.ts";
 import {ClaimTokenController} from "@/dialogs/token/ClaimTokenController.ts";
 import {TaskPanelMode} from "@/dialogs/core/DialogUtils.ts";
 import TaskPanel from "@/dialogs/core/task/TaskPanel.vue";
+import {walletManager} from "@/utils/RouteManager.ts";
 
 const showDialog = defineModel("showDialog", {
   type: Boolean,

--- a/src/dialogs/token/ClaimTokenGroupController.ts
+++ b/src/dialogs/token/ClaimTokenGroupController.ts
@@ -3,8 +3,8 @@
 import {computed, Ref} from "vue";
 import {TransactionGroupController} from "@/dialogs/core/transaction/TransactionGroupController.ts";
 import {TokenAirdrop, Transaction} from "@/schemas/MirrorNodeSchemas.ts";
-import {walletManager} from "@/router.ts";
 import {PendingAirdropCache} from "@/utils/cache/PendingAirdropCache.ts";
+import {walletManager} from "@/utils/RouteManager.ts";
 
 export class ClaimTokenGroupController extends TransactionGroupController {
 

--- a/src/dialogs/token/DissociateTokenController.ts
+++ b/src/dialogs/token/DissociateTokenController.ts
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {computed, Ref} from "vue";
-import {walletManager} from "@/router.ts";
 import {TransactionController} from "@/dialogs/core/transaction/TransactionController.ts";
 import {TokenAssociationStatus, TokenInfoAnalyzer} from "@/components/token/TokenInfoAnalyzer.ts";
 import {Transaction} from "@/schemas/MirrorNodeSchemas.ts";
 import {waitForTransactionRefresh} from "@/schemas/MirrorNodeUtils.ts";
+import {walletManager} from "@/utils/RouteManager.ts";
 
 export class DissociateTokenController extends TransactionController {
 

--- a/src/dialogs/token/DissociateTokenDialog.vue
+++ b/src/dialogs/token/DissociateTokenDialog.vue
@@ -34,9 +34,9 @@ import TransactionDialog from "@/dialogs/core/transaction/TransactionDialog.vue"
 import {computed, PropType} from "vue";
 import {TokenInfoAnalyzer} from "@/components/token/TokenInfoAnalyzer.ts";
 import {DissociateTokenController} from "@/dialogs/token/DissociateTokenController.ts";
-import {walletManager} from "@/router.ts";
 import {TaskPanelMode} from "@/dialogs/core/DialogUtils.ts";
 import TaskPanel from "@/dialogs/core/task/TaskPanel.vue";
+import {walletManager} from "@/utils/RouteManager.ts";
 
 const showDialog = defineModel("showDialog", {
   type: Boolean,

--- a/src/dialogs/token/RejectTokenController.ts
+++ b/src/dialogs/token/RejectTokenController.ts
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {computed, Ref} from "vue";
-import {walletManager} from "@/router.ts";
 import {TransactionController} from "@/dialogs/core/transaction/TransactionController.ts";
 import {TokenInfoAnalyzer} from "@/components/token/TokenInfoAnalyzer.ts";
 import {Transaction} from "@/schemas/MirrorNodeSchemas.ts";
 import {waitForTransactionRefresh} from "@/schemas/MirrorNodeUtils.ts";
 import {TokenId, TokenRejectTransaction} from "@hashgraph/sdk";
+import {walletManager} from "@/utils/RouteManager.ts";
 
 export class RejectTokenController extends TransactionController {
 

--- a/src/dialogs/token/RejectTokenDialog.vue
+++ b/src/dialogs/token/RejectTokenDialog.vue
@@ -32,12 +32,12 @@
 <script setup lang="ts">
 
 import {computed, PropType} from "vue";
-import {walletManager} from "@/router.ts";
 import TransactionDialog from "@/dialogs/core/transaction/TransactionDialog.vue";
 import {TokenInfoAnalyzer} from "@/components/token/TokenInfoAnalyzer.ts";
 import {RejectTokenController} from "@/dialogs/token/RejectTokenController.ts";
 import {TaskPanelMode} from "@/dialogs/core/DialogUtils.ts";
 import TaskPanel from "@/dialogs/core/task/TaskPanel.vue";
+import {walletManager} from "@/utils/RouteManager.ts";
 
 const showDialog = defineModel("showDialog", {
   type: Boolean,

--- a/src/dialogs/token/RejectTokenGroupController.ts
+++ b/src/dialogs/token/RejectTokenGroupController.ts
@@ -6,9 +6,9 @@ import {FreezeStatus, Nft, Token, Transaction} from "@/schemas/MirrorNodeSchemas
 import {tokenOrNftId} from "@/schemas/MirrorNodeUtils.ts";
 import {NftId, TokenId, TokenRejectTransaction} from "@hashgraph/sdk";
 import {TokenAssociationCache} from "@/utils/cache/TokenAssociationCache.ts";
-import {walletManager} from "@/router.ts";
 import {TokenInfoCache} from "@/utils/cache/TokenInfoCache.ts";
 import {TaskPanelMode} from "@/dialogs/core/DialogUtils.ts";
+import {walletManager} from "@/utils/RouteManager.ts";
 
 export class RejectTokenGroupController extends TransactionGroupController {
 

--- a/src/dialogs/token/WatchTokenController.ts
+++ b/src/dialogs/token/WatchTokenController.ts
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {computed, Ref} from "vue";
-import {walletManager} from "@/router.ts";
 import {TransactionController} from "@/dialogs/core/transaction/TransactionController.ts";
 import {TokenInfoAnalyzer} from "@/components/token/TokenInfoAnalyzer.ts";
 import {Transaction} from "@/schemas/MirrorNodeSchemas.ts";
+import {walletManager} from "@/utils/RouteManager.ts";
 
 export class WatchTokenController extends TransactionController {
 

--- a/src/dialogs/token/WatchTokenDialog.vue
+++ b/src/dialogs/token/WatchTokenDialog.vue
@@ -32,12 +32,12 @@
 <script setup lang="ts">
 
 import {computed, PropType} from "vue";
-import {walletManager} from "@/router.ts";
 import TransactionDialog from "@/dialogs/core/transaction/TransactionDialog.vue";
 import {TokenInfoAnalyzer} from "@/components/token/TokenInfoAnalyzer.ts";
 import {WatchTokenController} from "@/dialogs/token/WatchTokenController.ts";
 import {TaskPanelMode} from "@/dialogs/core/DialogUtils.ts";
 import TaskPanel from "@/dialogs/core/task/TaskPanel.vue";
+import {walletManager} from "@/utils/RouteManager.ts";
 
 const showDialog = defineModel("showDialog", {
   type: Boolean,

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,6 @@
 
 import {createApp} from 'vue'
 import Root from './Root.vue'
-import router, {routeManager} from './router'
 import axios from 'axios'
 import {OrugaConfig} from '@oruga-ui/oruga-next'
 import {FontAwesomeIcon} from "@fortawesome/vue-fontawesome";
@@ -13,6 +12,7 @@ import "@/styles/explorer.css";
 import {AxiosMonitor} from "@/utils/AxiosMonitor";
 import {CoreConfig} from "@/config/CoreConfig";
 import {NetworkConfig} from "@/config/NetworkConfig";
+import router, {routeManager} from "@/utils/RouteManager.ts";
 
 library.add(faForward);
 export default FontAwesomeIcon;

--- a/src/pages/AccountDetails.vue
+++ b/src/pages/AccountDetails.vue
@@ -358,7 +358,6 @@ import AccountLink from "@/components/values/link/AccountLink.vue";
 import {AccountLocParser} from "@/utils/parser/AccountLocParser";
 import {ContractByIdCache} from "@/utils/cache/ContractByIdCache";
 import TransactionFilterSelect from "@/components/transaction/TransactionFilterSelect.vue";
-import router, {routeManager, walletManager} from "@/router";
 import TransactionLink from "@/components/values/TransactionLink.vue";
 import {StakingRewardsTableController} from "@/components/staking/StakingRewardsTableController";
 import StakingRewardsTable from "@/components/staking/StakingRewardsTable.vue";
@@ -395,6 +394,7 @@ import {Download} from 'lucide-vue-next';
 import DomainLabel from "@/components/values/DomainLabel.vue";
 import PublicLabel from "@/components/values/PublicLabel.vue";
 import {PublicLabelsCache} from "@/utils/cache/PublicLabelsCache.ts";
+import router, {routeManager, walletManager} from "@/utils/RouteManager.ts";
 
 const props = defineProps({
   accountId: String,

--- a/src/pages/AddressDetails.vue
+++ b/src/pages/AddressDetails.vue
@@ -15,11 +15,11 @@
 <script setup lang="ts">
 
 import {onMounted} from 'vue';
-import router, {routeManager} from "@/router";
 import {PathParam} from "@/utils/PathParam";
 import {RouteLocationRaw} from "vue-router";
 import {ContractByAddressCache} from "@/utils/cache/ContractByAddressCache";
 import {AccountByAddressCache} from "@/utils/cache/AccountByAddressCache";
+import router, {routeManager} from "@/utils/RouteManager.ts";
 
 const props = defineProps({
   accountAddress: String,

--- a/src/pages/BlockDetails.vue
+++ b/src/pages/BlockDetails.vue
@@ -116,12 +116,12 @@ import PageFrameV2 from "@/components/page/PageFrameV2.vue";
 import PlainAmount from "@/components/values/PlainAmount.vue";
 import BlockTransactionTable from "@/components/block/BlockTransactionTable.vue";
 import {TransactionGroupByBlockCache} from "@/utils/cache/TransactionGroupByBlockCache";
-import {routeManager} from "@/router";
 import MirrorLink from "@/components/MirrorLink.vue";
 import DashboardCardV2 from "@/components/DashboardCardV2.vue";
 import ButtonView from "@/elements/ButtonView.vue";
 import {ArrowLeft, ArrowRight} from 'lucide-vue-next';
 import {ButtonSize} from "@/dialogs/core/DialogUtils.ts";
+import {routeManager} from "@/utils/RouteManager.ts";
 
 const props = defineProps({
   blockHon: String,

--- a/src/pages/ContractDetails.vue
+++ b/src/pages/ContractDetails.vue
@@ -235,7 +235,6 @@ import Property from "@/components/Property.vue";
 import {AccountByIdCache} from "@/utils/cache/AccountByIdCache";
 import {ContractLocParser} from "@/utils/parser/ContractLocParser";
 import {NetworkConfig} from "@/config/NetworkConfig";
-import {routeManager} from "@/router";
 import TransactionLink from "@/components/values/TransactionLink.vue";
 import EVMAddress from "@/components/values/EVMAddress.vue";
 import ContractByteCodeSection from "@/components/contract/ContractByteCodeSection.vue";
@@ -257,6 +256,7 @@ import {ERCAnalyzer} from "@/utils/analyzer/ERCAnalyzer.ts";
 import DomainLabel from "@/components/values/DomainLabel.vue";
 import PublicLabel from "@/components/values/PublicLabel.vue";
 import {PublicLabelsCache} from "@/utils/cache/PublicLabelsCache.ts";
+import {routeManager} from "@/utils/RouteManager.ts";
 
 const props = defineProps({
   contractId: String,

--- a/src/pages/MainDashboard.vue
+++ b/src/pages/MainDashboard.vue
@@ -63,7 +63,8 @@ import ChartView from "@/charts/core/ChartView.vue";
 import {NetworkFeeController} from "@/charts/hgraph/NetworkFeeController.ts";
 import {ActiveAccountController} from "@/charts/hgraph/ActiveAccountController.ts";
 import {ThemeController} from "@/components/ThemeController.ts";
-import {routeManager} from "@/router.ts";
+
+import {routeManager} from "@/utils/RouteManager.ts";
 
 defineProps({
   network: String

--- a/src/pages/NftDetails.vue
+++ b/src/pages/NftDetails.vue
@@ -155,7 +155,6 @@
 
 <script setup lang="ts">
 import {computed, inject, onBeforeUnmount, onMounted, ref, watch} from "vue"
-import router, {routeManager} from "@/router"
 import TimestampValue from "@/components/values/TimestampValue.vue"
 import BlobValue from "@/components/values/BlobValue.vue"
 import PageFrameV2 from "@/components/page/PageFrameV2.vue";
@@ -179,6 +178,7 @@ import NftPreview from "@/components/token/NftPreview.vue";
 import {CoreConfig} from "@/config/CoreConfig";
 import DashboardCardV2 from "@/components/DashboardCardV2.vue";
 import PlayPauseButton from "@/components/PlayPauseButton.vue";
+import router, {routeManager} from "@/utils/RouteManager.ts";
 
 const props = defineProps({
   tokenId: {

--- a/src/pages/NodeAdminKeyDetails.vue
+++ b/src/pages/NodeAdminKeyDetails.vue
@@ -44,7 +44,8 @@ import PageFrameV2 from "@/components/page/PageFrameV2.vue";
 import KeyValue from "@/components/values/KeyValue.vue";
 import DashboardCardV2 from "@/components/DashboardCardV2.vue";
 import {NodeAnalyzer} from "@/utils/analyzer/NodeAnalyzer.ts";
-import {routeManager} from "@/router.ts";
+
+import {routeManager} from "@/utils/RouteManager.ts";
 
 const props = defineProps({
   nodeId: {

--- a/src/pages/NodeDetails.vue
+++ b/src/pages/NodeDetails.vue
@@ -189,13 +189,13 @@ import {PathParam} from "@/utils/PathParam";
 import {NodeAnalyzer} from "@/utils/analyzer/NodeAnalyzer";
 import {NetworkNode} from "@/schemas/MirrorNodeSchemas";
 import {makeStakePercentage} from "@/schemas/MirrorNodeUtils.ts";
-import {routeManager} from "@/router";
 import {CoreConfig} from "@/config/CoreConfig.ts";
 import DashboardCardV2 from "@/components/DashboardCardV2.vue";
 import NetworkDashboardItemV2 from "@/components/node/NetworkDashboardItemV2.vue";
 import MirrorLink from "@/components/MirrorLink.vue";
 import HexaValue from "@/components/values/HexaValue.vue";
 import {loadingKey} from "@/AppKeys.ts";
+import {routeManager} from "@/utils/RouteManager.ts";
 
 const props = defineProps({
   nodeId: {

--- a/src/pages/Nodes.vue
+++ b/src/pages/Nodes.vue
@@ -91,10 +91,10 @@ import {formatSeconds} from "@/utils/Duration";
 import {StakeCache} from "@/utils/cache/StakeCache";
 import {NetworkAnalyzer} from "@/utils/analyzer/NetworkAnalyzer";
 import {makeAnnualizedRate} from "@/schemas/MirrorNodeUtils.ts";
-import {routeManager} from "@/router";
 import {CoreConfig} from "@/config/CoreConfig.ts";
 import DashboardCardV2 from "@/components/DashboardCardV2.vue";
 import NetworkDashboardItemV2 from "@/components/node/NetworkDashboardItemV2.vue";
+import {routeManager} from "@/utils/RouteManager.ts";
 
 defineProps({
   network: String

--- a/src/pages/ScheduleDetails.vue
+++ b/src/pages/ScheduleDetails.vue
@@ -142,7 +142,6 @@ import BlobValue from "@/components/values/BlobValue.vue";
 import PageFrameV2 from "@/components/page/PageFrameV2.vue";
 import NotificationBanner from "@/components/NotificationBanner.vue";
 import Property from "@/components/Property.vue";
-import {routeManager} from "@/router"
 import MirrorLink from "@/components/MirrorLink.vue";
 import DashboardCardV2 from "@/components/DashboardCardV2.vue";
 import {ScheduleByIdCache} from "@/utils/cache/ScheduleByIdCache.ts";
@@ -153,6 +152,7 @@ import {base64Decode, byteToHex} from "@/utils/B64Utils.ts";
 import HexaValue from "@/components/values/HexaValue.vue";
 import {proto} from "@hashgraph/proto";
 import {loadingKey} from "@/AppKeys.ts";
+import {routeManager} from "@/utils/RouteManager.ts";
 
 const props = defineProps({
   scheduleId: String,

--- a/src/pages/Staking.vue
+++ b/src/pages/Staking.vue
@@ -113,7 +113,6 @@
 
 import {computed, onBeforeUnmount, onMounted, ref} from 'vue';
 import PageFrameV2 from "@/components/page/PageFrameV2.vue";
-import {routeManager, walletManager} from "@/router";
 import UpdateAccountDialog from "@/dialogs/UpdateAccountDialog.vue";
 import StopStakingDialog from "@/dialogs/staking/StopStakingDialog.vue";
 import AccountLink from "@/components/values/link/AccountLink.vue";
@@ -128,6 +127,7 @@ import NetworkDashboardItemV2 from "@/components/node/NetworkDashboardItemV2.vue
 import RecentRewardsSection from "@/components/staking/RecentRewardsSection.vue";
 import ButtonView from "@/elements/ButtonView.vue";
 import NotificationBanner from "@/components/NotificationBanner.vue";
+import {routeManager, walletManager} from "@/utils/RouteManager.ts";
 
 defineProps({
   network: String

--- a/src/pages/TokenDetails.vue
+++ b/src/pages/TokenDetails.vue
@@ -220,7 +220,6 @@
 
 import {computed, inject, onBeforeUnmount, onMounted} from 'vue';
 import {useRouter} from "vue-router";
-import {routeManager, walletManager} from "@/router";
 import TimestampValue from "@/components/values/TimestampValue.vue";
 import TokenBalanceTable from "@/components/token/TokenBalanceTable.vue";
 import DurationValue from "@/components/values/DurationValue.vue";
@@ -255,6 +254,7 @@ import PlayPauseButton from "@/components/PlayPauseButton.vue";
 import EntityIDView from "@/components/values/EntityIDView.vue";
 import PublicLabel from "@/components/values/PublicLabel.vue";
 import {PublicLabelsCache} from "@/utils/cache/PublicLabelsCache.ts";
+import {routeManager, walletManager} from "@/utils/RouteManager.ts";
 
 const props = defineProps({
   tokenId: {

--- a/src/pages/TransactionDetails.vue
+++ b/src/pages/TransactionDetails.vue
@@ -334,7 +334,6 @@ import ContractResult from "@/components/contract/ContractResult.vue";
 import {TransactionDetail, TransactionType} from "@/schemas/MirrorNodeSchemas";
 import TopicMessage from "@/components/topic/TopicMessage.vue";
 import {TopicMessageByTimestampCache} from "@/utils/cache/TopicMessageByTimestampCache.ts";
-import {routeManager} from "@/router"
 import TokenLink from "@/components/values/link/TokenLink.vue";
 import {TransactionLocParser} from "@/utils/parser/TransactionLocParser";
 import {TransactionGroupAnalyzer} from "@/components/transaction/TransactionGroupAnalyzer";
@@ -354,6 +353,7 @@ import KeyValue from "@/components/values/KeyValue.vue";
 import {HbarPriceCache} from "@/utils/cache/HbarPriceCache.ts";
 import {cryptoRateToPrice} from "@/schemas/MirrorNodeUtils.ts";
 import TransactionIdValue from "@/components/values/TransactionIdValue.vue";
+import {routeManager} from "@/utils/RouteManager.ts";
 
 const MAX_INLINE_CHILDREN = 10
 

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,10 +1,1 @@
 // SPDX-License-Identifier: Apache-2.0
-
-import {RouteManager} from "@/utils/RouteManager";
-import {WalletManagerV4} from "@/utils/wallet/WalletManagerV4.ts";
-
-export const routeManager = new RouteManager()
-export const walletManager = new WalletManagerV4(routeManager)
-
-const router = routeManager.router
-export default router

--- a/src/schemas/SystemContractRegistry.ts
+++ b/src/schemas/SystemContractRegistry.ts
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {EntityID} from "@/utils/EntityID";
-import {routeManager} from "@/router.ts";
 import {ethers} from "ethers";
+import {routeManager} from "@/utils/RouteManager.ts";
 
 export class SystemContractRegistry {
 

--- a/src/utils/RouteManager.ts
+++ b/src/utils/RouteManager.ts
@@ -49,6 +49,7 @@ import {CoreConfig} from "@/config/CoreConfig";
 import {NetworkConfig, NetworkEntry} from "@/config/NetworkConfig";
 import ERC20ByName from "@/pages/ERC20ByName.vue";
 import ERC721ByName from "@/pages/ERC721ByName.vue";
+import {WalletManagerV4} from "@/utils/wallet/WalletManagerV4.ts";
 
 export class RouteManager {
 
@@ -1052,3 +1053,6 @@ const routes: Array<RouteRecordRaw> = [
 ]
 
 
+export const routeManager = new RouteManager()
+export const walletManager = new WalletManagerV4(routeManager)
+export default routeManager.router;

--- a/src/utils/analyzer/ContractResultAnalyzer.ts
+++ b/src/utils/analyzer/ContractResultAnalyzer.ts
@@ -7,7 +7,8 @@ import {computed, ref, Ref, watch, WatchStopHandle} from "vue"
 import {ContractResultByTsCache} from "@/utils/cache/ContractResultByTsCache";
 import {ContractByAddressCache} from "@/utils/cache/ContractByAddressCache";
 import {systemContractRegistry} from "@/schemas/SystemContractRegistry";
-import {routeManager} from "@/router.ts";
+
+import {routeManager} from "@/utils/RouteManager.ts";
 
 export class ContractResultAnalyzer {
 

--- a/src/utils/cache/ERC1155Cache.ts
+++ b/src/utils/cache/ERC1155Cache.ts
@@ -2,7 +2,8 @@
 
 import {SingletonCache} from "@/utils/cache/base/SingletonCache";
 import axios from "axios";
-import {routeManager} from "@/router";
+
+import {routeManager} from "@/utils/RouteManager.ts";
 
 export class ERC1155Cache extends SingletonCache<ERC1155Index> {
 

--- a/src/utils/cache/ERC20Cache.ts
+++ b/src/utils/cache/ERC20Cache.ts
@@ -2,7 +2,8 @@
 
 import axios from "axios";
 import {SingletonCache} from "@/utils/cache/base/SingletonCache";
-import {routeManager} from "@/router";
+
+import {routeManager} from "@/utils/RouteManager.ts";
 
 export class ERC20Cache extends SingletonCache<ERC20Contract[]> {
 

--- a/src/utils/cache/ERC721Cache.ts
+++ b/src/utils/cache/ERC721Cache.ts
@@ -2,7 +2,8 @@
 
 import axios from "axios";
 import {SingletonCache} from "@/utils/cache/base/SingletonCache";
-import {routeManager} from "@/router";
+
+import {routeManager} from "@/utils/RouteManager.ts";
 
 export class ERC721Cache extends SingletonCache<ERC721Contract[]> {
 

--- a/src/utils/cache/PublicLabelsCache.ts
+++ b/src/utils/cache/PublicLabelsCache.ts
@@ -2,7 +2,8 @@
 
 import {SingletonCache} from "@/utils/cache/base/SingletonCache";
 import axios from "axios";
-import {routeManager} from "@/router";
+
+import {routeManager} from "@/utils/RouteManager.ts";
 
 export class PublicLabelsCache extends SingletonCache<PublicLabelsIndex> {
 

--- a/src/utils/cache/SelectedTokensCache.ts
+++ b/src/utils/cache/SelectedTokensCache.ts
@@ -2,7 +2,8 @@
 
 import {SingletonCache} from "@/utils/cache/base/SingletonCache";
 import axios from "axios";
-import {routeManager} from "@/router";
+
+import {routeManager} from "@/utils/RouteManager.ts";
 
 export class SelectedTokensCache extends SingletonCache<SelectedTokensIndex> {
 

--- a/src/utils/cache/SourcifyCache.ts
+++ b/src/utils/cache/SourcifyCache.ts
@@ -4,7 +4,8 @@ import axios, {AxiosResponse} from "axios";
 import {EntityCache} from "@/utils/cache/base/EntityCache";
 import {SolcMetadata} from "@/utils/solc/SolcMetadata";
 import {ContractByIdCache} from "@/utils/cache/ContractByIdCache";
-import {routeManager} from "@/router";
+
+import {routeManager} from "@/utils/RouteManager.ts";
 
 export class SourcifyCache extends EntityCache<string, SourcifyRecord | null> {
 

--- a/src/utils/cache/VerifiedContractsBuffer.ts
+++ b/src/utils/cache/VerifiedContractsBuffer.ts
@@ -2,8 +2,8 @@
 
 import {Contract, ContractsResponse, TransactionResponse} from "@/schemas/MirrorNodeSchemas";
 import axios, {AxiosResponse} from "axios";
-import {routeManager} from "@/router";
 import {SourcifyCache} from "@/utils/cache/SourcifyCache";
+import {routeManager} from "@/utils/RouteManager.ts";
 
 export class VerifiedContractsBuffer {
 

--- a/src/utils/name_service/NameQuery.ts
+++ b/src/utils/name_service/NameQuery.ts
@@ -2,9 +2,9 @@
 
 
 import {computed, ref, Ref, watch, WatchStopHandle} from "vue";
-import {routeManager} from "@/router";
 import {AppStorage} from "@/AppStorage";
 import {NameRecord, NameService} from "@/utils/name_service/NameService";
+import {routeManager} from "@/utils/RouteManager.ts";
 
 export class NameQuery {
 

--- a/src/utils/parser/AccountLocParser.ts
+++ b/src/utils/parser/AccountLocParser.ts
@@ -8,11 +8,11 @@ import {AccountAlias} from "@/utils/AccountAlias";
 import {AccountByIdCache} from "@/utils/cache/AccountByIdCache";
 import {AccountBalanceTransactions, Key, TokenBalance} from "@/schemas/MirrorNodeSchemas";
 import {NetworkConfig} from "@/config/NetworkConfig";
-import {routeManager} from "@/router";
 import {NodeAnalyzer} from "@/utils/analyzer/NodeAnalyzer";
 import {makeEthAddressForAccount} from "@/schemas/MirrorNodeUtils.ts";
 import {AccountByAddressCache} from "@/utils/cache/AccountByAddressCache";
 import {AccountByAliasCache} from "@/utils/cache/AccountByAliasCache";
+import {routeManager} from "@/utils/RouteManager.ts";
 
 export class AccountLocParser {
 

--- a/src/utils/sourcify/SourcifyUtils.ts
+++ b/src/utils/sourcify/SourcifyUtils.ts
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import {routeManager} from "@/router";
 import {ContractByIdCache} from "@/utils/cache/ContractByIdCache";
 import axios from "axios";
+import {routeManager} from "@/utils/RouteManager.ts";
 
 export class SourcifyUtils {
 

--- a/src/utils/wallet/EIP6963Agent.ts
+++ b/src/utils/wallet/EIP6963Agent.ts
@@ -7,7 +7,6 @@ import {AccountByAddressCache} from "@/utils/cache/AccountByAddressCache";
 import {WalletSession} from "@/utils/wallet/WalletSession";
 import {WalletClient} from "@/utils/wallet/client/WalletClient";
 import {HEDERA_LOGO, networkToChainId, WalletClient_Ethereum} from "@/utils/wallet/client/WalletClient_Ethereum";
-import {routeManager} from "@/router";
 import {EIP6963AnnounceProviderEvent, EIP6963ProviderDetail} from "@/utils/wallet/eip6963";
 import {
     AddEthereumChainParameter,
@@ -20,6 +19,7 @@ import {
     wallet_revokePermissions,
     wallet_switchEthereumChain
 } from "@/utils/wallet/eip1193";
+import {routeManager} from "@/utils/RouteManager.ts";
 
 
 export class EIP6963Agent {

--- a/src/utils/wallet/WalletConnectAgent.ts
+++ b/src/utils/wallet/WalletConnectAgent.ts
@@ -11,11 +11,11 @@ import {CAAccountId, CAChainId} from "@/utils/wallet/caip";
 import {AccountByIdCache} from "@/utils/cache/AccountByIdCache";
 import type SignClient from "@walletconnect/sign-client";
 import {ProposalTypes, SessionTypes, SignClientTypes} from "@walletconnect/types";
-import {routeManager} from "@/router";
 import type {WalletConnectModal} from "@walletconnect/modal"; // "type" to avoid unit test break
 import {AccountByAddressCache} from "@/utils/cache/AccountByAddressCache";
 import {EntityID} from "@/utils/EntityID";
 import {getSdkError} from "@walletconnect/utils";
+import {routeManager} from "@/utils/RouteManager.ts";
 
 export class WalletConnectAgent {
 

--- a/tests/unit/App.spec.ts
+++ b/tests/unit/App.spec.ts
@@ -2,7 +2,6 @@
 
 import {describe, expect, test} from 'vitest'
 import {flushPromises, mount} from "@vue/test-utils"
-import router from "@/router";
 import axios from "axios";
 import {SAMPLE_NETWORK_EXCHANGERATE, SAMPLE_NETWORK_SUPPLY, SAMPLE_TOKEN, SAMPLE_TRANSACTIONS} from "./Mocks";
 import App from "@/App.vue";
@@ -10,10 +9,10 @@ import MockAdapter from "axios-mock-adapter";
 import Oruga from "@oruga-ui/oruga-next";
 import {HMSF} from "@/utils/HMSF";
 import {NetworkConfig} from "@/config/NetworkConfig.ts";
-import {routeManager} from "@/router.ts";
 import MainDashboardHeader from "@/components/page/header/MainDashboardHeader.vue";
 import Footer from "@/components/page/Footer.vue";
 import ChartView from "@/charts/core/ChartView.vue";
+import router, {routeManager} from "@/utils/RouteManager.ts";
 
 /*
     Bookmarks

--- a/tests/unit/account/AccountDetails.spec.ts
+++ b/tests/unit/account/AccountDetails.spec.ts
@@ -4,7 +4,6 @@
 
 import {describe, expect, it} from 'vitest'
 import {flushPromises, mount} from "@vue/test-utils"
-import router, {routeManager} from "@/router";
 import axios from "axios";
 import AccountDetails from "@/pages/AccountDetails.vue";
 import {
@@ -40,6 +39,7 @@ import {NetworkConfig} from "@/config/NetworkConfig.ts";
 import {networkConfigKey} from "@/AppKeys.ts";
 import {fetchGetURLs} from "../MockUtils";
 import PageHeader from "@/components/page/header/PageHeader.vue";
+import router, {routeManager} from "@/utils/RouteManager.ts";
 
 /*
     Bookmarks

--- a/tests/unit/account/Accounts.spec.ts
+++ b/tests/unit/account/Accounts.spec.ts
@@ -2,7 +2,6 @@
 
 import {describe, expect, test} from 'vitest'
 import {flushPromises, mount} from "@vue/test-utils"
-import router from "@/router";
 import axios from "axios";
 import {SAMPLE_ACCOUNTS, SAMPLE_TOKEN} from "../Mocks";
 import Accounts from "@/pages/Accounts.vue";
@@ -11,6 +10,7 @@ import AccountTable from "@/components/account/AccountTable.vue";
 import MockAdapter from "axios-mock-adapter";
 import Oruga from "@oruga-ui/oruga-next";
 import {HMSF} from "@/utils/HMSF";
+import router from "@/utils/RouteManager.ts";
 
 /*
     Bookmarks

--- a/tests/unit/account/AdminKeyDetails.spec.ts
+++ b/tests/unit/account/AdminKeyDetails.spec.ts
@@ -4,7 +4,6 @@
 
 import {describe, expect, test} from 'vitest'
 import {flushPromises, mount} from "@vue/test-utils"
-import router from "@/router";
 import axios from "axios";
 import AccountDetails from "@/pages/AccountDetails.vue";
 import {SAMPLE_ACCOUNT, SAMPLE_ACCOUNT_PROTOBUF_KEY, SAMPLE_TOKEN, SAMPLE_TRANSACTIONS,} from "../Mocks";
@@ -15,6 +14,7 @@ import AdminKeyDetails from "@/pages/AdminKeyDetails.vue";
 import ComplexKeyValue from "@/components/values/ComplexKeyValue.vue";
 import KeyValue from "@/components/values/KeyValue.vue";
 import {fetchGetURLs} from "../MockUtils";
+import router from "@/utils/RouteManager.ts";
 
 /*
     Bookmarks

--- a/tests/unit/account/NodeAdminKeyDetails.spec.ts
+++ b/tests/unit/account/NodeAdminKeyDetails.spec.ts
@@ -4,7 +4,6 @@
 
 import {describe, expect, test} from 'vitest'
 import {flushPromises, mount} from "@vue/test-utils"
-import router from "@/router";
 import axios from "axios";
 import {SAMPLE_NETWORK_NODES,} from "../Mocks";
 import MockAdapter from "axios-mock-adapter";
@@ -14,6 +13,7 @@ import ComplexKeyValue from "@/components/values/ComplexKeyValue.vue";
 import KeyValue from "@/components/values/KeyValue.vue";
 import {fetchGetURLs} from "../MockUtils";
 import NodeAdminKeyDetails from "@/pages/NodeAdminKeyDetails.vue";
+import router from "@/utils/RouteManager.ts";
 
 /*
     Bookmarks

--- a/tests/unit/account/TokensSection.spec.ts
+++ b/tests/unit/account/TokensSection.spec.ts
@@ -19,8 +19,8 @@ import Oruga from "@oruga-ui/oruga-next";
 import TokensSection from "@/components/token/TokensSection.vue";
 import Tabs from "@/components/Tabs.vue";
 import {HMSF} from "@/utils/HMSF.ts";
-import router from "@/router";
 import {fetchGetURLs} from "../MockUtils";
+import router from "@/utils/RouteManager.ts";
 
 /*
     Bookmarks

--- a/tests/unit/block/BlockDetails.spec.ts
+++ b/tests/unit/block/BlockDetails.spec.ts
@@ -4,7 +4,6 @@
 
 import {describe, expect, it} from 'vitest'
 import {flushPromises, mount} from "@vue/test-utils"
-import router from "@/router";
 import axios from "axios";
 import {SAMPLE_BLOCKSRESPONSE, SAMPLE_CONTRACTCALL_TRANSACTIONS, SAMPLE_TOKEN, SAMPLE_TRANSACTIONS,} from "../Mocks";
 import MockAdapter from "axios-mock-adapter";
@@ -15,6 +14,7 @@ import BlockDetails from "@/pages/BlockDetails.vue";
 import BlockTransactionTable from "@/components/block/BlockTransactionTable.vue";
 import {PathParam} from "@/utils/PathParam";
 import {fetchGetURLs} from "../MockUtils";
+import router from "@/utils/RouteManager.ts";
 
 /*
     Bookmarks

--- a/tests/unit/block/Blocks.spec.ts
+++ b/tests/unit/block/Blocks.spec.ts
@@ -2,7 +2,6 @@
 
 import {describe, expect, it} from 'vitest'
 import {flushPromises, mount} from "@vue/test-utils"
-import router from "@/router";
 import axios from "axios";
 import {SAMPLE_BLOCKSRESPONSE} from "../Mocks";
 import DashboardCardV2 from "@/components/DashboardCardV2.vue";
@@ -12,6 +11,7 @@ import {HMSF} from "@/utils/HMSF";
 import Blocks from "@/pages/Blocks.vue";
 import BlockTable from "@/components/block/BlockTable.vue";
 import {fetchGetURLs} from "../MockUtils";
+import router from "@/utils/RouteManager.ts";
 
 /*
     Bookmarks

--- a/tests/unit/contract/ContractDetails.spec.ts
+++ b/tests/unit/contract/ContractDetails.spec.ts
@@ -4,7 +4,6 @@
 
 import {describe, expect, it} from 'vitest'
 import {flushPromises, mount} from "@vue/test-utils"
-import router, {routeManager} from "@/router";
 import axios from "axios";
 import {
     SAMPLE_ACCOUNT_BALANCES,
@@ -33,6 +32,7 @@ import {ContractStateResponse} from "@/schemas/MirrorNodeSchemas.ts";
 import {fetchGetURLs} from "../MockUtils";
 import {networkConfigKey} from "@/AppKeys.ts";
 import PageHeader from "@/components/page/header/PageHeader.vue";
+import router, {routeManager} from "@/utils/RouteManager.ts";
 
 /*
     Bookmarks

--- a/tests/unit/contract/ContractResult.spec.ts
+++ b/tests/unit/contract/ContractResult.spec.ts
@@ -4,7 +4,6 @@
 
 import {describe, expect, it} from 'vitest'
 import {flushPromises, mount} from "@vue/test-utils"
-import router from "@/router";
 import axios from "axios";
 import {
     SAMPLE_CONTRACT_RESULT_DETAILS,
@@ -23,6 +22,7 @@ import ContractActionsTable from "@/components/contract/ContractActionsTable.vue
 import ContractResultStateChangeEntry from "@/components/contract/ContractResultStateChangeEntry.vue";
 import {fetchGetURLs} from "../MockUtils";
 import {Transaction} from "@/schemas/MirrorNodeSchemas.ts";
+import router from "@/utils/RouteManager.ts";
 
 /*
     Bookmarks

--- a/tests/unit/contract/ContractResultLogEntry.spec.ts
+++ b/tests/unit/contract/ContractResultLogEntry.spec.ts
@@ -4,7 +4,6 @@
 
 import {describe, expect, it} from 'vitest'
 import {flushPromises, mount} from "@vue/test-utils"
-import router, {routeManager} from "@/router";
 import axios from "axios";
 import {SAMPLE_CONTRACT} from "../Mocks";
 import MockAdapter from "axios-mock-adapter";
@@ -13,6 +12,7 @@ import Oruga from "@oruga-ui/oruga-next";
 import ContractResultLogEntry from "@/components/contract/ContractResultLogEntry.vue";
 import {SAMPLE_LOG_RESULT, SAMPLE_SOURCIFY_RESPONSE} from "../utils/analyzer/ContractLogAnalyzer.spec";
 import {fetchGetURLs} from "../MockUtils";
+import router, {routeManager} from "@/utils/RouteManager.ts";
 
 /*
     Bookmarks

--- a/tests/unit/contract/Contracts.spec.ts
+++ b/tests/unit/contract/Contracts.spec.ts
@@ -2,7 +2,6 @@
 
 import {describe, expect, test} from 'vitest'
 import {flushPromises, mount} from "@vue/test-utils"
-import router from "@/router";
 import axios from "axios";
 import {SAMPLE_CONTRACTS} from "../Mocks";
 import Contracts from "@/pages/Contracts.vue";
@@ -12,6 +11,7 @@ import MockAdapter from "axios-mock-adapter";
 import Oruga from "@oruga-ui/oruga-next";
 import {HMSF} from "@/utils/HMSF";
 import {fetchGetURLs} from "../MockUtils";
+import router from "@/utils/RouteManager.ts";
 
 /*
     Bookmarks

--- a/tests/unit/dashboard/MainDashboard.spec.ts
+++ b/tests/unit/dashboard/MainDashboard.spec.ts
@@ -2,7 +2,6 @@
 
 import {describe, expect, test} from 'vitest'
 import {flushPromises, mount} from "@vue/test-utils"
-import router from "@/router";
 import axios from "axios";
 import {SAMPLE_NETWORK_EXCHANGERATE, SAMPLE_NETWORK_SUPPLY,} from "../Mocks";
 import MainDashboard from "@/pages/MainDashboard.vue";
@@ -11,6 +10,7 @@ import Oruga from "@oruga-ui/oruga-next";
 import {HMSF} from "@/utils/HMSF";
 import MarketDashboard from "@/components/dashboard/MarketDashboard.vue";
 import {fetchGetURLs} from "../MockUtils";
+import router from "@/utils/RouteManager.ts";
 
 /*
     Bookmarks

--- a/tests/unit/infoTooltip.spec.ts
+++ b/tests/unit/infoTooltip.spec.ts
@@ -3,8 +3,8 @@
 import {describe, expect, test} from 'vitest'
 import {flushPromises, mount} from "@vue/test-utils";
 import InfoTooltip from "@/components/InfoTooltip.vue";
-import router from "@/router";
 import Oruga from "@oruga-ui/oruga-next";
+import router from "@/utils/RouteManager.ts";
 
 describe("InfoTooltip.vue", () => {
 

--- a/tests/unit/node/NodeDetails.spec.ts
+++ b/tests/unit/node/NodeDetails.spec.ts
@@ -4,7 +4,6 @@
 
 import {describe, expect, it} from 'vitest'
 import {flushPromises, mount} from "@vue/test-utils"
-import router from "@/router";
 import axios from "axios";
 import {SAMPLE_NETWORK_NODES, SAMPLE_NETWORK_STAKE} from "../Mocks";
 import MockAdapter from "axios-mock-adapter";
@@ -12,6 +11,7 @@ import Oruga from "@oruga-ui/oruga-next";
 import {HMSF} from "@/utils/HMSF";
 import NodeDetails from "@/pages/NodeDetails.vue";
 import {fetchGetURLs} from "../MockUtils";
+import router from "@/utils/RouteManager.ts";
 
 /*
     Bookmarks

--- a/tests/unit/node/Nodes.spec.ts
+++ b/tests/unit/node/Nodes.spec.ts
@@ -2,7 +2,6 @@
 
 import {describe, expect, it} from 'vitest'
 import {flushPromises, mount} from "@vue/test-utils"
-import router from "@/router";
 import axios from "axios";
 import {SAMPLE_NETWORK_NODES, SAMPLE_NETWORK_STAKE} from "../Mocks";
 import DashboardCardV2 from "@/components/DashboardCardV2.vue";
@@ -13,6 +12,7 @@ import Nodes from "@/pages/Nodes.vue";
 import NodeTable from "@/components/node/NodeTable.vue";
 import NetworkDashboardItemV2 from "@/components/node/NetworkDashboardItemV2.vue";
 import {fetchGetURLs} from "../MockUtils";
+import router from "@/utils/RouteManager.ts";
 
 /*
     Bookmarks

--- a/tests/unit/token/NftDetails.spec.ts
+++ b/tests/unit/token/NftDetails.spec.ts
@@ -7,8 +7,8 @@ import {IPFS_METADATA_CONTENT, IPFS_METADATA_CONTENT_URL, SAMPLE_NFTS, SAMPLE_NO
 import MockAdapter from "axios-mock-adapter";
 import Oruga from "@oruga-ui/oruga-next";
 import {HMSF} from "@/utils/HMSF.ts";
-import router from "@/router";
 import NftDetails from "@/pages/NftDetails.vue";
+import router from "@/utils/RouteManager.ts";
 
 /*
     Bookmarks

--- a/tests/unit/token/TokenCell.spec.ts
+++ b/tests/unit/token/TokenCell.spec.ts
@@ -3,12 +3,12 @@
 import {describe, expect, test} from 'vitest'
 import {flushPromises, mount} from "@vue/test-utils";
 import TokenCell, {TokenCellItem} from "@/components/token/TokenCell.vue";
-import router from "@/router";
 import Oruga from "@oruga-ui/oruga-next";
 import {SAMPLE_ASSOCIATED_TOKEN, SAMPLE_NONFUNGIBLE} from "../Mocks";
 import MockAdapter from "axios-mock-adapter";
 import axios from "axios";
 import {fetchGetURLs} from "../MockUtils";
+import router from "@/utils/RouteManager.ts";
 
 describe("TokenCell.vue", () => {
 

--- a/tests/unit/token/TokenDetails.spec.ts
+++ b/tests/unit/token/TokenDetails.spec.ts
@@ -4,7 +4,6 @@
 
 import {describe, expect, it} from 'vitest'
 import {flushPromises, mount} from "@vue/test-utils"
-import router, {routeManager} from "@/router";
 import TokenDetails from "@/pages/TokenDetails.vue";
 import axios from "axios";
 import {
@@ -36,6 +35,7 @@ import {fetchGetURLs} from "../MockUtils";
 import {networkConfigKey} from "@/AppKeys.ts";
 import PageHeader from "@/components/page/header/PageHeader.vue";
 import NotificationBanner from "@/components/NotificationBanner.vue";
+import router, {routeManager} from "@/utils/RouteManager.ts";
 
 /*
     Bookmarks

--- a/tests/unit/token/Tokens.spec.ts
+++ b/tests/unit/token/Tokens.spec.ts
@@ -2,7 +2,6 @@
 
 import {describe, expect, test} from 'vitest'
 import {flushPromises, mount} from "@vue/test-utils"
-import router from "@/router";
 import axios from "axios";
 import {SAMPLE_TOKENS} from "../Mocks";
 import Tokens from "@/pages/Tokens.vue";
@@ -12,6 +11,7 @@ import MockAdapter from "axios-mock-adapter";
 import Oruga from "@oruga-ui/oruga-next";
 import {HMSF} from "@/utils/HMSF";
 import {fetchGetURLs} from "../MockUtils";
+import router from "@/utils/RouteManager.ts";
 
 /*
     Bookmarks

--- a/tests/unit/topic/TopicDetails.spec.ts
+++ b/tests/unit/topic/TopicDetails.spec.ts
@@ -2,7 +2,6 @@
 
 import {describe, expect, it} from 'vitest'
 import {flushPromises, mount} from "@vue/test-utils"
-import router, {routeManager} from "@/router";
 import axios from "axios";
 import TopicDetails from "@/pages/TopicDetails.vue";
 import TopicMessageTable from "@/components/topic/TopicMessageTable.vue";
@@ -25,6 +24,7 @@ import DashboardCardV2 from "@/components/DashboardCardV2.vue";
 import FixedFeeTable from "@/components/token/FixedFeeTable.vue";
 import {networkConfigKey} from "@/AppKeys.ts";
 import PageHeader from "@/components/page/header/PageHeader.vue";
+import router, {routeManager} from "@/utils/RouteManager.ts";
 
 /*
     Bookmarks

--- a/tests/unit/topic/Topics.spec.ts
+++ b/tests/unit/topic/Topics.spec.ts
@@ -2,7 +2,6 @@
 
 import {describe, expect, test} from 'vitest'
 import {flushPromises, mount} from "@vue/test-utils"
-import router from "@/router";
 import axios from "axios";
 import {SAMPLE_CREATETOPIC_TRANSACTIONS} from "../Mocks";
 import Topics from "@/pages/Topics.vue";
@@ -11,6 +10,7 @@ import TopicTable from "@/components/topic/TopicTable.vue";
 import MockAdapter from "axios-mock-adapter";
 import Oruga from "@oruga-ui/oruga-next";
 import {HMSF} from "@/utils/HMSF";
+import router from "@/utils/RouteManager.ts";
 
 /*
     Bookmarks

--- a/tests/unit/transaction/ScheduleDetails.spec.ts
+++ b/tests/unit/transaction/ScheduleDetails.spec.ts
@@ -4,7 +4,6 @@
 
 import {describe, expect, it} from 'vitest'
 import {flushPromises, mount} from "@vue/test-utils"
-import router from "@/router";
 import axios, {AxiosRequestConfig} from "axios";
 import {SAMPLE_SCHEDULE, SAMPLE_SCHEDULING_SCHEDULED_TRANSACTIONS} from "../Mocks";
 import MockAdapter from "axios-mock-adapter";
@@ -13,6 +12,7 @@ import {TransactionID} from "@/utils/TransactionID";
 import Oruga from "@oruga-ui/oruga-next";
 import {fetchGetURLs} from "../MockUtils";
 import ScheduleDetails from "@/pages/ScheduleDetails.vue";
+import router from "@/utils/RouteManager.ts";
 
 /*
     Bookmarks

--- a/tests/unit/transaction/TransactionByIdTable.spec.ts
+++ b/tests/unit/transaction/TransactionByIdTable.spec.ts
@@ -2,7 +2,6 @@
 
 import {describe, expect, it} from 'vitest'
 import {flushPromises, mount} from "@vue/test-utils"
-import router from "@/router";
 import {
     SAMPLE_DUDE_WITH_KEYS,
     SAMPLE_PARENT_CHILD_TRANSACTIONS,
@@ -16,6 +15,7 @@ import {Transaction} from "@/schemas/MirrorNodeSchemas";
 import TransactionByIdTable from "@/components/transaction/TransactionByIdTable.vue";
 import MockAdapter from "axios-mock-adapter";
 import axios from "axios";
+import router from "@/utils/RouteManager.ts";
 
 /*
     Bookmarks

--- a/tests/unit/transaction/TransactionDetails.spec.ts
+++ b/tests/unit/transaction/TransactionDetails.spec.ts
@@ -4,7 +4,6 @@
 
 import {describe, expect, it} from 'vitest'
 import {flushPromises, mount} from "@vue/test-utils"
-import router from "@/router";
 import TransactionDetails from "@/pages/TransactionDetails.vue";
 import HbarTransferGraphF from "@/components/transfer_graphs/HbarTransferGraphF.vue";
 import TokenTransferGraph from "@/components/transfer_graphs/TokenTransferGraphF.vue";
@@ -49,6 +48,7 @@ import Oruga from "@oruga-ui/oruga-next";
 import ContractResult from "@/components/contract/ContractResult.vue";
 import {base64Decode, byteToHex} from "@/utils/B64Utils";
 import {fetchGetURLs} from "../MockUtils";
+import router from "@/utils/RouteManager.ts";
 
 /*
     Bookmarks

--- a/tests/unit/transaction/Transactions.spec.ts
+++ b/tests/unit/transaction/Transactions.spec.ts
@@ -2,7 +2,6 @@
 
 import {describe, expect, test} from 'vitest'
 import {flushPromises, mount} from "@vue/test-utils"
-import router from "@/router";
 import axios from "axios";
 import {SAMPLE_TOKEN, SAMPLE_TRANSACTION, SAMPLE_TRANSACTIONS} from "../Mocks";
 import Transactions from "@/pages/Transactions.vue";
@@ -15,6 +14,7 @@ import MockAdapter from "axios-mock-adapter";
 import Oruga from "@oruga-ui/oruga-next";
 import {HMSF} from "@/utils/HMSF";
 import {fetchGetURLs} from "../MockUtils";
+import router from "@/utils/RouteManager.ts";
 
 /*
     Bookmarks

--- a/tests/unit/transfer_graphs/NftTransferGraph.spec.ts
+++ b/tests/unit/transfer_graphs/NftTransferGraph.spec.ts
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {describe, expect, test} from 'vitest'
-import router from "@/router";
 import {flushPromises, mount} from "@vue/test-utils";
 import NftTransferGraph from "@/components/transfer_graphs/NftTransferGraph.vue";
 import {TransactionDetail} from "@/schemas/MirrorNodeSchemas";
 import {SAMPLE_NONFUNGIBLE, SAMPLE_NONFUNGIBLE_DUDE} from "../Mocks";
 import MockAdapter from "axios-mock-adapter";
 import axios from "axios";
+import router from "@/utils/RouteManager.ts";
 
 const mock = new MockAdapter(axios as any);
 const matcher1 = "/api/v1/tokens/" + SAMPLE_NONFUNGIBLE.token_id

--- a/tests/unit/transfer_graphs/RewardTransferGraph.spec.ts
+++ b/tests/unit/transfer_graphs/RewardTransferGraph.spec.ts
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {describe, expect, test} from 'vitest'
-import router from "@/router";
 import {flushPromises, mount} from "@vue/test-utils";
 import {Transaction, TransactionDetail} from "@/schemas/MirrorNodeSchemas";
 import RewardTransferGraph from "@/components/transfer_graphs/RewardTransferGraph.vue";
@@ -12,6 +11,7 @@ import {
 } from "../Mocks";
 import MockAdapter from "axios-mock-adapter";
 import axios from "axios";
+import router from "@/utils/RouteManager.ts";
 
 describe("RewardTransferGraph.vue", () => {
 

--- a/tests/unit/transfer_graphs/TokenTransferGraphC.spec.ts
+++ b/tests/unit/transfer_graphs/TokenTransferGraphC.spec.ts
@@ -3,13 +3,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {describe, expect, test} from 'vitest'
-import router from "@/router";
 import {flushPromises, mount} from "@vue/test-utils";
 import TokenTransferGraphC from "@/components/transfer_graphs/TokenTransferGraphC.vue";
 import {Transaction} from "@/schemas/MirrorNodeSchemas";
 import {SAMPLE_TOKEN, SAMPLE_TOKEN_DUDE} from "../Mocks";
 import MockAdapter from "axios-mock-adapter";
 import axios from "axios";
+import router from "@/utils/RouteManager.ts";
 
 
 const mock = new MockAdapter(axios as any);

--- a/tests/unit/transfer_graphs/TokenTransferGraphF.spec.ts
+++ b/tests/unit/transfer_graphs/TokenTransferGraphF.spec.ts
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {describe, expect, test} from 'vitest'
-import router from "@/router";
 import {flushPromises, mount} from "@vue/test-utils";
 import TokenTransferGraph from "@/components/transfer_graphs/TokenTransferGraphF.vue";
 import {Transaction} from "@/schemas/MirrorNodeSchemas";
 import {SAMPLE_TOKEN, SAMPLE_TOKEN_DUDE} from "../Mocks";
 import MockAdapter from "axios-mock-adapter";
 import axios from "axios";
+import router from "@/utils/RouteManager.ts";
 
 
 const mock = new MockAdapter(axios as any);

--- a/tests/unit/utils/ContractAnalyzer.spec.ts
+++ b/tests/unit/utils/ContractAnalyzer.spec.ts
@@ -10,8 +10,8 @@ import axios from "axios";
 import {ContractAnalyzer, GlobalState} from "@/utils/analyzer/ContractAnalyzer";
 import {SAMPLE_CONTRACT, SAMPLE_TOKEN, SAMPLE_TOKEN_WITH_KEYS} from "../Mocks";
 import {SourcifyResponse} from "@/utils/cache/SourcifyCache";
-import {routeManager} from "@/router";
 import {fetchGetURLs} from "../MockUtils.ts";
+import {routeManager} from "@/utils/RouteManager.ts";
 
 describe("ContractAnalyzer.spec.ts", () => {
 

--- a/tests/unit/utils/EVMAddress.spec.ts
+++ b/tests/unit/utils/EVMAddress.spec.ts
@@ -3,11 +3,11 @@
 import {describe, expect, test, vi} from 'vitest'
 import {flushPromises, mount} from "@vue/test-utils";
 import EVMAddress from "@/components/values/EVMAddress.vue";
-import router from "@/router";
 import Oruga from "@oruga-ui/oruga-next";
 import {SAMPLE_ACCOUNT_WITH_NATIVE_EVM_ADDRESS} from "../Mocks";
 import MockAdapter from "axios-mock-adapter";
 import axios from "axios";
+import router from "@/utils/RouteManager.ts";
 
 describe("EVMAddress", () => {
 

--- a/tests/unit/utils/analyzer/ABIAnalyzer.spec.ts
+++ b/tests/unit/utils/analyzer/ABIAnalyzer.spec.ts
@@ -18,7 +18,8 @@ import {fetchGetURLs} from "../../MockUtils";
 import MockAdapter from "axios-mock-adapter";
 import axios from "axios";
 import {ABIController, ABIMode} from "@/components/contract/ABIController";
-import {routeManager} from "@/router";
+
+import {routeManager} from "@/utils/RouteManager.ts";
 
 
 describe("ABIAnalyzer.ts", async () => {

--- a/tests/unit/utils/analyzer/ContractLogAnalyzer.spec.ts
+++ b/tests/unit/utils/analyzer/ContractLogAnalyzer.spec.ts
@@ -9,9 +9,9 @@ import axios from "axios";
 import {ref, Ref} from "vue";
 import {ContractLogAnalyzer} from "@/utils/analyzer/ContractLogAnalyzer";
 import {ContractResultLog} from "@/schemas/MirrorNodeSchemas";
-import {routeManager} from "@/router";
 import {SourcifyResponse} from "@/utils/cache/SourcifyCache";
 import {flushPromises} from "@vue/test-utils";
+import {routeManager} from "@/utils/RouteManager.ts";
 
 describe("ContractLogAnalyzer.spec.ts", () => {
 

--- a/tests/unit/utils/analyzer/ContractResultAnalyzer.spec.ts
+++ b/tests/unit/utils/analyzer/ContractResultAnalyzer.spec.ts
@@ -9,8 +9,8 @@ import {flushPromises} from "@vue/test-utils";
 import MockAdapter from "axios-mock-adapter";
 import axios from "axios";
 import {fetchGetURLs} from "../../MockUtils";
-import {routeManager} from "@/router";
 import {Transaction} from "@/schemas/MirrorNodeSchemas.ts";
+import {routeManager} from "@/utils/RouteManager.ts";
 
 describe("ContractResultAnalyzer.spec.ts", () => {
 

--- a/tests/unit/utils/analyzer/FunctionCallAnalyzer.spec.ts
+++ b/tests/unit/utils/analyzer/FunctionCallAnalyzer.spec.ts
@@ -9,9 +9,9 @@ import {flushPromises} from "@vue/test-utils";
 import MockAdapter from "axios-mock-adapter";
 import axios from "axios";
 import {SignatureCache} from "@/utils/cache/SignatureCache";
-import {routeManager} from "@/router";
 import {fetchGetURLs} from "../../MockUtils.ts";
 import {ethers} from "ethers";
+import {routeManager} from "@/utils/RouteManager.ts";
 
 describe("FunctionCallAnalyzer.spec.ts", () => {
 

--- a/tests/unit/values/AccountLink.spec.ts
+++ b/tests/unit/values/AccountLink.spec.ts
@@ -2,11 +2,11 @@
 
 import {describe, expect, it} from 'vitest'
 import {flushPromises, mount} from "@vue/test-utils"
-import router from "@/router";
 import AccountLink from "@/components/values/link/AccountLink.vue";
 import {SAMPLE_NETWORK_NODES} from "../Mocks";
 import MockAdapter from "axios-mock-adapter";
 import axios from "axios";
+import router from "@/utils/RouteManager.ts";
 
 describe("AccountLink.vue", () => {
 

--- a/tests/unit/values/BlockLink.spec.ts
+++ b/tests/unit/values/BlockLink.spec.ts
@@ -2,8 +2,8 @@
 
 import {describe, expect, it} from 'vitest'
 import {mount} from "@vue/test-utils"
-import router from "@/router";
 import BlockLink from "@/components/values/BlockLink.vue";
+import router from "@/utils/RouteManager.ts";
 
 describe("BlockLink.vue", () => {
 

--- a/tests/unit/values/ComplexKeyValue.spec.ts
+++ b/tests/unit/values/ComplexKeyValue.spec.ts
@@ -2,9 +2,9 @@
 
 
 import {describe, expect, it} from 'vitest'
-import router from "@/router";
 import {mount} from "@vue/test-utils";
 import ComplexKeyValue from "@/components/values/ComplexKeyValue.vue";
+import router from "@/utils/RouteManager.ts";
 
 describe("ComplexKeyValue.vue", () => {
 

--- a/tests/unit/values/ContractLink.spec.ts
+++ b/tests/unit/values/ContractLink.spec.ts
@@ -2,8 +2,8 @@
 
 import {describe, expect, test} from 'vitest'
 import {mount} from "@vue/test-utils"
-import router from "@/router";
 import ContractLink from "@/components/values/link/ContractLink.vue";
+import router from "@/utils/RouteManager.ts";
 
 describe("ContractLink.vue", () => {
 

--- a/tests/unit/values/OpcodeValue.spec.ts
+++ b/tests/unit/values/OpcodeValue.spec.ts
@@ -14,7 +14,8 @@ import OpcodeValue from "@/components/values/OpcodeValue.vue";
 import MockAdapter from "axios-mock-adapter";
 import axios from "axios";
 import {DisassembledOpcodeOutput} from "@/utils/bytecode_tools/disassembler/utils/helpers";
-import router from "@/router";
+
+import router from "@/utils/RouteManager.ts";
 
 describe("OpcodeValue.vue", () => {
 

--- a/tests/unit/values/SmartLink.spec.ts
+++ b/tests/unit/values/SmartLink.spec.ts
@@ -2,11 +2,11 @@
 
 import {describe, expect, test} from 'vitest'
 import {flushPromises, mount} from "@vue/test-utils"
-import router from "@/router";
 import SmartLink from "@/components/values/link/SmartLink.vue";
 import MockAdapter from "axios-mock-adapter";
 import axios from "axios";
 import {SAMPLE_NETWORK_NODES} from "../Mocks";
+import router from "@/utils/RouteManager.ts";
 
 describe("SmartLink.vue", () => {
 

--- a/tests/unit/values/TokenAmount.spec.ts
+++ b/tests/unit/values/TokenAmount.spec.ts
@@ -9,13 +9,13 @@
 
 import {afterAll, beforeAll, describe, expect, it} from 'vitest'
 import {flushPromises, mount} from "@vue/test-utils";
-import router from "@/router";
 import {SAMPLE_TOKEN, SAMPLE_TOKEN_DUDE, SAMPLE_TOKEN_WITH_LARGE_DECIMAL_COUNT} from "../Mocks";
 import TokenAmount from "@/components/values/TokenAmount.vue";
 import MockAdapter from "axios-mock-adapter";
 import axios from "axios";
 import Oruga from "@oruga-ui/oruga-next";
 import {truncateTokenSymbol} from "./TokenLink.spec";
+import router from "@/utils/RouteManager.ts";
 
 describe("TokenAmount.vue", () => {
 

--- a/tests/unit/values/TokenExtra.spec.ts
+++ b/tests/unit/values/TokenExtra.spec.ts
@@ -9,12 +9,12 @@
 
 import {describe, expect, it} from 'vitest'
 import {flushPromises, mount} from "@vue/test-utils";
-import router from "@/router";
 import {SAMPLE_TOKEN, SAMPLE_TOKEN_DUDE} from "../Mocks";
 import MockAdapter from "axios-mock-adapter";
 import axios from "axios";
 import TokenExtra from "@/components/values/link/TokenExtra.vue";
 import {truncateTokenSymbol} from "./TokenLink.spec";
+import router from "@/utils/RouteManager.ts";
 
 describe("TokenExtra.vue", () => {
 

--- a/tests/unit/values/TokenLink.spec.ts
+++ b/tests/unit/values/TokenLink.spec.ts
@@ -11,10 +11,10 @@
 import {describe, expect, it} from 'vitest'
 import {flushPromises, mount} from "@vue/test-utils";
 import TokenLink from "@/components/values/link/TokenLink.vue";
-import router from "@/router";
 import {SAMPLE_TOKEN, SAMPLE_TOKEN_DUDE} from "../Mocks";
 import MockAdapter from "axios-mock-adapter";
 import axios from "axios";
+import router from "@/utils/RouteManager.ts";
 
 describe("TokenLink.vue", () => {
 

--- a/tests/unit/values/TopicLink.spec.ts
+++ b/tests/unit/values/TopicLink.spec.ts
@@ -3,7 +3,8 @@
 import {describe, expect, it} from 'vitest'
 import {mount} from "@vue/test-utils"
 import TopicLink from "@/components/values/link/TopicLink.vue"
-import router from "@/router";
+
+import router from "@/utils/RouteManager.ts";
 
 describe("TopicLink.vue", () => {
 


### PR DESCRIPTION
**Description**:

Changes below move some declarations:
- `router` and `routeManager` singletons moves from `router.ts` to `RouteManager.ts`
- `routes` array moves from `RouteManager.ts` to `router.ts`

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
