### PR TITLE
feat: better decoding of calls to redirectForToken()

### DIFF
--- a/src/components/contract/ContractActionDetails.vue
+++ b/src/components/contract/ContractActionDetails.vue
@@ -38,9 +38,9 @@
         <PlainAmount :amount="action?.gas_used"/>
       </template>
     </Property>
-    <FunctionError :analyzer="functionCallAnalyzer" :custom-nb-col-class="propertySizeClass" :show-none="true"/>
-    <FunctionInput :analyzer="functionCallAnalyzer" :custom-nb-col-class="propertySizeClass" :show-none="true"/>
+    <FunctionInput :analyzer="functionCallAnalyzer" :custom-nb-col-class="propertySizeClass"/>
     <FunctionResult :analyzer="functionCallAnalyzer" :custom-nb-col-class="propertySizeClass" :show-none="true"/>
+    <FunctionError :analyzer="functionCallAnalyzer" :custom-nb-col-class="propertySizeClass" :show-none="true"/>
   </div>
 </template>
 

--- a/src/components/values/FunctionError.vue
+++ b/src/components/values/FunctionError.vue
@@ -5,9 +5,10 @@
 <!-- --------------------------------------------------------------------------------------------------------------- -->
 
 <template>
-  <template v-if="errorSignature">
-    <template v-if="error">
-      <div class="h-sub-section">Error</div>
+  <template v-if="errorInputs.length >= 1">
+    <div class="h-sub-section">Error</div>
+
+    <template v-if="errorSignature">
 
       <Property :custom-nb-col-class="customNbColClass" id="errorFunction">
         <template #name>
@@ -18,24 +19,15 @@
           <div class="h-is-extra-text h-should-wrap">{{ errorSignature }}</div>
         </template>
       </Property>
-
-      <template v-for="arg in errorInputs" :key="arg.name">
-        <Property :custom-nb-col-class="customNbColClass" :keep-case="true">
-          <template #name>
-            <span style="padding-left: 16px;">{{ arg.name != "" ? arg.name : "message" }}</span>
-          </template>
-          <template #value>
-            <FunctionValue :ntv="arg"/>
-          </template>
-        </Property>
-      </template>
     </template>
 
-    <template v-else>
-      <Property :custom-nb-col-class="customNbColClass" id="functionInput">
-        <template #name>Error Message</template>
+    <template v-for="arg in errorInputs" :key="arg.name">
+      <Property :custom-nb-col-class="customNbColClass" :keep-case="true">
+        <template #name>
+          <span style="padding-left: 16px;">{{ arg.name != "" ? arg.name : "message" }}</span>
+        </template>
         <template #value>
-          <HexaDumpValue :show-none="true"/>
+          <FunctionValue :ntv="arg"/>
         </template>
       </Property>
     </template>

--- a/src/components/values/FunctionValue.vue
+++ b/src/components/values/FunctionValue.vue
@@ -32,7 +32,7 @@
 import {computed, inject, PropType, ref} from 'vue';
 import {initialLoadingKey} from "@/AppKeys";
 import EVMAddress from "@/components/values/EVMAddress.vue";
