### PR TITLE
chore: WalletConnectAgent class no longer use async promise executor

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -25,7 +25,6 @@ export default tseslint.config(
         },
         rules: {
 
-            "no-async-promise-executor": "off",
 
             "@typescript-eslint/no-explicit-any": "off",
             "@typescript-eslint/no-unused-vars": "off",

--- a/src/utils/wallet/WalletConnectAgent.ts
+++ b/src/utils/wallet/WalletConnectAgent.ts
@@ -249,21 +249,18 @@ export class WalletConnectAgent {
         approval: () => Promise<SessionTypes.Struct>,
         connectModal: WalletConnectModal): Promise<SessionTypes.Struct | null> {
 
-        return new Promise(async (resolve, reject) => {
+        return new Promise((resolve, reject) => {
             connectModal.subscribeModal((state: { open: boolean }) => {
                 if (!state.open) {
                     // User has closed the modal without flashing the QR code
                     resolve(null)
                 }
             })
-            try {
-                await connectModal.openModal({uri})
-                resolve(await approval())
-            } catch (reason) {
-                reject(reason)
-            } finally {
-                connectModal.closeModal()
-            }
+            connectModal.openModal({uri})
+                .then(() => approval())
+                .then((session) => resolve(session))
+                .catch((reason) => reject(reason))
+                .finally(() => connectModal.closeModal())
         })
     }
 }


### PR DESCRIPTION
**Description**:

Changes below fix a warning reported by `eslint` when `no-async-promise-executor` flag is on.
They re-write `WalletConnectAgent.waitForApprovalOrModalClose()` to avoid passing an `async` function to `Promise` constructor. And they switch  `no-async-promise-executor` flag on.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
