### PR TITLE
feat: display remaining allowance

### DIFF
--- a/src/components/allowances/HbarAllowanceTable.vue
+++ b/src/components/allowances/HbarAllowanceTable.vue
@@ -33,6 +33,10 @@
     </o-table-column>
 
     <o-table-column v-slot="props" field="amount" label="AMOUNT" position="right">
+      <HbarAmount :amount="props.row.amount"/>
+    </o-table-column>
+
+    <o-table-column v-slot="props" field="granted" label="AMOUNT GRANTED" position="right">
       <HbarAmount :amount="props.row.amount_granted"/>
     </o-table-column>
 

--- a/src/components/allowances/HbarAllowanceTable.vue
+++ b/src/components/allowances/HbarAllowanceTable.vue
@@ -32,7 +32,7 @@
       <TimestampValue v-bind:timestamp="props.row.timestamp.from"/>
     </o-table-column>
 
-    <o-table-column v-slot="props" field="amount" label="AMOUNT" position="right">
+    <o-table-column v-slot="props" field="amount" label="AMOUNT REMAINING" position="right">
       <HbarAmount :amount="props.row.amount"/>
     </o-table-column>
 

--- a/src/components/allowances/TokenAllowanceTable.vue
+++ b/src/components/allowances/TokenAllowanceTable.vue
@@ -32,7 +32,7 @@
       <TokenLink :token-id="props.row.token_id" :show-extra="true"/>
     </o-table-column>
 
-    <o-table-column v-slot="props" field="amount" label="AMOUNT">
+    <o-table-column v-slot="props" field="amount" label="AMOUNT REMAINING">
       <TokenAmount :token-id="props.row.token_id" :amount="BigInt(props.row.amount)"/>
     </o-table-column>
 

--- a/src/components/allowances/TokenAllowanceTable.vue
+++ b/src/components/allowances/TokenAllowanceTable.vue
@@ -28,12 +28,16 @@
       <AccountLink class="entity-id" :account-id="props.row.spender" :show-extra="true"/>
     </o-table-column>
 
-    <o-table-column v-slot="props" field="amount" label="AMOUNT">
-      <TokenAmount :token-id="props.row.token_id" :amount="BigInt(props.row.amount_granted)"/>
-    </o-table-column>
-
     <o-table-column v-slot="props" field="token" label="TOKEN ID">
       <TokenLink :token-id="props.row.token_id" :show-extra="true"/>
+    </o-table-column>
+
+    <o-table-column v-slot="props" field="amount" label="AMOUNT">
+      <TokenAmount :token-id="props.row.token_id" :amount="BigInt(props.row.amount)"/>
+    </o-table-column>
+
+    <o-table-column v-slot="props" field="granted" label="AMOUNT GRANTED">
+      <TokenAmount :token-id="props.row.token_id" :amount="BigInt(props.row.amount_granted)"/>
     </o-table-column>
 
     <o-table-column v-slot="props" field="timestamp" label="TIME">

