### PR TITLE
fix: interpretation of parent/child relationship between transactions

### DIFF
--- a/src/components/transaction/TransactionByIdTable.vue
+++ b/src/components/transaction/TransactionByIdTable.vue
@@ -112,10 +112,12 @@ const makeRelationshipLabel = (row: Transaction): string => {
   } else if (row.scheduled) {
     result = "Scheduled"
   } else if (hasChild.value) {
-    if (row.nonce && row.nonce > 0) {
+    if (row.nonce !== null && row.nonce > 0 && row.parent_consensus_timestamp) {
       result = "Child"
-    } else {
+    } else if (row.nonce !== null && row.nonce === 0) {
       result = "Parent"
+    } else {
+      result = "n/a"
     }
   } else {
     result = ""

--- a/src/components/transaction/TransactionGroupAnalyzer.ts
+++ b/src/components/transaction/TransactionGroupAnalyzer.ts
@@ -48,6 +48,7 @@ export class TransactionGroupAnalyzer {
                 }
             }
         }
+        result = this.childTransactions.value.length > 0 ? result : null // can't be a parent without children
         return result
     })
 

--- a/src/pages/TransactionDetails.vue
+++ b/src/pages/TransactionDetails.vue
@@ -220,7 +220,7 @@
         <Property id="duration">
           <template #name>Valid Duration</template>
           <template #value>
-            <DurationValue :string-value="transaction?.valid_duration_seconds" :show-none="true"/>
+            <DurationValue :string-value="transaction?.valid_duration_seconds ?? undefined" :show-none="true"/>
           </template>
         </Property>
         <Property id="nonce">

--- a/src/pages/TransactionDetails.vue
+++ b/src/pages/TransactionDetails.vue
@@ -255,35 +255,37 @@
             </template>
           </Property>
         </template>
-        <Property v-if="parentTransaction" id="parentTransaction">
-          <template #name>Parent Transaction</template>
-          <template #value>
-            <router-link :to="routeManager.makeRouteToTransactionObj(parentTransaction)">
-              {{ makeTypeLabel(parentTransaction.name) }}
-            </router-link>
-          </template>
-        </Property>
-        <Property v-if="childTransactions.length" id="childTransactions">
-          <template #name>Child Transactions</template>
-          <template #value>
-            <div v-for="tx in childTransactions.slice(0, MAX_INLINE_CHILDREN)" :key="tx.nonce">
-              <router-link :to="routeManager.makeRouteToTransactionObj(tx)">
-                <span class="h-is-numeric">{{ '#' + tx.nonce }}</span>
-                <span class="ml-2">{{ makeTypeLabel(tx.name) }}</span>
+        <template v-else>
+          <Property v-if="parentTransaction" id="parentTransaction">
+            <template #name>Parent Transaction</template>
+            <template #value>
+              <router-link :to="routeManager.makeRouteToTransactionObj(parentTransaction)">
+                {{ makeTypeLabel(parentTransaction.name) }}
               </router-link>
-              <span v-for="id in getTargetedTokens(tx, 5)" :key="id" class="ml-2">
+            </template>
+          </Property>
+          <Property v-if="childTransactions.length" id="childTransactions">
+            <template #name>Child Transactions</template>
+            <template #value>
+              <div v-for="tx in childTransactions.slice(0, MAX_INLINE_CHILDREN)" :key="tx.nonce">
+                <router-link :to="routeManager.makeRouteToTransactionObj(tx)">
+                  <span class="h-is-numeric">{{ '#' + tx.nonce }}</span>
+                  <span class="ml-2">{{ makeTypeLabel(tx.name) }}</span>
+                </router-link>
+                <span v-for="id in getTargetedTokens(tx, 5)" :key="id" class="ml-2">
                 <TokenExtra :token-id="id" :use-anchor="true"/>
               </span>
-            </div>
-            <ArrowLink
-                style="text-align: left"
-                v-if="displayAllChildrenLink"
-                id="allChildrenLink"
-                :route="routeManager.makeRouteToTransactionsById(transactionId ?? '')"
-                :text="'All ' + childTransactions.length + ' child transactions'"
-            />
-          </template>
-        </Property>
+              </div>
+              <ArrowLink
+                  style="text-align: left"
+                  v-if="displayAllChildrenLink"
+                  id="allChildrenLink"
+                  :route="routeManager.makeRouteToTransactionsById(transactionId ?? '')"
+                  :text="'All ' + childTransactions.length + ' child transactions'"
+              />
+            </template>
+          </Property>
+        </template>
       </template>
     </DashboardCardV2>
 