-import {NameTypeValue} from "@/utils/analyzer/FunctionCallAnalyzer";
+import {NameTypeValue} from "@/utils/analyzer/call/FunctionCallDecoder.ts";
 
 const props = defineProps({
   ntv: Object as PropType<NameTypeValue>,

--- a/src/components/values/SignatureValue.vue
+++ b/src/components/values/SignatureValue.vue
@@ -11,7 +11,7 @@
       <div class="h-is-extra-text h-should-wrap">{{ signature }}</div>
       <Tooltip v-if="is4byteSignature"
                text="Decoding of the signature provided by the 4byte.directory Signature Database">
-        <span class="h-has-pill" style="background-color: var(--status-success-color)">4byte</span>
+        <span class="h-has-pill h-chip-success">4byte</span>
       </Tooltip>
     </div>
   </div>

--- a/src/schemas/MirrorNodeUtils.ts
+++ b/src/schemas/MirrorNodeUtils.ts
@@ -305,6 +305,13 @@ export function decodeRedirectForTokenInput(functionFragment: ethers.FunctionFra
     }
 }
 
+export function decodeRedirectForTokenOutput(output: string): ethers.Result {
+    // Official signature of redirectToken is:
+    //      function redirectForToken(address token, bytes encodedFunctionSelector) returns (int64 responseCode, bytes response)
+    // But output params return by mirror node contains "bytes response".
+    return new ethers.Result([output])
+}
+
 export function resolveFunctionFragmentForHTSProxyContract(functionFragment: ethers.FunctionFragment, inputArgs: string): ethers.FunctionFragment {
     const inputResult = decodeRedirectForTokenInput(functionFragment, inputArgs)
     const encodedFunction4BytesSignature = inputResult[1].slice(0, 10)

--- a/src/utils/analyzer/ContractActionAnalyzer.ts
+++ b/src/utils/analyzer/ContractActionAnalyzer.ts
@@ -20,7 +20,7 @@ export class ContractActionAnalyzer {
 
     public constructor(action: Ref<ContractAction | null>) {
         this.action = action
-        this.functionCallAnalyzer = new FunctionCallAnalyzer(this.input, this.output, this.error, this.toId)
+        this.functionCallAnalyzer = new FunctionCallAnalyzer(this.input, this.output, this.error, this.revertReason, this.toId)
     }
 
     public mount(): void {
@@ -97,7 +97,17 @@ export class ContractActionAnalyzer {
 
     public readonly error = computed(() => {
         let result: string | null
-        if (this.action?.value?.result_data_type != ResultDataType.OUTPUT) {
+        if (this.action?.value?.result_data_type == ResultDataType.ERROR) {
+            result = this.action?.value?.result_data ?? null
+        } else {
+            result = null
+        }
+        return result
+    })
+
+    private readonly revertReason = computed(() => {
+        let result: string | null
+        if (this.action?.value?.result_data_type == ResultDataType.REVERT_REASON) {
             result = this.action?.value?.result_data ?? null
         } else {
             result = null

--- a/src/utils/analyzer/ContractLogAnalyzer.ts
+++ b/src/utils/analyzer/ContractLogAnalyzer.ts
@@ -4,7 +4,7 @@ import {computed, ComputedRef, Ref, shallowRef, watch, WatchStopHandle} from "vu
 import {ContractResultLog} from "@/schemas/MirrorNodeSchemas";
 import {ContractAnalyzer} from "@/utils/analyzer/ContractAnalyzer";
 import {ethers} from "ethers";
-import {NameTypeValue} from "@/utils/analyzer/FunctionCallAnalyzer";
+import {NameTypeValue} from "@/utils/analyzer/call/FunctionCallDecoder.ts";
 
 export class ContractLogAnalyzer {
 

--- a/src/utils/analyzer/ContractResultAnalyzer.ts
+++ b/src/utils/analyzer/ContractResultAnalyzer.ts
@@ -24,7 +24,7 @@ export class ContractResultAnalyzer {
 
     public constructor(public readonly transaction: Ref<Transaction | null>) {
         this.functionCallAnalyzer = new FunctionCallAnalyzer(
-            this.input, this.output, this.error, this.toId, this.isContractCreate)
+            this.input, this.output, this.error, ref(null), this.toId, this.isContractCreate)
     }
 
     public mount(): void {

--- a/src/utils/analyzer/FunctionCallAnalyzer.ts
+++ b/src/utils/analyzer/FunctionCallAnalyzer.ts
@@ -1,72 +1,72 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import {computed, ComputedRef, ref, Ref, shallowRef, watch, WatchStopHandle} from "vue";
-import {ethers} from "ethers";
-import {ContractAnalyzer} from "@/utils/analyzer/ContractAnalyzer";
-import {SignatureCache, SignatureRecord, SignatureResponse} from "@/utils/cache/SignatureCache";
-import {
-    decodeRedirectForTokenInput,
-    isRedirectForTokenTx,
-    labelForResponseCode,
-    resolveFunctionFragmentForHTSProxyContract
-} from "@/schemas/MirrorNodeUtils.ts";
+import {computed, ComputedRef, ref, Ref} from "vue";
+import {FunctionCallDecoder, NameTypeValue} from "@/utils/analyzer/call/FunctionCallDecoder.ts";
+import {isRedirectForTokenTx} from "@/schemas/MirrorNodeUtils.ts";
+import {EntityID} from "@/utils/EntityID.ts";
 
 export class FunctionCallAnalyzer {
 
-    private readonly contractAnalyzer: ContractAnalyzer
-    private readonly signatureResponse = shallowRef<SignatureResponse | null>(null)
-    private readonly functionFragment = shallowRef<ethers.FunctionFragment | ethers.ConstructorFragment | null>(null)
-    private readonly is4byteFunctionFragment = ref<boolean>(false)
-    private readonly functionDecodingFailure = shallowRef<unknown>(null)
-    private readonly inputResult = shallowRef<ethers.Result | null>(null)
-    private readonly inputDecodingFailure = shallowRef<unknown>(null)
-    private readonly outputResult = shallowRef<ethers.Result | null>(null)
-    private readonly outputDecodingFailure = shallowRef<unknown>(null)
-    private readonly errorDescription = shallowRef<ethers.ErrorDescription | null>(null)
-    private readonly errorDecodingFailure = shallowRef<unknown>(null)
-    private readonly watchHandle: Ref<WatchStopHandle[]> = ref([])
+    private readonly callDecoder: FunctionCallDecoder
 
     //
     // Public
     //
 
     public constructor(
-        public readonly input: Ref<string | null>,
-        public readonly output: Ref<string | null>,
-        public readonly error: Ref<string | null>,
-        public readonly contractId: Ref<string | null>,
-        public readonly contractCreate: Ref<boolean> = ref(false)) {
-        this.contractAnalyzer = new ContractAnalyzer(contractId)
+        private readonly input: Ref<string | null>,
+        private readonly output: Ref<string | null>,
+        private readonly error: Ref<string | null>,
+        private readonly contractId: Ref<string | null>,
+        private readonly contractCreate: Ref<boolean> = ref(false)) {
+        this.callDecoder = new FunctionCallDecoder(
+            this.contractForDecoder,
+            this.inputForDecoder,
+            this.normalizedOutput,
+            this.normalizedError,
+            this.contractCreate
+        )
     }
 
     public mount(): void {
-        this.watchHandle.value = [
-            watch([this.functionHash, this.contractAnalyzer.report], this.updateSignatureResponse, {immediate: true}),
-            watch([this.functionHash, this.contractAnalyzer.interface, this.signatureResponse, this.input], this.updateFunctionFragment, {immediate: true}),
-            watch([this.input, this.functionFragment], this.updateInputResult, {immediate: true}),
-            watch([this.output, this.functionFragment], this.updateOutputResult, {immediate: true}),
-            watch([this.error, this.contractAnalyzer.interface], this.updateErrorDescription, {immediate: true})
-        ]
-        this.contractAnalyzer.mount()
+        this.callDecoder.mount()
     }
 
     public unmount(): void {
-        this.contractAnalyzer.unmount()
-        for (const wh of this.watchHandle.value) {
-            wh()
-        }
-        this.watchHandle.value = []
-        this.signatureResponse.value = null
-        this.functionFragment.value = null
-        this.functionDecodingFailure.value = null
-        this.inputResult.value = null
-        this.inputDecodingFailure.value = null
-        this.outputResult.value = null
-        this.outputDecodingFailure.value = null
-        this.errorDescription.value = null
-        this.errorDecodingFailure.value = null
-        this.is4byteFunctionFragment.value = false
+        this.callDecoder.unmount()
     }
+
+    public readonly functionHash: ComputedRef<string|null> = computed(() => {
+        let result: string|null
+        if (this.contractCreate.value) {
+            // constructor input has no 4-bytes selector
+            result = null
+        } else {
+            const input = this.input.value
+            result = input !== null ? input.slice(0, 10) : null
+        }
+        return result
+    })
+
+
+    public readonly functionParams = computed(() => {
+        let result: string | null
+        if (this.contractCreate.value) {
+            // constructor input has no 4-bytes selector
+            result = this.input.value
+        } else {
+            // function input starts with 4-bytes selector => we remove it
+            const input = this.input.value
+            result = input !== null ? "0x" + input.slice(10) : null
+        }
+        return result
+    })
+
+    public readonly isRedirect = computed(() => {
+        const contractId = this.contractId.value
+        const functionHash = this.functionHash.value
+        return contractId !== null && functionHash !== null && isRedirectForTokenTx(contractId, functionHash)
+    })
 
     public readonly normalizedInput: ComputedRef<string | null> = computed(() => {
         return this.input.value == "0x" ? null : this.input.value
@@ -80,353 +80,117 @@ export class FunctionCallAnalyzer {
         return this.error.value == "0x" ? null : this.error.value
     })
 
-    public readonly functionHash: ComputedRef<string|null> = computed(() => {
+    public readonly signature: ComputedRef<string | null> = computed(() => {
         let result: string|null
-        if (this.contractCreate.value) {
-            result = null
+        if (this.isRedirect.value) {
+            result = "function redirectForToken(address token, bytes encodedFunctionSelector) returns (int64 responseCode, bytes response)"
         } else {
-            const input = this.normalizedInput.value
-            result = input !== null ? input.slice(0, 10) : null
+            result = this.callDecoder.signature.value
         }
         return result
     })
 
-    public readonly signature: ComputedRef<string | null> = computed(() => {
-        return this.functionFragment.value?.format("full") ?? null
-    })
-
     public readonly is4byteSignature: ComputedRef<boolean> = computed(() => {
-        return this.is4byteFunctionFragment.value
+        return this.isRedirect.value ? false : this.callDecoder.is4byteSignature.value
     })
 
     public readonly errorSignature: ComputedRef<string | null> = computed(() => {
-        return this.errorDescription.value?.signature ?? null
+        return this.callDecoder.errorSignature.value
     })
 
     public readonly errorHash: ComputedRef<string | null> = computed(() => {
-        return this.errorDescription.value?.selector ?? null
+        return this.callDecoder.errorHash.value
     })
 
     public readonly inputs: ComputedRef<NameTypeValue[]> = computed(() => {
-        const result: NameTypeValue[] = []
-        if (this.functionFragment.value !== null && this.inputResult.value !== null) {
-            const results = this.inputResult.value
-            const fragmentInputs = this.functionFragment.value.inputs
-            for (let i = 0, count = results.length; i < count; i += 1) {
-                const value = results[i]
-                const name = i < fragmentInputs.length ? fragmentInputs[i].name : "?"
-                const type = i < fragmentInputs.length ? fragmentInputs[i].type : "?"
-                result.push(new NameTypeValue(name, type, value, null, null))
+        let result: NameTypeValue[]
+        if (this.isRedirect.value) {
+            const functionParams = this.functionParams.value
+            if (functionParams !== null) {
+                const tokenAddress = `0x${functionParams.slice(2, 42)}`
+                const encodedFunctionSelector = `0x${functionParams.slice(42)}`
+                result = [
+                    new NameTypeValue("token", "address", tokenAddress, null, null),
+                    new NameTypeValue("encodedFunctionSelector", "bytes", encodedFunctionSelector, null, null),
+                ]
+                if (this.callDecoder.signature.value !== null) {
+                    result.push(
+                        new NameTypeValue("signature", "string", this.callDecoder.signature.value, null, null),
+                    )
+                    for (let ntv of this.callDecoder.decodedInput.value) {
+                        result.push(ntv)
+                    }
+                }
+            } else {
+                result = []
             }
+        } else {
+            result = this.callDecoder.decodedInput.value
         }
         return result
     })
 
     public readonly outputs: ComputedRef<NameTypeValue[]> = computed(() => {
-        const result: NameTypeValue[] = []
-        if (this.functionFragment.value instanceof ethers.FunctionFragment && this.outputResult.value !== null) {
-            const results = this.outputResult.value
-            const fragmentOutputs = this.functionFragment.value.outputs
-            for (let i = 0, count = results.length; i < count; i += 1) {
-                const value = results[i]
-                const name = i < fragmentOutputs.length ? fragmentOutputs[i].name : "?"
-                const type = i < fragmentOutputs.length ? fragmentOutputs[i].type : "?"
-                const comment = i < fragmentOutputs.length ? this.makeComment(value, fragmentOutputs[i]) : null
-                result.push(new NameTypeValue(name, type, value, null, comment))
-            }
-        }
-        return result
+        return this.callDecoder.decodedOutput.value
     })
 
     public readonly errorInputs: ComputedRef<NameTypeValue[]> = computed(() => {
-        const result: NameTypeValue[] = []
-        if (this.errorDescription.value !== null) {
-            const results = this.errorDescription.value.args
-            const fragmentInputs = this.errorDescription.value?.fragment.inputs ?? []
-            for (let i = 0, count = results.length; i < count; i += 1) {
-                const value = results[i]
-                const name = i < fragmentInputs.length ? fragmentInputs[i].name : "?"
-                const type = i < fragmentInputs.length ? fragmentInputs[i].type : "?"
-                result.push(new NameTypeValue(name, type, value, null, null))
-            }
-        }
-        return result
+        return this.callDecoder.decodedError.value
     })
 
     public readonly functionDecodingStatus = computed(() => {
-        let result: string | null
-        if (this.functionDecodingFailure.value !== null) {
-            result = this.makeDecodingErrorMessage(this.functionDecodingFailure.value)
-        } else {
-            result = null
-        }
-        return result
+        return this.callDecoder.decodedFunctionStatus.value
     })
 
     public readonly inputDecodingStatus = computed(() => {
-        let result: string | null
-        if (this.inputDecodingFailure.value !== null) {
-            result = this.makeDecodingErrorMessage(this.inputDecodingFailure.value)
-        } else {
-            result = null
-        }
-        return result
+        return this.callDecoder.decodedInputStatus.value
     })
 
     public readonly outputDecodingStatus = computed(() => {
-        let result: string | null
-
-        if (this.outputDecodingFailure.value !== null) {
-            result = this.makeDecodingErrorMessage(this.outputDecodingFailure.value)
-        } else {
-            result = null
-        }
-        return result
+        return this.callDecoder.decodedOutputStatus.value
     })
 
     public readonly errorDecodingStatus = computed(() => {
-        let result: string | null
-        if (this.errorDecodingFailure.value !== null) {
-            result = this.makeDecodingErrorMessage(this.errorDecodingFailure.value)
-        } else {
-            result = null
-        }
-        return result
+        return this.callDecoder.decodedErrorStatus.value
     })
 
     public readonly inputArgsOnly = computed(() => {
-        let result: string | null
-        if (this.normalizedInput.value !== null) {
-            if (this.contractCreate.value) {
-                // constructor input has no 4-bytes selector
-                result = this.normalizedInput.value
-            } else {
-                // function input starts with 4-bytes selector => we remove it
-                result = "0x" + this.normalizedInput.value.slice(10) // "0x" + 2x4 bytes
-            }
-        } else {
-            result = null
-        }
-        return result
+        return this.functionParams.value
     })
 
     //
     // Private
     //
 
-    private makeDecodingErrorMessage(failure: unknown): string {
-        const f = failure as ethers.EthersError
-        return "Decoding Error (" + f.shortMessage + ")"
-    }
-
-    private readonly updateSignatureResponse = async () => {
-        if (this.functionHash.value !== null
-            && this.contractAnalyzer.report.value !== null
-            && this.contractAnalyzer.report.value.abi === null) {
-            try {
-                this.signatureResponse.value = await SignatureCache.instance.lookup(this.functionHash.value)
-            } catch {
-                this.signatureResponse.value = null
-            }
-        } else {
-            this.signatureResponse.value = null
-        }
-    }
-
-    private readonly updateFunctionFragment = async () => {
-        const i = this.contractAnalyzer.interface.value
-        const r = this.signatureResponse.value
-        const functionHash = this.functionHash.value
-        const contractId = this.contractAnalyzer.contractId.value
-        const inputArgs = this.inputArgsOnly.value
-
-        if (i !== null) {
-            try {
-                if (this.contractCreate.value) {
-
-                    this.functionFragment.value = getConstructor(i)
-                    this.functionDecodingFailure.value = null
-                    this.is4byteFunctionFragment.value = false
-
-                } else if (functionHash !== null && inputArgs !== null && contractId !== null) {
-
-                    const ff = i.getFunction(functionHash)
-                    this.functionDecodingFailure.value = null
-                    this.is4byteFunctionFragment.value = false
-
-                    // please refer to the ticket below for more information on this logic for redirectForToken(address,bytes) method on HTS System Contract
-                    // https://github.com/hashgraph/hedera-mirror-node-explorer/issues/921
-                    if (ff !== null && isRedirectForTokenTx(contractId, functionHash)) {
-                        this.functionFragment.value = resolveFunctionFragmentForHTSProxyContract(ff, inputArgs)
-                    } else {
-                        this.functionFragment.value = ff
-                    }
-                } else {
-                    this.functionFragment.value = null
-                    this.functionDecodingFailure.value = null
-                    this.is4byteFunctionFragment.value = false
-                }
-            } catch (failure) {
-                this.functionFragment.value = null
-                this.functionDecodingFailure.value = failure
-                this.is4byteFunctionFragment.value = false
-            }
-        } else if (r !== null && r.results.length >= 1) {
-            let r0: SignatureRecord | null
-            if (r.results.length == 1) {
-                r0 = r.results[0]
+    private readonly contractForDecoder = computed(() => {
+        let result: string|null
+        if (this.isRedirect.value) {
+            if (this.functionParams.value !== null) {
+                const tokenAddress = `0x${this.functionParams.value.slice(2, 42)}`
+                const entityId = EntityID.fromAddress(tokenAddress)
+                result = entityId !== null ? entityId.toString() : null
             } else {
-                // Mmmm ... we have multiple signatures for this selector … :(
-                // We take the first one which enables to decode input… if we have input … :/
-                if (this.inputArgsOnly.value !== null) {
-                    r0 = FunctionCallAnalyzer.resolveSignatureCollisions(r.results, this.inputArgsOnly.value)
-                } else {
-                    r0 = null // We'll see later when this.input.value is available
-                }
-            }
-            if (r0 !== null) {
-                this.functionFragment.value = ethers.FunctionFragment.from(r0.text_signature)
-                this.functionDecodingFailure.value = null
-                this.is4byteFunctionFragment.value = true
-            } else {
-                this.functionFragment.value = null
-                this.functionDecodingFailure.value = null
-                this.is4byteFunctionFragment.value = false
+                result = null
             }
         } else {
-            this.functionFragment.value = null
-            this.functionDecodingFailure.value = null
-            this.is4byteFunctionFragment.value = false
-        }
-    }
-
-    private readonly updateInputResult = () => {
-        const ff = this.functionFragment.value
-        const inputArgs = this.inputArgsOnly.value
-        const contractId = this.contractAnalyzer.contractId.value
-        const functionHash = this.functionHash.value
-
-        if (inputArgs !== null) {
-            try {
-                if (ff instanceof ethers.FunctionFragment) {
-                    // Call is a function
-                    if (contractId !== null && functionHash !== null) {
-                        if (isRedirectForTokenTx(contractId, functionHash)) {
-                            this.inputResult.value = decodeRedirectForTokenInput(ff, inputArgs)
-                            this.inputDecodingFailure.value = null
-                        } else {
-                            this.inputResult.value = ethers.AbiCoder.defaultAbiCoder().decode(ff.inputs, inputArgs)
-                            this.inputDecodingFailure.value = null
-                        }
-                    } else {
-                        this.inputResult.value = null
-                        this.inputDecodingFailure.value = null
-                    }
-                } else if (ff instanceof ethers.ConstructorFragment) {
-                    // Call is a constructor
-                    this.inputResult.value = ethers.AbiCoder.defaultAbiCoder().decode(ff.inputs, inputArgs)
-                    this.inputDecodingFailure.value = null
-                } else {
-                    this.inputResult.value = null
-                    this.inputDecodingFailure.value = null
-                }
-            } catch (failure) {
-                this.inputResult.value = null
-                this.inputDecodingFailure.value = failure
-            }
-        } else {
-            this.inputResult.value = null
-            this.inputDecodingFailure.value = null
-        }
-    }
-
-    private readonly updateOutputResult = () => {
-        const ff = this.functionFragment.value
-        const output = this.normalizedOutput.value
-        if (ff instanceof ethers.FunctionFragment && output !== null) {
-            try {
-                this.outputResult.value = ethers.AbiCoder.defaultAbiCoder().decode(ff.outputs, output)
-                this.outputDecodingFailure.value = null
-            } catch (failure) {
-                this.outputResult.value = null
-                this.outputDecodingFailure.value = failure
-            }
-        } else {
-            this.outputResult.value = null
-            this.outputDecodingFailure.value = null
-        }
-    }
-
-    private readonly updateErrorDescription = async () => {
-        const i = this.contractAnalyzer.interface.value
-        const error = this.normalizedError.value
-        if (i !== null && error !== null && error !== "0x") {
-            try {
-                this.errorDescription.value = i.parseError(error)
-                this.errorDecodingFailure.value = null
-            } catch (failure) {
-                this.errorDescription.value = null
-                this.errorDecodingFailure.value = failure
-            }
-        } else {
-            this.errorDescription.value = null
-            this.errorDecodingFailure.value = null
-        }
-    }
-
-    private static resolveSignatureCollisions(records: SignatureRecord[], inputArgs: string): SignatureRecord | null {
-        //
-        // Some selectors (like 0x70a08231) have multiple signatures registered on 4bytes.directory.
-        // We select the first signature which enables to decode inputArgs.
-        //
-        let result: SignatureRecord | null = null
-        for (const r of records) {
-            try {
-                const ff = ethers.FunctionFragment.from(r.text_signature)
-                const decodedArgs = ethers.AbiCoder.defaultAbiCoder().decode(ff.inputs, inputArgs)
-                const encodedArgs = ethers.AbiCoder.defaultAbiCoder().encode(ff.inputs, decodedArgs)
-                if (encodedArgs == inputArgs) {
-                    result = r
-                    break
-                }
-            } catch {
-                // Ignored
-            }
+            result = this.contractId.value
         }
         return result
-    }
+    })
 
-    private makeComment(value: unknown, paramType: ethers.ParamType): string | null {
-        if (this.contractAnalyzer.isSystemContract.value
-            && paramType.name == "responseCode"
-            && typeof value == "bigint") {
-            // It's a responseCode from a system contract
-            return labelForResponseCode(value)
+    private readonly inputForDecoder = computed(() => {
+        let result: string|null
+        if (this.isRedirect.value) {
+            if (this.functionParams.value !== null) {
+                result = `0x${this.functionParams.value.slice(42)}`
+            } else {
+                result = null
+            }
         } else {
-            return null
+            result = this.normalizedInput.value
         }
-    }
+        return result
+    })
 
 }
 
-export class NameTypeValue {
-    public readonly name: string
-    public readonly type: string
-    public readonly value: unknown
-    public readonly indexed: boolean | null
-    public readonly comment: string | null
-
-    public constructor(name: string, type: string, value: unknown, indexed: boolean | null = null, comment: string | null) {
-        this.name = name
-        this.type = type
-        this.value = value
-        this.indexed = indexed
-        this.comment = comment
-    }
-}
-
-
-function getConstructor(i: ethers.Interface): ethers.ConstructorFragment|null {
-    const result = i.fragments.find((f: ethers.Fragment): boolean => ethers.ConstructorFragment.isFragment(f))
-    return result as ethers.ConstructorFragment|null
-}

--- a/src/utils/analyzer/FunctionCallAnalyzer.ts
+++ b/src/utils/analyzer/FunctionCallAnalyzer.ts
@@ -17,6 +17,7 @@ export class FunctionCallAnalyzer {
         private readonly input: Ref<string | null>,
         private readonly output: Ref<string | null>,
         private readonly error: Ref<string | null>,
+        private readonly revertReason: Ref<string | null>,
         private readonly contractId: Ref<string | null>,
         private readonly contractCreate: Ref<boolean> = ref(false)) {
         this.callDecoder = new FunctionCallDecoder(
@@ -24,6 +25,7 @@ export class FunctionCallAnalyzer {
             this.inputForDecoder,
             this.normalizedOutput,
             this.normalizedError,
+            this.normalizedRevertReason,
             this.contractCreate
         )
     }
@@ -78,6 +80,10 @@ export class FunctionCallAnalyzer {
 
     public readonly normalizedError: ComputedRef<string | null> = computed(() => {
         return this.error.value == "0x" ? null : this.error.value
+    })
+
+    public readonly normalizedRevertReason: ComputedRef<string | null> = computed(() => {
+        return this.revertReason.value == "0x" ? null : this.revertReason.value
     })
 
     public readonly signature: ComputedRef<string | null> = computed(() => {

--- a/src/utils/analyzer/call/FourByteAnalyzer.ts
+++ b/src/utils/analyzer/call/FourByteAnalyzer.ts
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {Ref, shallowRef, watch, WatchStopHandle} from "vue";
+import {SignatureCache, SignatureRecord} from "@/utils/cache/SignatureCache.ts";
+import {ethers} from "ethers";
+
+export class FourByteAnalyzer {
+
+    public readonly fragment = shallowRef<ethers.FunctionFragment | ethers.ConstructorFragment | null>(null)
+    private watchHandle: WatchStopHandle|null = null
+
+
+    //
+    // Public
+    //
+
+    public constructor(
+        private readonly functionHash: Ref<string|null>,
+        private readonly functionParams: Ref<string|null>,
+        private readonly enabled: Ref<boolean>) {}
+
+
+    public mount(): void {
+        this.watchHandle = watch([this.functionHash, this.functionParams, this.enabled], this.analyze, {immediate: true})
+    }
+
+    public unmount(): void {
+        if (this.watchHandle !== null) {
+            this.watchHandle()
+            this.watchHandle = null
+        }
+        this.fragment.value = null
+    }
+
+    //
+    // Private
+    //
+
+    private readonly analyze = async () => {
+        const h = this.functionHash.value
+        const p = this.functionParams.value
+
+        if (h !== null && p !== null && this.enabled.value) {
+            this.fragment.value = await FourByteAnalyzer.search4bytes(h, p)
+        } else {
+            this.fragment.value = null
+        }
+    }
+
+    //
+    // Private (4byte)
+    //
+
+    private static async search4bytes(functionHash: string, callParams: string): Promise<ethers.FunctionFragment|null> {
+        let result: ethers.FunctionFragment|null
+        const r = await SignatureCache.instance.lookup(functionHash)
+        if (r !== null) {
+            const r0 = FourByteAnalyzer.resolveSignatureCollisions(r.results, callParams)
+            if (r0 !== null) {
+                result = ethers.FunctionFragment.from(r0.text_signature)
+            } else {
+                result = null
+            }
+        } else {
+            result = null
+        }
+        return Promise.resolve(result)
+    }
+
+    private static resolveSignatureCollisions(records: SignatureRecord[], callParams: string): SignatureRecord | null {
+        //
+        // Some selectors (like 0x70a08231) have multiple signatures registered on 4bytes.directory.
+        // We select the first signature which enables to decode inputArgs.
+        //
+        let result: SignatureRecord | null = null
+        for (const r of records) {
+            try {
+                const ff = ethers.FunctionFragment.from(r.text_signature)
+                const decodedArgs = ethers.AbiCoder.defaultAbiCoder().decode(ff.inputs, callParams)
+                const encodedArgs = ethers.AbiCoder.defaultAbiCoder().encode(ff.inputs, decodedArgs)
+                if (encodedArgs == callParams) {
+                    result = r
+                    break
+                }
+            } catch {
+                // Ignored
+            }
+        }
+        return result
+    }
+}

--- a/src/utils/analyzer/call/FunctionCallDecoder.ts
+++ b/src/utils/analyzer/call/FunctionCallDecoder.ts
@@ -1,0 +1,323 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {computed, ComputedRef, Ref} from "vue";
+import {ethers} from "ethers";
+import {ContractAnalyzer} from "@/utils/analyzer/ContractAnalyzer.ts";
+import {FourByteAnalyzer} from "@/utils/analyzer/call/FourByteAnalyzer.ts";
+
+export class FunctionCallDecoder {
+
+    private readonly contractAnalyzer: ContractAnalyzer
+    private readonly fourByteAnalyzer: FourByteAnalyzer
+
+    //
+    // Public
+    //
+
+    public constructor(
+        contractId: Ref<string | null>,
+        private readonly input: Ref<string | null>,
+        private readonly output: Ref<string | null>,
+        private readonly error: Ref<string | null>,
+        private readonly contractCreate: Ref<boolean>) {
+        this.contractAnalyzer = new ContractAnalyzer(contractId)
+        this.fourByteAnalyzer = new FourByteAnalyzer(this.functionHash, this.functionParams, this.fourByteAnalyzerEnabled)
+    }
+
+    public mount(): void {
+        this.contractAnalyzer.mount()
+        this.fourByteAnalyzer.mount()
+    }
+
+    public unmount(): void {
+        this.contractAnalyzer.unmount()
+        this.fourByteAnalyzer.unmount()
+    }
+
+    public readonly functionHash: ComputedRef<string|null> = computed(() => {
+        let result: string|null
+        if (this.contractCreate.value) {
+            // constructor input has no 4-bytes selector
+            result = null
+        } else {
+            const input = this.input.value
+            result = input !== null ? input.slice(0, 10) : null
+        }
+        return result
+    })
+
+
+    public readonly functionParams = computed(() => {
+        let result: string | null
+        if (this.contractCreate.value) {
+            // constructor input has no 4-bytes selector
+            result = this.input.value
+        } else {
+            // function input starts with 4-bytes selector => we remove it
+            const input = this.input.value
+            result = input !== null ? "0x" + input.slice(10) : null
+        }
+        return result
+    })
+
+    public readonly signature = computed(() => {
+        let result: string|null
+        if (this.fragment.value !== null) {
+            result = this.fragment.value?.format("full") ?? null
+        } else {
+            result = null
+        }
+        return result
+    })
+
+    public readonly is4byteSignature = computed(() => {
+        return this.fourByteAnalyzer.fragment.value !== null
+    })
+
+    public readonly errorSignature = computed(() => {
+        return this.errorDescription.value?.signature ?? null
+    })
+
+    public readonly errorHash = computed(() => {
+        return this.errorDescription.value?.selector ?? null
+    })
+
+    public readonly decodedFunctionStatus = computed(() => {
+        let result: string | null
+
+        const functionHash = this.functionHash.value
+        const callParams = this.functionParams.value
+        const i = this.contractAnalyzer.interface.value
+
+        if (i !== null) {
+            if (this.contractCreate.value) {
+                result = null
+            } else if (functionHash !== null && callParams !== null) {
+                try {
+                    i.getFunction(functionHash)
+                    result = null
+                } catch(error) {
+                    result = this.makeDecodingErrorMessage(error)
+                }
+            } else {
+                result = null
+            }
+        } else {
+            result = null
+        }
+        return result
+    })
+
+    public readonly decodedInput = computed<NameTypeValue[]>(() => {
+        const result: NameTypeValue[] = []
+
+        const ff = this.fragment.value
+        const functionParams = this.functionParams.value
+        if (ff !== null && functionParams !== null) {
+            try {
+                const fragmentInputs = ff.inputs
+                const r = ethers.AbiCoder.defaultAbiCoder().decode(fragmentInputs, functionParams)
+                for (let i = 0, count = r.length; i < count; i += 1) {
+                    const value = r[i]
+                    const name = i < fragmentInputs.length ? fragmentInputs[i].name : "?"
+                    const type = i < fragmentInputs.length ? fragmentInputs[i].type : "?"
+                    result.push(new NameTypeValue(name, type, value, null, null))
+                }
+            } catch {
+                // Keeps result empty
+            }
+        } else {
+            // Keeps result empty
+        }
+
+        return result
+    })
+
+    public readonly decodedInputStatus = computed(() => {
+        let result: string|null
+
+        const ff = this.fragment.value
+        const functionParams = this.functionParams.value
+        if (ff !== null && functionParams !== null) {
+            try {
+                ethers.AbiCoder.defaultAbiCoder().decode(ff.inputs, functionParams)
+                result = null
+             } catch(error) {
+                result = this.makeDecodingErrorMessage(error)
+            }
+        } else {
+            result = null
+        }
+
+        return result
+    })
+
+    public readonly decodedOutput = computed<NameTypeValue[]>(() => {
+        const result: NameTypeValue[] = []
+
+        const ff = this.fragment.value
+        const output = this.output.value
+        if (ff instanceof ethers.FunctionFragment && output !== null) {
+            try {
+                const fragmentOutputs = ff.outputs
+                const r = ethers.AbiCoder.defaultAbiCoder().decode(fragmentOutputs, output)
+                for (let i = 0, count = r.length; i < count; i += 1) {
+                    const value = r[i]
+                    const name = i < fragmentOutputs.length ? fragmentOutputs[i].name : "?"
+                    const type = i < fragmentOutputs.length ? fragmentOutputs[i].type : "?"
+                    result.push(new NameTypeValue(name, type, value, null, null))
+                }
+            } catch {
+                // Keeps result empty
+            }
+        } else {
+            // Keeps result empty
+        }
+
+        return result
+    })
+
+    public readonly decodedOutputStatus = computed(() => {
+        let result: string|null
+
+        const ff = this.fragment.value
+        const output = this.output.value
+        if (ff instanceof ethers.FunctionFragment && output !== null) {
+            try {
+                ethers.AbiCoder.defaultAbiCoder().decode(ff.outputs, output)
+                result = null
+            } catch(error) {
+                result = this.makeDecodingErrorMessage(error)
+            }
+        } else {
+            result = null
+        }
+
+        return result
+    })
+
+
+    public readonly decodedError = computed<NameTypeValue[]>(() => {
+        const result: NameTypeValue[] = []
+
+        const errorDescription = this.errorDescription.value
+        const error = this.error.value
+        if (errorDescription !== null && error !== null) {
+            try {
+                const errorArgs = errorDescription.args
+                const fragmentInputs = errorDescription.fragment.inputs ?? []
+                for (let i = 0, count = errorArgs.length; i < count; i += 1) {
+                    const value = errorArgs[i]
+                    const name = i < fragmentInputs.length ? fragmentInputs[i].name : "?"
+                    const type = i < fragmentInputs.length ? fragmentInputs[i].type : "?"
+                    result.push(new NameTypeValue(name, type, value, null, null))
+                }
+            } catch {
+                // Keeps result empty
+            }
+        } else {
+            // Keeps result empty
+        }
+
+        return result
+    })
+
+    public readonly decodedErrorStatus = computed(() => {
+        let result: string|null
+
+        const i = this.contractAnalyzer.interface.value
+        const error = this.error.value
+        if (i !== null && error !== null) {
+            try {
+                i.parseError(error)
+                result = null
+            } catch(error) {
+                result = this.makeDecodingErrorMessage(error)
+            }
+        } else {
+            result = null
+        }
+
+        return result
+    })
+
+
+    //
+    // Private
+    //
+
+    private readonly fragment = computed(() => {
+        let result: ethers.ConstructorFragment | ethers.FunctionFragment | null
+
+        const functionHash = this.functionHash.value
+        const callParams = this.functionParams.value
+        const i = this.contractAnalyzer.interface.value
+
+        if (i !== null) {
+            if (this.contractCreate.value) {
+                result = getConstructor(i)
+            } else if (functionHash !== null && callParams !== null) {
+                try {
+                    result = i.getFunction(functionHash)
+                } catch {
+                    result = null
+                }
+            } else {
+                result = null
+            }
+        } else {
+            result = this.fourByteAnalyzer.fragment.value
+        }
+        return result
+    })
+
+    private readonly errorDescription = computed(() => {
+        let result: ethers.ErrorDescription|null
+
+        const i = this.contractAnalyzer.interface.value
+        const error = this.error.value
+        if (i !== null && error !== null) {
+            try {
+                result = i.parseError(error)
+            } catch {
+                result = null
+            }
+        } else {
+            result = null
+        }
+
+        return result
+    })
+
+    private readonly fourByteAnalyzerEnabled = computed(() => {
+        // We enable four byte analysis only if contract analyzer completed without finding abi
+        return this.contractAnalyzer.report.value !== null && this.contractAnalyzer.report.value.abi === null
+    })
+
+    private makeDecodingErrorMessage(failure: unknown): string {
+        const f = failure as ethers.EthersError
+        return "Decoding Error (" + f.shortMessage + ")"
+    }
+
+}
+
+export class NameTypeValue {
+    public readonly name: string
+    public readonly type: string
+    public readonly value: unknown
+    public readonly indexed: boolean | null
+    public readonly comment: string | null
+
+    public constructor(name: string, type: string, value: unknown, indexed: boolean | null = null, comment: string | null) {
+        this.name = name
+        this.type = type
+        this.value = value
+        this.indexed = indexed
+        this.comment = comment
+    }
+}
+
+function getConstructor(i: ethers.Interface): ethers.ConstructorFragment|null {
+    const result = i.fragments.find((f: ethers.Fragment): boolean => ethers.ConstructorFragment.isFragment(f))
+    return result as ethers.ConstructorFragment|null
+}

--- a/tests/unit/utils/analyzer/FunctionCallAnalyzer.spec.ts
+++ b/tests/unit/utils/analyzer/FunctionCallAnalyzer.spec.ts
@@ -25,8 +25,9 @@ describe("FunctionCallAnalyzer.spec.ts", () => {
         const input: Ref<string | null> = ref(null)
         const output: Ref<string | null> = ref(null)
         const error: Ref<string | null> = ref(null)
+        const revertReason: Ref<string | null> = ref(null)
         const contractId: Ref<string | null> = ref(null)
-        const functionCallAnalyzer = new FunctionCallAnalyzer(input, output, error, contractId)
+        const functionCallAnalyzer = new FunctionCallAnalyzer(input, output, error, revertReason, contractId)
         await flushPromises()
         expect(fetchGetURLs(mock)).toStrictEqual([])
         expect(functionCallAnalyzer.functionHash.value).toBeNull()
@@ -192,8 +193,9 @@ describe("FunctionCallAnalyzer.spec.ts", () => {
         const input: Ref<string | null> = ref(null)
         const output: Ref<string | null> = ref(null)
         const error: Ref<string | null> = ref(null)
+        const revertReason: Ref<string | null> = ref(null)
         const contractId: Ref<string | null> = ref(null)
-        const functionCallAnalyzer = new FunctionCallAnalyzer(input, output, error, contractId)
+        const functionCallAnalyzer = new FunctionCallAnalyzer(input, output, error, revertReason, contractId)
         await flushPromises()
         expect(fetchGetURLs(mock)).toStrictEqual([])
         expect(functionCallAnalyzer.functionHash.value).toBeNull()
@@ -300,8 +302,9 @@ describe("FunctionCallAnalyzer.spec.ts", () => {
         const input: Ref<string | null> = ref(null)
         const output: Ref<string | null> = ref(null)
         const error: Ref<string | null> = ref(null)
+        const revertReason: Ref<string | null> = ref(null)
         const contractId: Ref<string | null> = ref(null)
-        const functionCallAnalyzer = new FunctionCallAnalyzer(input, output, error, contractId)
+        const functionCallAnalyzer = new FunctionCallAnalyzer(input, output, error, revertReason, contractId)
         await flushPromises()
         expect(fetchGetURLs(mock)).toStrictEqual([])
         expect(functionCallAnalyzer.functionHash.value).toBeNull()
@@ -407,9 +410,10 @@ describe("FunctionCallAnalyzer.spec.ts", () => {
         const input: Ref<string | null> = ref(null)
         const output: Ref<string | null> = ref(null)
         const error: Ref<string | null> = ref(null)
+        const revertReason: Ref<string | null> = ref(null)
         const contractId: Ref<string | null> = ref(null)
         const isContractCreate = ref(true)
-        const functionCallAnalyzer = new FunctionCallAnalyzer(input, output, error, contractId, isContractCreate)
+        const functionCallAnalyzer = new FunctionCallAnalyzer(input, output, error, revertReason, contractId, isContractCreate)
         await flushPromises()
         expect(fetchGetURLs(mock)).toStrictEqual([])
         expect(functionCallAnalyzer.functionHash.value).toBeNull()
@@ -507,8 +511,9 @@ describe("FunctionCallAnalyzer.spec.ts", () => {
         const input: Ref<string | null> = ref(null)
         const output: Ref<string | null> = ref(null)
         const error: Ref<string | null> = ref(null)
+        const revertReason: Ref<string | null> = ref(null)
         const contractId: Ref<string | null> = ref(null)
-        const functionCallAnalyzer = new FunctionCallAnalyzer(input, output, error, contractId)
+        const functionCallAnalyzer = new FunctionCallAnalyzer(input, output, error, revertReason, contractId)
         await flushPromises()
         expect(fetchGetURLs(mock)).toStrictEqual([])
         expect(functionCallAnalyzer.functionHash.value).toBeNull()
@@ -608,8 +613,9 @@ describe("FunctionCallAnalyzer.spec.ts", () => {
         const input: Ref<string | null> = ref(null)
         const output: Ref<string | null> = ref(null)
         const error: Ref<string | null> = ref(null)
+        const revertReason: Ref<string | null> = ref(null)
         const contractId: Ref<string | null> = ref(null)
-        const functionCallAnalyzer = new FunctionCallAnalyzer(input, output, error, contractId)
+        const functionCallAnalyzer = new FunctionCallAnalyzer(input, output, error, revertReason, contractId)
         await flushPromises()
         expect(fetchGetURLs(mock)).toStrictEqual([])
         expect(functionCallAnalyzer.functionHash.value).toBeNull()
@@ -649,6 +655,7 @@ describe("FunctionCallAnalyzer.spec.ts", () => {
         input.value = "0x618dc65e0000000000000000000000000000000000163b5a095ea7b300000000000000000000000000000000000000000000000000000000003c437a0000000000000000000000000000000000000000000000008ac7230489e80000"
         output.value = null
         error.value = "0x494e56414c49445f4f5045524154494f4e"
+        revertReason.value = "0x0000000000000000000000000000000000000000000000000000000000000124"
         contractId.value = "0.0.359"
         await flushPromises()
         await vi.dynamicImportSettled()
@@ -662,7 +669,9 @@ describe("FunctionCallAnalyzer.spec.ts", () => {
         expect(functionCallAnalyzer.outputs.value).toStrictEqual([])
         expect(functionCallAnalyzer.errorHash.value).toBeNull()
         expect(functionCallAnalyzer.errorSignature.value).toBeNull()
-        expect(functionCallAnalyzer.errorInputs.value).toStrictEqual([])
+        expect(functionCallAnalyzer.errorInputs.value).toStrictEqual([
+            new NameTypeValue("revertReason", "int64", 292n, null, "SPENDER_DOES_NOT_HAVE_ALLOWANCE")
+        ])
         expect(functionCallAnalyzer.inputDecodingStatus.value).toBeNull()
         expect(functionCallAnalyzer.outputDecodingStatus.value).toBeNull()
         expect(functionCallAnalyzer.errorDecodingStatus.value).toBeNull()
@@ -684,7 +693,9 @@ describe("FunctionCallAnalyzer.spec.ts", () => {
         expect(functionCallAnalyzer.outputs.value).toStrictEqual([])
         expect(functionCallAnalyzer.errorHash.value).toBeNull()
         expect(functionCallAnalyzer.errorSignature.value).toBeNull()
-        expect(functionCallAnalyzer.errorInputs.value).toStrictEqual([])
+        expect(functionCallAnalyzer.errorInputs.value).toStrictEqual([
+            new NameTypeValue("revertReason", "int64", 292n, null, "SPENDER_DOES_NOT_HAVE_ALLOWANCE")
+        ])
         expect(functionCallAnalyzer.inputDecodingStatus.value).toBeNull()
         expect(functionCallAnalyzer.outputDecodingStatus.value).toBeNull()
         expect(functionCallAnalyzer.errorDecodingStatus.value).toBeNull()
@@ -704,8 +715,9 @@ describe("FunctionCallAnalyzer.spec.ts", () => {
         const input: Ref<string | null> = ref(null)
         const output: Ref<string | null> = ref(null)
         const error: Ref<string | null> = ref(null)
+        const revertReason: Ref<string | null> = ref(null)
         const contractId: Ref<string | null> = ref(null)
-        const functionCallAnalyzer = new FunctionCallAnalyzer(input, output, error, contractId)
+        const functionCallAnalyzer = new FunctionCallAnalyzer(input, output, error, revertReason, contractId)
         await flushPromises()
         expect(fetchGetURLs(mock)).toStrictEqual([])
         expect(functionCallAnalyzer.functionHash.value).toBeNull()
@@ -743,6 +755,7 @@ describe("FunctionCallAnalyzer.spec.ts", () => {
         input.value = "0x618dc65e00000000000000000000000000000000005cea6223b872dd000000000000000000000000208b15dab9903be8d34336d0b7f930e5f0a76ec5000000000000000000000000d717723692444f3d0f18d8ec2ccae7b25fc1d696000000000000000000000000000000000000000000000000000000000000000a"
         output.value = null
         error.value = "0x0000000000000000000000000000000000000000000000000000000000000124"
+        revertReason.value = null
         contractId.value = "0.0.359"
         await flushPromises()
         await vi.dynamicImportSettled()


### PR DESCRIPTION
**Description**:
Changes below:
- refactor `FunctionCallAnalyzer` (it now delegates some tasks to `FunctionCallDecoder` and `FourByteAnalyzer`)
- add logic for decoding call embedded in `redirectForToken()`(which fixes #2005)
- update unit tests
- fix a styling issue in `SignatureValue` view

**Related issue(s)**:

Fixes #2005

**Notes for reviewer**:

- Open transaction [1748689276.438110000 ](https://hashscan.io/testnet/transaction/1748689276.438110000 )
- Go to `Call Trace` section
- Expand last call trace item

Before:

<img width="1035" alt="image" src="https://github.com/user-attachments/assets/418133fc-2c2a-416c-8e60-d6966a478a7b" />

After:

<img width="1035" alt="image" src="https://github.com/user-attachments/assets/a9dc14bb-4b32-4ceb-bf0a-8992a2131909" />


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
