### PR TITLE
chore: re-enabled no-require-imports and no-this-alias flags in eslint config.

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -27,8 +27,6 @@ export default tseslint.config(
 
 
             "@typescript-eslint/no-explicit-any": "off",
-            "@typescript-eslint/no-require-imports": "off",
-            "@typescript-eslint/no-this-alias": "off",
 
             "vue/no-reserved-component-names": "off",
             "vue/multi-word-component-names": "off",


### PR DESCRIPTION
**Description**:

Changes re-enable `no-require-imports` and `no-this-alias flags` in `eslint` config.
Current code does not trigger any warning for those flags.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