@@ -442,7 +444,7 @@ const parentTransaction = computed(() => {
   let result: TransactionDetail | null
   const t = transactionLocParser.transaction.value
   const p = transactionGroupAnalyzer.parentTransaction.value
-  if (t !== null && p !== null && t.consensus_timestamp !== p.consensus_timestamp) {
+  if (t !== null && p !== null && t.parent_consensus_timestamp === p.consensus_timestamp) {
     result = p
   } else {
     result = null

--- a/src/schemas/MirrorNodeSchemas.ts
+++ b/src/schemas/MirrorNodeSchemas.ts
@@ -164,7 +164,7 @@ export interface Transaction {
     transaction_hash: string
     transaction_id: string
     transfers: Transfer[]
-    valid_duration_seconds: string
+    valid_duration_seconds: string | null // can be null according to our observation
     valid_start_timestamp: string
 }
 

--- a/tests/unit/Mocks.ts
+++ b/tests/unit/Mocks.ts
@@ -10,6 +10,7 @@ import {
     KeyType,
     Schedule,
     SignatureType,
+    TransactionByIdResponse,
     TransactionResponse,
     TransactionType
 } from "@/schemas/MirrorNodeSchemas.ts";
@@ -2145,6 +2146,108 @@ export const SAMPLE_PARENT_CHILD_TRANSACTIONS: TransactionResponse = {
     "links": {
         next: null
     }
+}
+
+export const SAMPLE_PARENT_CHILD_AND_UNRELATED_TRANSACTIONS: TransactionByIdResponse = {
+    "transactions": [
+        {
+            "assessed_custom_fees": [],
+            "batch_key": null,
+            "bytes": null,
+            "charged_tx_fee": 0,
+            "consensus_timestamp": "1722372192.370623549",
+            "entity_id": "0.0.4452547",
+            "max_fee": "0",
+            "memo_base64": "",
+            "name": TransactionType.CRYPTOUPDATEACCOUNT,
+            "nft_transfers": [],
+            "node": null,
+            "nonce": 1,
+            "parent_consensus_timestamp": null,
+            "result": "SUCCESS",
+            "scheduled": false,
+            "staking_reward_transfers": [],
+            "token_transfers": [],
+            "transaction_hash": "/c3U0kPPoDY87SnNCaWyBrPyXiicAjWADoamMcUacBNuY7BQCPGsdH6ggT2De3lK",
+            "transaction_id": "0.0.4419734-1722372182-141436565",
+            "transfers": [],
+            "valid_duration_seconds": null,
+            "valid_start_timestamp": "1722372182.141436565"
+        },
+        {
+            "assessed_custom_fees": [],
+            "batch_key": null,
+            "bytes": null,
+            "charged_tx_fee": 112677928,
+            "consensus_timestamp": "1722372192.370623550",
+            "entity_id": "0.0.4640464",
+            "max_fee": "1950000000",
+            "memo_base64": "",
+            "name": TransactionType.ETHEREUMTRANSACTION,
+            "nft_transfers": [],
+            "node": "0.0.6",
+            "nonce": 0,
+            "parent_consensus_timestamp": null,
+            "result": "SUCCESS",
+            "scheduled": false,
+            "staking_reward_transfers": [],
+            "token_transfers": [],
+            "transaction_hash": "gNyZLJBAIEr5BL705NcMi+25MOBxvLqwo00hVs/IMN/KknsY1PzP464sgxVDcuqP",
+            "transaction_id": "0.0.4419734-1722372182-141436565",
+            "transfers": [
+                {
+                    "account": "0.0.6",
+                    "amount": 2878739,
+                    "is_approval": false
+                },
+                {
+                    "account": "0.0.98",
+                    "amount": 101947895,
+                    "is_approval": false
+                },
+                {
+                    "account": "0.0.800",
+                    "amount": 7851294,
+                    "is_approval": false
+                },
+                {
+                    "account": "0.0.4419734",
+                    "amount": -81391687,
+                    "is_approval": false
+                },
+                {
+                    "account": "0.0.4452547",
+                    "amount": -31286241,
+                    "is_approval": false
+                }
+            ],
+            "valid_duration_seconds": "120",
+            "valid_start_timestamp": "1722372182.141436565"
+        },
+        {
+            "assessed_custom_fees": [],
+            "batch_key": null,
+            "bytes": null,
+            "charged_tx_fee": 0,
+            "consensus_timestamp": "1722372192.370623551",
+            "entity_id": "0.0.4640464",
+            "max_fee": "0",
+            "memo_base64": "",
+            "name": TransactionType.CONTRACTCREATEINSTANCE,
+            "nft_transfers": [],
+            "node": null,
+            "nonce": 2,
+            "parent_consensus_timestamp": "1722372192.370623550",
+            "result": "SUCCESS",
+            "scheduled": false,
+            "staking_reward_transfers": [],
+            "token_transfers": [],
+            "transaction_hash": "htcj5Lk6MSzAutJQSeBGedj8HXyN89PmJAoFI/sbevAvunv5Imy8Du7o/HoGaMos",
+            "transaction_id": "0.0.4419734-1722372182-141436565",
+            "transfers": [],
+            "valid_duration_seconds": null,
+            "valid_start_timestamp": "1722372182.141436565"
+        }]
 }
 
 //

--- a/tests/unit/transaction/TransactionByIdTable.spec.ts
+++ b/tests/unit/transaction/TransactionByIdTable.spec.ts
@@ -4,6 +4,7 @@ import {describe, expect, it} from 'vitest'
 import {flushPromises, mount} from "@vue/test-utils"
 import {
     SAMPLE_DUDE_WITH_KEYS,
+    SAMPLE_PARENT_CHILD_AND_UNRELATED_TRANSACTIONS,
     SAMPLE_PARENT_CHILD_TRANSACTIONS,
     SAMPLE_SAME_ID_NOT_PARENT_TRANSACTIONS,
     SAMPLE_SCHEDULING_SCHEDULED_TRANSACTIONS,
@@ -135,6 +136,36 @@ describe("TransactionByIdTable.vue", () => {
         expect(cells[1].text()).toBe("CONTRACT DELETE")
         expect(cells[3].text()).toBe("2")
 
+        wrapper.unmount()
+        await flushPromises()
+    });
+
+    it("Should list transactions as parent, child, and unrelated", async () => {
+
+        const mock = new MockAdapter(axios as any);
+
+        const wrapper = mount(TransactionByIdTable, {
+            global: {
+                plugins: [router, Oruga]
+            },
+            props: {
+                narrowed: true,
+                nbItems: 42,
+                transactions: SAMPLE_PARENT_CHILD_AND_UNRELATED_TRANSACTIONS.transactions,
+            },
+        });
+
+        await flushPromises()
+        // console.log(wrapper.text())
+
+        expect(wrapper.find('thead').text()).toBe("Time Type Content Relationship Nonce".toUpperCase())
+        expect(wrapper.find('tbody').text()).toBe(
+            "8:43:12.3706 PMJul 30, 2024, UTC" + "UPDATE ACCOUNT" + "Account:0.0.4452547" + "n/a" + "1" +
+            "8:43:12.3706 PMJul 30, 2024, UTC" + "ETHEREUM TRANSACTION" + "Account:0.0.4640464" + "Parent" + "0" +
+            "8:43:12.3706 PMJul 30, 2024, UTC" + "CONTRACT CREATE" + "Contract:0.0.4640464" + "Child" + "2"
+        )
+
+        mock.restore()
         wrapper.unmount()
         await flushPromises()
     });


### PR DESCRIPTION
**Description**:

When we get a set of transactions with the same ID, we currently assumes that once we find child (i.e. tx with a non-null parent_consensus_timestamp which are not in a batch), we determine that the parent is the tx with a nonce of 0, and from that we assume that all other transactions are children.

This is wrong since there might be unrelated transactions among this set, i.e. tx with a nonce > 0 and parent_consensus_timestamp === null.

An example of that can be obtained with this query to MN:
https://testnet.mirrornode.hedera.com/api/v1/transactions/0.0.4419734-1722372182-141436565
The first tx returned as a nonce of 1 and a null parent_consensus_timestamp. It is hence not a child of the transaction of nonce 0.

**Notes for reviewer**:

**Before the fix:**
<img width="1080" alt="Screenshot 2025-06-27 at 19 47 00" src="https://github.com/user-attachments/assets/39ae9ba0-2996-4bec-8629-895367cc7686" />
<img width="1080" alt="Screenshot 2025-06-27 at 19 49 17" src="https://github.com/user-attachments/assets/c9ca0e5f-8d8c-47a3-abcd-27d9bd2cc869" />

**With the fix:**
<img width="1080" alt="Screenshot 2025-06-27 at 19 48 33" src="https://github.com/user-attachments/assets/6abf8c6e-8630-4c81-b827-1a1014d2821c" />
<img width="1080" alt="Screenshot 2025-06-27 at 19 49 08" src="https://github.com/user-attachments/assets/d36d06ea-0644-4a0a-9024-e3fd87acf024" />

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
