### PR TITLE
chore: enabling @typescript-eslint/no-unsafe-function-type flag in eslint config

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -29,7 +29,6 @@ export default tseslint.config(
             "@typescript-eslint/no-explicit-any": "off",
             "@typescript-eslint/no-unused-vars": "off",
             "@typescript-eslint/no-require-imports": "off",
-            "@typescript-eslint/no-unsafe-function-type": "off",
             "@typescript-eslint/no-this-alias": "off",
 
             "vue/no-reserved-component-names": "off",

--- a/src/gtag.ts
+++ b/src/gtag.ts
@@ -9,7 +9,7 @@
 
 declare global {
     interface Window {
-        gtag: Function | undefined
+        gtag: (command: string, ...options: unknown[]) => void
     }
 }
 


### PR DESCRIPTION
**Description**:

Changes below enable `@typescript-eslint/no-unsafe-function-type` flag in `eslint` and fix reported warning.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
