### PR TITLE
fix: don't encode shard and realm in EVM address

### DIFF
--- a/src/utils/EntityID.ts
+++ b/src/utils/EntityID.ts
@@ -78,8 +78,6 @@ export class EntityID {
         const buffer = new Uint8Array(20);
         const view = new DataView(buffer.buffer, 0, 20);
 
-        view.setInt32(0, this.shard);
-        view.setBigInt64(4, BigInt(this.realm));
         view.setBigInt64(12, BigInt(this.num));
 
         return byteToHex(buffer)


### PR DESCRIPTION
**Description**:

Do not encode shard/realm in EntityID.toAddress(). 
The resulting EVM address will always have the first 12 bytes set to 0.

**Related issue(s)**:

Fixes #2004 