--- a/src/schemas/MirrorNodeSchemas.ts
+++ b/src/schemas/MirrorNodeSchemas.ts
@@ -81,6 +81,7 @@ export interface CryptoAllowancesResponse {
 }
 
 export interface CryptoAllowance {
+    amount: number,             // The amount remaining of the original amount granted in tinybars.
     amount_granted: number,     // The granted amount of the spender's allowance in tinybars.
     owner: string | null,       // Network entity ID in the format of shard.realm.num
     spender: string | null,     // Network entity ID in the format of shard.realm.num

--- a/tests/unit/account/HbarAllowanceTable.spec.ts
+++ b/tests/unit/account/HbarAllowanceTable.spec.ts
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {describe, expect, it} from 'vitest'
+import {flushPromises, mount} from "@vue/test-utils"
+import Oruga from "@oruga-ui/oruga-next";
+import {HMSF} from "@/utils/HMSF";
+import MockAdapter from "axios-mock-adapter";
+import axios from "axios";
+import {RouteManager} from "@/utils/RouteManager.ts";
+import HbarAllowanceTable from "@/components/allowances/HbarAllowanceTable.vue";
+import {HbarAllowanceTableController} from "@/components/allowances/HbarAllowanceTableController.ts";
+import {Router} from "vue-router";
+import {ref} from "vue";
+
+/*
+    Bookmarks
+        https://jestjs.io/docs/api
+        https://test-utils.vuejs.org/api/
+
+ */
+
+HMSF.forceUTC = true
+
+const cryptoAllowances = {
+    "allowances": [
+        {
+            "amount": 10000000000,
+            "amount_granted": 10000000000,
+            "owner": "0.0.1437",
+            "spender": "0.0.1584",
+            "timestamp": {"from": "1739314530.266092586", "to": null}
+        },
+        {
+            "amount": 1500000000,
+            "amount_granted": 1500000000,
+            "owner": "0.0.1437",
+            "spender": "0.0.1515",
+            "timestamp": {"from": "1718973027.174709785", "to": null}
+        },
+        {
+            "amount": 1400000000,
+            "amount_granted": 1400000000,
+            "owner": "0.0.1437",
+            "spender": "0.0.1414",
+            "timestamp": {"from": "1718972957.394744003", "to": null}
+        }
+    ],
+    "links": {"next": null}
+}
+
+function makeRouter(): Router {
+    const routeManager = new RouteManager()
+    return routeManager.router
+}
+
+describe("HbarAllowanceTable.vue", () => {
+
+    it("Should list hbar allowances", async () => {
+
+        const mock = new MockAdapter(axios as any);
+        const router = makeRouter()
+        const accountId = ref("0.0.1437")
+        const controller = new HbarAllowanceTableController(router, accountId, 15)
+
+        const matcher1 = "/api/v1/accounts/" + accountId.value + "/allowances/crypto"
+        mock.onGet(matcher1).reply(200, cryptoAllowances)
+
+        const wrapper = mount(HbarAllowanceTable, {
+            global: {
+                plugins: [router, Oruga]
+            },
+            props: {
+                controller: controller
+            },
+        });
+        controller.mount()
+        await flushPromises()
+        // console.log(wrapper.text())
+
+        expect(wrapper.find('thead').text()).toBe("SPENDER TIME AMOUNT AMOUNT GRANTED")
+        expect(wrapper.find('tbody').text()).toBe(
+            "0.0.1584" + "10:55:30.2660 PMFeb 11, 2025, UTC" + "100.00000000ℏ" + "100.00000000ℏ" +
+            "0.0.1515" + "12:30:27.1747 PMJun 21, 2024, UTC" + "15.00000000ℏ" + "15.00000000ℏ" +
+            "0.0.1414" + "12:29:17.3947 PMJun 21, 2024, UTC" + "14.00000000ℏ" + "14.00000000ℏ"
+        )
+
+        controller.unmount()
+        wrapper.unmount()
+        mock.restore()
+        await flushPromises()
+    });
+
+});

--- a/tests/unit/account/HbarAllowanceTable.spec.ts
+++ b/tests/unit/account/HbarAllowanceTable.spec.ts
@@ -77,7 +77,7 @@ describe("HbarAllowanceTable.vue", () => {
         await flushPromises()
         // console.log(wrapper.text())
 
-        expect(wrapper.find('thead').text()).toBe("SPENDER TIME AMOUNT AMOUNT GRANTED")
+        expect(wrapper.find('thead').text()).toBe("SPENDER TIME AMOUNT REMAINING AMOUNT GRANTED")
         expect(wrapper.find('tbody').text()).toBe(
             "0.0.1584" + "10:55:30.2660 PMFeb 11, 2025, UTC" + "100.00000000ℏ" + "100.00000000ℏ" +
             "0.0.1515" + "12:30:27.1747 PMJun 21, 2024, UTC" + "15.00000000ℏ" + "15.00000000ℏ" +

--- a/tests/unit/account/NftAllSerialsAllowanceTable.spec.ts
+++ b/tests/unit/account/NftAllSerialsAllowanceTable.spec.ts
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {describe, expect, it} from 'vitest'
+import {flushPromises, mount} from "@vue/test-utils"
+import Oruga from "@oruga-ui/oruga-next";
+import {HMSF} from "@/utils/HMSF";
+import MockAdapter from "axios-mock-adapter";
+import axios from "axios";
+import {RouteManager} from "@/utils/RouteManager.ts";
+import {Router} from "vue-router";
+import {ref} from "vue";
+import {NftAllSerialsAllowanceTableController} from "@/components/allowances/NftAllSerialsAllowanceTableController.ts";
+import NftAllSerialsAllowanceTable from "@/components/allowances/NftAllSerialsAllowanceTable.vue";
+
+/*
+    Bookmarks
+        https://jestjs.io/docs/api
+        https://test-utils.vuejs.org/api/
+
+ */
+
+HMSF.forceUTC = true
+
+const nftAllSerialAllowances = {
+    "allowances": [
+        {
+            "approved_for_all": true,
+            "owner": "0.0.1437",
+            "spender": "0.0.1500",
+            "timestamp": {"from": "1719932599.298779090", "to": null},
+            "token_id": "0.0.4457902"
+        },
+        {
+            "approved_for_all": true,
+            "owner": "0.0.1437",
+            "spender": "0.0.1584",
+            "timestamp": {"from": "1719932655.925687003", "to": null},
+            "token_id": "0.0.4457902"
+        },
+        {
+            "approved_for_all": true,
+            "owner": "0.0.1437",
+            "spender": "0.0.1584",
+            "timestamp": {"from": "1719841119.811055842", "to": null},
+            "token_id": "0.0.4458222"
+        }
+    ], "links": {"next": null}
+}
+
+function makeRouter(): Router {
+    const routeManager = new RouteManager()
+    return routeManager.router
+}
+
+describe("HbarAllowanceTable.vue", () => {
+
+    it("Should list nft (approved for all) allowances", async () => {
+
+        const mock = new MockAdapter(axios as any);
+        const router = makeRouter()
+        const accountId = ref("0.0.1437")
+        const controller = new NftAllSerialsAllowanceTableController(router, accountId, 15)
+
+        mock
+            .onGet("/api/v1/accounts/" + accountId.value + "/allowances/nfts")
+            .reply(200, nftAllSerialAllowances)
+
+        for (const allowance of nftAllSerialAllowances.allowances) {
+            const tokenId = allowance.token_id
+            const params = {
+                'token.id': tokenId,
+            }
+            mock
+                .onGet("/api/v1/accounts/" + accountId.value + "/tokens", {params: params})
+                .reply(200, [{token_id: tokenId}])
+        }
+
+        const wrapper = mount(NftAllSerialsAllowanceTable, {
+            global: {
+                plugins: [router, Oruga]
+            },
+            props: {
+                controller: controller
+            },
+        });
+        controller.mount()
+        await flushPromises()
+        console.log(wrapper.text())
+
+        expect(wrapper.find('thead').text()).toBe("SPENDER TOKEN ID TIME")
+        expect(wrapper.find('tbody').text()).toBe(
+            "0.0.1500" + "0.0.4457902" + "?" + "3:03:19.2987 PMJul 2, 2024, UTC" +
+            "0.0.1584" + "0.0.4457902" + "?" + "3:04:15.9256 PMJul 2, 2024, UTC" +
+            "0.0.1584" + "0.0.4458222" + "?" + "1:38:39.8110 PMJul 1, 2024, UTC"
+        )
+
+        controller.unmount()
+        wrapper.unmount()
+        mock.restore()
+        await flushPromises()
+    });
+
+});

--- a/tests/unit/account/NftAllowanceTable.spec.ts
+++ b/tests/unit/account/NftAllowanceTable.spec.ts
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {describe, expect, it} from 'vitest'
+import {flushPromises, mount} from "@vue/test-utils"
+import Oruga from "@oruga-ui/oruga-next";
+import {HMSF} from "@/utils/HMSF";
+import MockAdapter from "axios-mock-adapter";
+import axios from "axios";
+import {RouteManager} from "@/utils/RouteManager.ts";
+import {Router} from "vue-router";
+import {ref} from "vue";
+import {NftAllowanceTableController} from "@/components/allowances/NftAllowanceTableController.ts";
+import NftAllowanceTable from "@/components/allowances/NftAllowanceTable.vue";
+
+/*
+    Bookmarks
+        https://jestjs.io/docs/api
+        https://test-utils.vuejs.org/api/
+
+ */
+
+HMSF.forceUTC = true
+
+const nfts = {
+    "nfts": [
+        {
+            "account_id": "0.0.1437",
+            "created_timestamp": "1718907067.177742003",
+            "delegating_spender": null,
+            "deleted": false,
+            "metadata": "VGVzdA==",
+            "modified_timestamp": "1719824983.267446180",
+            "serial_number": 1,
+            "spender": "0.0.1584",
+            "token_id": "0.0.4458222"
+        },
+        {
+            "account_id": "0.0.1437",
+            "created_timestamp": "1718899707.180231003",
+            "delegating_spender": null,
+            "deleted": false,
+            "metadata": "",
+            "modified_timestamp": "1720771166.454882003",
+            "serial_number": 12,
+            "spender": "0.0.1789",
+            "token_id": "0.0.4457902"
+        },
+        {
+            "account_id": "0.0.1437",
+            "created_timestamp": "1718899707.180231003",
+            "delegating_spender": null,
+            "deleted": false,
+            "metadata": "",
+            "modified_timestamp": "1720771166.454882003",
+            "serial_number": 11,
+            "spender": "0.0.1789",
+            "token_id": "0.0.4457902"
+        }
+    ], "links": {"next": "/api/v1/accounts/0.0.1437/nfts?token.id=lte:0.0.4457902&serialnumber=lt:4"}
+}
+
+function makeRouter(): Router {
+    const routeManager = new RouteManager()
+    return routeManager.router
+}
+
+describe("HbarAllowanceTable.vue", () => {
+
+    it("Should list nft allowances", async () => {
+
+        const mock = new MockAdapter(axios as any);
+        const router = makeRouter()
+        const accountId = ref("0.0.1437")
+        const controller = new NftAllowanceTableController(router, accountId, 15)
+
+        mock
+            .onGet("/api/v1/accounts/" + accountId.value + "/nfts")
+            .reply(200, nfts)
+
+        const wrapper = mount(NftAllowanceTable, {
+            global: {
+                plugins: [router, Oruga]
+            },
+            props: {
+                controller: controller
+            },
+        });
+        controller.mount()
+        await flushPromises()
+        // console.log(wrapper.text())
+
+        expect(wrapper.find('thead').text()).toBe("TOKEN ID SERIAL # SPENDER TIME")
+        expect(wrapper.find('tbody').text()).toBe(
+            "0.0.4458222" + "?" + "1" + "0.0.1584" + "9:09:43.2674 AMJul 1, 2024, UTC" +
+            "0.0.4457902" + "?" + "12" + "0.0.1789" + "7:59:26.4548 AMJul 12, 2024, UTC" +
+            "0.0.4457902" + "?" + "11" + "0.0.1789" + "7:59:26.4548 AMJul 12, 2024, UTC"
+        )
+
+        controller.unmount()
+        wrapper.unmount()
+        mock.restore()
+        await flushPromises()
+    });
+
+});

--- a/tests/unit/account/TokenAllowanceTable.spec.ts
+++ b/tests/unit/account/TokenAllowanceTable.spec.ts
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {describe, expect, it} from 'vitest'
+import {flushPromises, mount} from "@vue/test-utils"
+import Oruga from "@oruga-ui/oruga-next";
+import {HMSF} from "@/utils/HMSF";
+import MockAdapter from "axios-mock-adapter";
+import axios from "axios";
+import {RouteManager} from "@/utils/RouteManager.ts";
+import {Router} from "vue-router";
+import {ref} from "vue";
+import {TokenAllowanceTableController} from "@/components/allowances/TokenAllowanceTableController.ts";
+import TokenAllowanceTable from "@/components/allowances/TokenAllowanceTable.vue";
+
+/*
+    Bookmarks
+        https://jestjs.io/docs/api
+        https://test-utils.vuejs.org/api/
+
+ */
+
+HMSF.forceUTC = true
+
+const tokenAllowances = {
+    "allowances": [
+        {
+            "amount": 2132000000,
+            "amount_granted": 2132000000,
+            "owner": "0.0.1437",
+            "spender": "0.0.1580",
+            "timestamp": {"from": "1720188352.354070003", "to": null},
+            "token_id": "0.0.3038008"
+        },
+        {
+            "amount": 1200,
+            "amount_granted": 1200,
+            "owner": "0.0.1437",
+            "spender": "0.0.1584",
+            "timestamp": {"from": "1720624336.763775003", "to": null},
+            "token_id": "0.0.3038008"
+        },
+        {
+            "amount": 1400,
+            "amount_granted": 1400,
+            "owner": "0.0.1437",
+            "spender": "0.0.1584",
+            "timestamp": {"from": "1718973345.354498003", "to": null},
+            "token_id": "0.0.3038433"
+        }
+    ], "links": {"next": null}
+}
+
+function makeRouter(): Router {
+    const routeManager = new RouteManager()
+    return routeManager.router
+}
+
+describe("HbarAllowanceTable.vue", () => {
+
+    it("Should list token allowances", async () => {
+
+        const mock = new MockAdapter(axios as any);
+        const router = makeRouter()
+        const accountId = ref("0.0.1437")
+        const controller = new TokenAllowanceTableController(router, accountId, 15)
+
+        mock
+            .onGet("/api/v1/accounts/" + accountId.value + "/allowances/tokens")
+            .reply(200, tokenAllowances)
+
+        for (const allowance of tokenAllowances.allowances) {
+            const tokenId = allowance.token_id
+            const params = {
+                'token.id': tokenId,
+            }
+            mock
+                .onGet("/api/v1/accounts/" + accountId.value + "/tokens", {params: params})
+                .reply(200, [{token_id: tokenId}])
+        }
+
+        const wrapper = mount(TokenAllowanceTable, {
+            global: {
+                plugins: [router, Oruga]
+            },
+            props: {
+                controller: controller
+            },
+        });
+        controller.mount()
+        await flushPromises()
+        // console.log(wrapper.text())
+
+        expect(wrapper.find('thead').text()).toBe("SPENDER TOKEN ID AMOUNT AMOUNT GRANTED TIME")
+        expect(wrapper.find('tbody').text()).toBe(
+            "0.0.1580" + "0.0.3038008" + "?" + "2:05:52.3540 PMJul 5, 2024, UTC" +
+            "0.0.1584" + "0.0.3038008" + "?" + "3:12:16.7637 PMJul 10, 2024, UTC" +
+            "0.0.1584" + "0.0.3038433" + "?" + "12:35:45.3544 PMJun 21, 2024, UTC"
+        )
+
+        controller.unmount()
+        wrapper.unmount()
+        mock.restore()
+        await flushPromises()
+    });
+
+});

--- a/tests/unit/account/TokenAllowanceTable.spec.ts
+++ b/tests/unit/account/TokenAllowanceTable.spec.ts
@@ -90,7 +90,7 @@ describe("HbarAllowanceTable.vue", () => {
         await flushPromises()
         // console.log(wrapper.text())
 
-        expect(wrapper.find('thead').text()).toBe("SPENDER TOKEN ID AMOUNT AMOUNT GRANTED TIME")
+        expect(wrapper.find('thead').text()).toBe("SPENDER TOKEN ID AMOUNT REMAINING AMOUNT GRANTED TIME")
         expect(wrapper.find('tbody').text()).toBe(
             "0.0.1580" + "0.0.3038008" + "?" + "2:05:52.3540 PMJul 5, 2024, UTC" +
             "0.0.1584" + "0.0.3038008" + "?" + "3:12:16.7637 PMJul 10, 2024, UTC" +


### PR DESCRIPTION
**Description**:

For HBAR and Fungible Token allowances, display the (remaining) amount available in addition to the granted amount since both values are now available in the API.

Add unit tests for the various allowance tables: 
`HbarAllowanceTable, TokenAllowanceTable, NftAllowanceTable, NftAllSerialsAllowanceTable`

**Related issue(s)**:

Fixes #2031 

**Notes for reviewer**:
<img width="1130" alt="Screenshot 2025-06-16 at 17 21 17" src="https://github.com/user-attachments/assets/79e2a39f-06b2-40d5-b51b-7382e77baa9c" />
<img width="1130" alt="Screenshot 2025-06-16 at 17 21 26" src="https://github.com/user-attachments/assets/028639e9-2831-495b-9da0-2a64337daee9" />

