### PR TITLE
chore: fix "unsafe-to-chain-command" lint errors in e2e tests.

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -32,7 +32,6 @@ export default tseslint.config(
             "vue/multi-word-component-names": "off",
             "vue/no-mutating-props": "off",
 
-            "cypress/unsafe-to-chain-command": "off",
         }
     }
 )

--- a/src/pages/ContractDetails_Summary.vue
+++ b/src/pages/ContractDetails_Summary.vue
@@ -156,7 +156,6 @@ const tooltipText = computed(() => isFullMatch.value ? FULL_MATCH_TOOLTIP : PART
 const ercAnalyzer = new ERCAnalyzer(parsedContractId)
 onMounted(() => ercAnalyzer.mount())
 onBeforeUnmount(() => ercAnalyzer.unmount())
-const showERCSection = computed(() => ercAnalyzer.isErc20.value || ercAnalyzer.isErc721.value)
 
 
 //

--- a/src/pages/Nodes_Network.vue
+++ b/src/pages/Nodes_Network.vue
@@ -134,8 +134,6 @@ const remainingMin = networkNodeAnalyzer.remainingMin
 
 const isMapVisible = computed(() => routeManager.currentNetwork.value === 'mainnet')
 
-const bothSectionVisible = computed(() => enableStaking && isMapVisible.value)
-
 </script>
 
 <!-- --------------------------------------------------------------------------------------------------------------- -->

--- a/src/utils/analyzer/ContractAnalyzer.ts
+++ b/src/utils/analyzer/ContractAnalyzer.ts
@@ -290,6 +290,7 @@ export class ContractAnalyzer {
         let sourcifyRecord: SourcifyRecord|null
         try {
             sourcifyRecord = await SourcifyCache.instance.lookup(contractId)
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         } catch (error) {
             sourcifyRecord = null
         }

--- a/tests/e2e/specs/AccountNavigation.cy.ts
+++ b/tests/e2e/specs/AccountNavigation.cy.ts
@@ -15,15 +15,20 @@ describe('Account Navigation', () => {
             .eq(0)
             .find('td')
             .eq(0)
-            .click()
             .then(($id) => {
-                // cy.log('Selected account Id: ' + $id.text())
-                cy.url().should('include', '/testnet/account/' + $id.text())
-                cy.contains('Account ID ' + $id.text())
+                cy.wrap($id).as('targetId')
+                const text = $id.text().trim()
+                cy.wrap(text).as('text')
             })
+
+        cy.get('@targetId').click()
+        cy.get('@text').then((text) => {
+            cy.url().should('include', '/testnet/account/' + text)
+            cy.contains('Account ID ' + text)
+        })
     })
 
-    it('should follow links to HTS tokens', () => {
+    it('should follow links to HTS fungible', () => {
         const accountId1 = "0.0.592746"
 
         cy.visit('mainnet/account/' + accountId1)
@@ -39,18 +44,31 @@ describe('Account Navigation', () => {
             .eq(0)
             .find('td')
             .eq(0)
-            .click()
             .then(($id) => {
-                cy.url().should('include', `/mainnet/token/${$id.text()}`)
-                cy.contains('Fungible Token')
-                cy.contains(`${$id.text()}`)
+                cy.wrap($id).as('targetId')
+                const text = $id.text().trim()
+                cy.wrap(text).as('text')
             })
 
-        cy.go('back')
+        cy.get('@targetId').click()
+        cy.get('@text').then((text) => {
+            cy.url().should('include', `/mainnet/token/${text}`)
+            cy.contains('Fungible Token')
+            cy.contains(`${text}`)
+        })
+    })
+
+    it('should follow links to HTS NFT', () => {
+        const accountId1 = "0.0.592746"
+
+        cy.visit('mainnet/account/' + accountId1)
         cy.url().should('include', '/mainnet/account/')
         cy.contains('Account ' + accountId1)
 
+        cy.get('#tab-AccountDetails_Assets').click()
+
         cy.get('#tab-nfts').click()
+
         cy.get('#nftsTable')
             .find('tbody tr')
             .should('be.visible')
@@ -58,14 +76,20 @@ describe('Account Navigation', () => {
             .eq(0)
             .find('td')
             .eq(1)
-            .click()
             .then(($id) => {
-                cy.url().should('include', `/mainnet/token/${$id.text()}`)
-                cy.contains('NFT Details')
-                cy.contains('Non Fungible Token')
-                cy.contains('NFT Collection')
-                cy.contains(`${$id.text()}`)
+                cy.wrap($id).as('targetId')
+                const text = $id.text().trim()
+                cy.wrap(text).as('text')
             })
+
+        cy.get('@targetId').click()
+        cy.get('@text').then((text) => {
+            cy.url().should('include', `/mainnet/token/${text}`)
+            cy.contains('NFT Details')
+            cy.contains('Non Fungible Token')
+            cy.contains('NFT Collection')
+            cy.contains(`${text}`)
+        })
 
         cy.go('back')
         cy.url().should('include', '/mainnet/account/')
@@ -87,12 +111,17 @@ describe('Account Navigation', () => {
             .eq(0)
             .find('td')
             .eq(0)
-            .click()
             .then(($id) => {
-                // cy.log('Selected transaction Id: ' + $id.text())
-                cy.url().should('include', '/testnet/transaction/')
-                cy.contains('Transaction ' + $id.text())
+                cy.wrap($id).as('targetId')
+                const text = $id.text().trim()
+                cy.wrap(text).as('text')
             })
+
+        cy.get('@targetId').click()
+        cy.get('@text').then((text) => {
+            cy.url().should('include', '/testnet/transaction/')
+            cy.contains('Transaction ' + text)
+        })
     })
 
     it('should follow link to recent created contract', () => {
@@ -114,12 +143,17 @@ describe('Account Navigation', () => {
             .eq(0)
             .find('td')
             .eq(0)
-            .click()
             .then(($id) => {
-                cy.url().should('include', '/testnet/contract/' + $id.text())
-                cy.contains('Contract ' + $id.text())
-                cy.contains($id.text())
+                cy.wrap($id).as('targetId')
+                const text = $id.text().trim()
+                cy.wrap(text).as('text')
             })
+
+        cy.get('@targetId').click()
+        cy.get('@text').then((text) => {
+            cy.url().should('include', '/testnet/contract/' + text)
+            cy.contains('Contract ' + text)
+        })
     })
 
     it.skip('should follow link to recent reward transaction', () => {

--- a/tests/e2e/specs/BlockNavigation.cy.ts
+++ b/tests/e2e/specs/BlockNavigation.cy.ts
@@ -15,12 +15,17 @@ describe('Block Navigation', () => {
             .eq(0)
             .find('td')
             .eq(0)
-            .click()
             .then(($id) => {
-                // cy.log('Selected block number: ' + $id.text())
-                cy.url().should('include', '/testnet/block/' + $id.text())
-                cy.contains('Block ' + $id.text())
+                cy.wrap($id).as('targetId')
+                const text = $id.text().trim()
+                cy.wrap(text).as('text')
             })
+
+        cy.get('@targetId').click()
+        cy.get('@text').then((text) => {
+            cy.url().should('include', '/testnet/block/' + text)
+            cy.contains('Block ' + text)
+        })
     })
 
     it('should navigate from block details to previous block details', () => {
@@ -50,17 +55,24 @@ describe('Block Navigation', () => {
             .click()
 
         cy.get('table')
-            .contains('td', '@').click()
+            .contains('td', '@')
             .then(($id) => {
-                // cy.log('Selected transaction ID: ' + $id.text())
-                cy.url().should('include', '/testnet/transaction/')
-                cy.contains('Transaction ' + $id.text())
-                cy.get('#blockNumberValue')
-                    .contains(blockNumber)
-                    .click()
-                    .url().should('include', '/testnet/block/' + blockNumber)
-                cy.contains('Block ' + blockNumber)
+                cy.wrap($id).as('targetId')
+                const text = $id.text().trim()
+                cy.wrap(text).as('text')
             })
-    })
 
+        cy.get('@targetId').click()
+        cy.get('@text').then((text) => {
+            cy.url().should('include', '/testnet/transaction/')
+            cy.contains('Transaction ' + text)
+        })
+
+        cy.get('#blockNumberValue')
+            .contains(blockNumber)
+            .click()
+
+        cy.url().should('include', '/testnet/block/' + blockNumber)
+        cy.contains('Block ' + blockNumber)
+    })
 })

--- a/tests/e2e/specs/ContractNavigation.cy.ts
+++ b/tests/e2e/specs/ContractNavigation.cy.ts
@@ -15,12 +15,17 @@ describe('Contract Navigation', () => {
             .eq(0)
             .find('td')
             .eq(0)
-            .click()
             .then(($id) => {
-                // cy.log('Selected account Id: ' + $id.text())
-                cy.url().should('include', '/testnet/contract/' + $id.text())
-                cy.contains('Contract ID ' + $id.text())
+                cy.wrap($id).as('targetId')
+                const text = $id.text().trim()
+                cy.wrap(text).as('text')
             })
+
+        cy.get('@targetId').click()
+        cy.get('@text').then((text) => {
+            cy.url().should('include', '/testnet/contract/' + text)
+            cy.contains('Contract ID ' + text)
+        })
     })
 
     it('should follow links from contract details', () => {
@@ -42,12 +47,17 @@ describe('Contract Navigation', () => {
 
         cy.get('#blockNumber')
             .find('a')
-            .click()
-            .then(($number) => {
-                cy.log('Selected block number: ' + $number.text())
-                cy.url().should('include', '/mainnet/block/' + $number.text())
-                cy.contains('Block ' + $number.text())
+            .then(($id) => {
+                cy.wrap($id).as('targetId')
+                const text = $id.text().trim()
+                cy.wrap(text).as('text')
             })
+
+        cy.get('@targetId').click()
+        cy.get('@text').then((text) => {
+            cy.url().should('include', '/mainnet/block/' + text)
+            cy.contains('Block ' + text)
+        })
     })
 
     it('should display contract details using contract ID', () => {

--- a/tests/e2e/specs/NodeNavigation.cy.ts
+++ b/tests/e2e/specs/NodeNavigation.cy.ts
@@ -19,12 +19,17 @@ describe('Node Navigation', () => {
             .eq(0)
             .find('td')
             .eq(0)
-            .click()
             .then(($id) => {
-                // cy.log('Selected node Id: ' + $id.text())
-                cy.url().should('include', '/testnet/node/' + $id.text())
-                cy.contains('Node ' + $id.text())
+                cy.wrap($id).as('targetId')
+                const text = $id.text().trim()
+                cy.wrap(text).as('text')
             })
+
+        cy.get('@targetId').click()
+        cy.get('@text').then((text) => {
+            cy.url().should('include', '/testnet/node/' + text)
+            cy.contains('Node ' + text)
+        })
     })
 
     it('should follow links from node to account', () => {

--- a/tests/e2e/specs/TokenNavigation.cy.ts
+++ b/tests/e2e/specs/TokenNavigation.cy.ts
@@ -163,7 +163,5 @@ describe('Token Navigation', () => {
 
         cy.get('#tab-TokenDetails_Others')
             .click()
-
     })
-
 })

--- a/tests/e2e/specs/TopNavigationBar.cy.ts
+++ b/tests/e2e/specs/TopNavigationBar.cy.ts
@@ -19,6 +19,7 @@ describe('Top Navigation Bar', () => {
 
         cy.get('[data-cy="network-selector"]')
             .select('MAINNET')
+        cy.get('[data-cy="network-selector"]')
             .should('have.value', 'mainnet')
 
         cy.url().should('include', '/mainnet/home')
@@ -28,7 +29,7 @@ describe('Top Navigation Bar', () => {
 
         cy.get('[data-cy="network-selector"]')
             .select('TESTNET')
-            .should('have.value', 'testnet')
+        cy.should('have.value', 'testnet')
 
         cy.url().should('include', '/testnet/home')
         cy.contains('Transactions Over Time')
@@ -37,6 +38,7 @@ describe('Top Navigation Bar', () => {
 
         cy.get('[data-cy="network-selector"]')
             .select('PREVIEWNET')
+        cy.get('[data-cy="network-selector"]')
             .should('have.value', 'previewnet')
 
         cy.url().should('include', '/previewnet/home')

--- a/tests/e2e/specs/TopicNavigation.cy.ts
+++ b/tests/e2e/specs/TopicNavigation.cy.ts
@@ -15,12 +15,17 @@ describe('Topic Navigation', () => {
             .eq(0)
             .find('td')
             .eq(0)
-            .click()
             .then(($id) => {
-                // cy.log('Selected topic Id: ' + $id.text())
-                cy.url().should('include', '/testnet/topic/' + $id.text())
-                cy.contains('Topic ' + $id.text())
+                cy.wrap($id).as('targetId')
+                const text = $id.text().trim()
+                cy.wrap(text).as('text')
             })
+
+        cy.get('@targetId').click()
+        cy.get('@text').then((text) => {
+            cy.url().should('include', '/testnet/topic/' + text)
+            cy.contains('Topic ' + text)
+        })
     })
 
     it('should navigate from transaction details to topic message table back to transaction', () => {
@@ -33,29 +38,45 @@ describe('Topic Navigation', () => {
 
         cy.get('#entityId')
             .find('a')
-            .click()
-            .then(($topicId) => {
-                cy.url().should('include', '/mainnet/topic/' + $topicId.text())
-                cy.contains('Topic ' + $topicId.text())
-
-                cy.get('#tab-TopicDetails_Messages')
-                    .click()
-
-                cy.get('table')
-                    .find('tbody tr')
-                    .should('have.length.at.least', 2)
-                    .eq(0)
-                    .find('td')
-                    .eq(0)
-                    .click()
-                    .then(($seqNumber) => {
-                        cy.url().should('include', '/mainnet/transaction/')
-                        cy.contains('Topic ID' + $topicId.text())
-                        cy.get('#tab-TransactionDetails_Message')
-                            .click()
-                        cy.contains('Message Submitted')
-                        cy.contains('Sequence Number' + $seqNumber.text())
-                    })
+            .then(($id) => {
+                cy.wrap($id).as('topicId')
+                const text = $id.text().trim()
+                cy.wrap(text).as('topicText')
             })
+
+        cy.get('@topicId').click()
+        cy.get('@topicText').then((text) => {
+            cy.url().should('include', '/mainnet/topic/' + text)
+            cy.contains('Topic ' + text)
+        })
+
+        cy.get('#tab-TopicDetails_Messages')
+            .click()
+
+        cy.get('table')
+            .find('tbody tr')
+            .should('have.length.at.least', 2)
+            .eq(0)
+            .find('td')
+            .eq(0)
+            .then(($seqNumber) => {
+                cy.wrap($seqNumber).as('seqNumber')
+                const text = $seqNumber.text().trim()
+                cy.wrap(text).as('seqNumberText')
+            })
+
+        cy.get('@seqNumber').click()
+        cy.url().should('include', '/mainnet/transaction/')
+
+        cy.get('@topicText').then((text) => {
+            cy.contains('Topic ID' + text)
+        })
+
+        cy.get('#tab-TransactionDetails_Message')
+            .click()
+        cy.contains('Message Submitted')
+        cy.get('@seqNumberText').then((text) => {
+            cy.contains('Sequence Number' + text)
+        })
     })
 })

--- a/tests/e2e/specs/TransactionNavigation.cy.ts
+++ b/tests/e2e/specs/TransactionNavigation.cy.ts
@@ -16,12 +16,17 @@ describe('Transaction Navigation', () => {
             .eq(0)
             .find('td')
             .eq(0)
-            .click()
             .then(($id) => {
-                // cy.log('Selected transaction Id: ' + $id.text())
-                cy.url().should('include', '/testnet/transaction/')
-                cy.contains('Transaction ' + $id.text())
+                cy.wrap($id).as('targetId')
+                const text = $id.text().trim()
+                cy.wrap(text).as('text')
             })
+
+        cy.get('@targetId').click()
+        cy.get('@text').then((text) => {
+            cy.url().should('include', '/testnet/transaction/')
+            cy.contains('Transaction ' + text)
+        })
     })
 
     it('should filter table by transaction type', () => {
@@ -32,10 +37,10 @@ describe('Transaction Navigation', () => {
 
         cy.get('[data-cy="select-type"]')
             .select(selectType)
-            .then(($type) => {
-                cy.wrap($type).should('have.value', selectType)
-                cy.url().should('include', '/testnet/transactions?type=' + selectType.toLowerCase())
-            })
+        cy.get('[data-cy="select-type"]')
+            .should('have.value', selectType)
+
+        cy.url().should('include', '/testnet/transactions?type=' + selectType.toLowerCase())
 
         cy.get('[data-cy="pauseButton"]')
             .click()
@@ -53,12 +58,17 @@ describe('Transaction Navigation', () => {
 
         cy.get('#operatorAccount')
             .find('a')
-            .click()
             .then(($id) => {
-                // cy.log('Selected operator Id: ' + $id.text())
-                cy.url().should('include', '/mainnet/account/' + $id.text())
-                cy.get('title').contains('Account ' + $id.text())
+                cy.wrap($id).as('targetId')
+                const text = $id.text().trim()
+                cy.wrap(text).as('text')
             })
+
+        cy.get('@targetId').click()
+        cy.get('@text').then((text) => {
+            cy.url().should('include', '/mainnet/account/' + text)
+            cy.get('title').contains('Account ' + text)
+        })
 
         cy.go('back')
         cy.url().should('include', '/mainnet/transaction/')
@@ -66,12 +76,17 @@ describe('Transaction Navigation', () => {
 
         cy.get('#nodeAccount')
             .find('a')
-            .click()
             .then(($id) => {
-                // cy.log('Selected operator Id: ' + $id.text())
-                cy.url().should('include', '/mainnet/account/' + $id.text())
-                cy.get('title').contains('Account ' + $id.text())
+                cy.wrap($id).as('targetId')
+                const text = $id.text().trim()
+                cy.wrap(text).as('text')
             })
+
+        cy.get('@targetId').click()
+        cy.get('@text').then((text) => {
+            cy.url().should('include', '/mainnet/account/' + text)
+            cy.get('title').contains('Account ' + text)
+        })
 
         cy.go('back')
         cy.url().should('include', '/mainnet/transaction/')
@@ -90,29 +105,26 @@ describe('Transaction Navigation', () => {
         cy.get('#scheduledTransactionValue')
             .find('a')
             .click()
-            .then(() => {
-                cy.url().should('include', '/mainnet/transaction/')
-                cy.url().should('include', scheduledConsensusTimestamp)
-                cy.get('title').contains('Transaction ' + scheduledConsensusTimestamp)
-            })
+
+        cy.url().should('include', '/mainnet/transaction/')
+        cy.url().should('include', scheduledConsensusTimestamp)
+        cy.get('title').contains('Transaction ' + scheduledConsensusTimestamp)
 
         cy.get('#scheduleCreateTransaction')
             .find('a')
             .click()
-            .then(() => {
-                cy.url().should('include', '/mainnet/transaction/')
-                cy.url().should('include', schedulingConsensusTimestamp)
-                cy.get('title').contains('Transaction ' + schedulingConsensusTimestamp)
-            })
+
+        cy.url().should('include', '/mainnet/transaction/')
+        cy.url().should('include', schedulingConsensusTimestamp)
+        cy.get('title').contains('Transaction ' + schedulingConsensusTimestamp)
 
         cy.get('#entityIdValue')
             .find('a')
             .click()
-            .then(() => {
-                cy.url().should('include', '/mainnet/schedule/')
-                cy.url().should('include', scheduleId)
-                cy.get('title').contains('Schedule ' + scheduleId)
-            })
+
+        cy.url().should('include', '/mainnet/schedule/')
+        cy.url().should('include', scheduleId)
+        cy.get('title').contains('Schedule ' + scheduleId)
     })
 
     it('should follow parent/child relationship links', () => {
@@ -128,22 +140,18 @@ describe('Transaction Navigation', () => {
             .should('have.length', 6)
             .eq(0)
             .click()
-            .then(() => {
-                // cy.log('Selected operator Id: ' + $id.text())
-                cy.url().should('include', '/mainnet/transaction/')
-                cy.url().should('include', childConsensusTimestamp)
-                cy.get('title').contains('Transaction ' + childConsensusTimestamp)
-            })
+
+        cy.url().should('include', '/mainnet/transaction/')
+        cy.url().should('include', childConsensusTimestamp)
+        cy.get('title').contains('Transaction ' + childConsensusTimestamp)
 
         cy.get('#parentTransactionValue')
             .find('a')
             .click()
-            .then(() => {
-                // cy.log('Selected operator Id: ' + $id.text())
-                cy.url().should('include', '/mainnet/transaction/')
-                cy.url().should('include', parentConsensusTimestamp)
-                cy.get('title').contains('Transaction ' + parentConsensusTimestamp)
-            })
+
+        cy.url().should('include', '/mainnet/transaction/')
+        cy.url().should('include', parentConsensusTimestamp)
+        cy.get('title').contains('Transaction ' + parentConsensusTimestamp)
     })
 
     it('should follow link "Transactions with same ID"', () => {
@@ -183,17 +191,17 @@ describe('Transaction Navigation', () => {
 
         cy.get('[data-cy="select-format"]')
             .select('dashForm')
-            .then(($type) => {
-                cy.wrap($type).should('have.value', 'dashForm')
-                cy.contains('Transaction ' + makeExchangeFormat(transactionId))
-            })
+
+        cy.get('[data-cy="select-format"]')
+            .should('have.value', 'dashForm')
+        cy.contains('Transaction ' + makeExchangeFormat(transactionId))
 
         cy.get('[data-cy="select-format"]')
             .select('atForm')
-            .then(($type) => {
-                cy.wrap($type).should('have.value', 'atForm')
-                cy.contains('Transaction ' + transactionId)
-            })
+
+        cy.get('[data-cy="select-format"]')
+            .should('have.value', 'atForm')
+        cy.contains('Transaction ' + transactionId)
     })
 
     it('should handle ETHEREUMTRANSACTION type', () => {
@@ -215,12 +223,11 @@ describe('Transaction Navigation', () => {
             .should('have.length', 1)
             .eq(0)
             .click()
-            .then(() => {
-                // cy.log('Selected operator Id: ' + $id.text())
-                cy.url().should('include', '/mainnet/contract/')
-                cy.url().should('include', contractId)
-                cy.get('title').contains('Contract ' + contractId)
-            })
+
+        cy.url().should('include', '/mainnet/contract/')
+        cy.url().should('include', contractId)
+        cy.get('title').contains('Contract ' + contractId)
+
         cy.go('back')
 
         cy.get('#childTransactionsValue')
@@ -228,22 +235,18 @@ describe('Transaction Navigation', () => {
             .should('have.length', 4)
             .eq(0)
             .click()
-            .then(() => {
-                // cy.log('Selected operator Id: ' + $id.text())
-                cy.url().should('include', '/mainnet/transaction/')
-                cy.url().should('include', childConsensusTimestamp)
-                cy.get('title').contains('Transaction ' + childConsensusTimestamp)
-            })
+
+        cy.url().should('include', '/mainnet/transaction/')
+        cy.url().should('include', childConsensusTimestamp)
+        cy.get('title').contains('Transaction ' + childConsensusTimestamp)
 
         cy.get('#parentTransactionValue')
             .find('a')
             .click()
-            .then(() => {
-                // cy.log('Selected operator Id: ' + $id.text())
-                cy.url().should('include', '/mainnet/transaction/')
-                cy.url().should('include', parentConsensusTimestamp)
-                cy.get('title').contains('Transaction ' + parentConsensusTimestamp)
-            })
+
+        cy.url().should('include', '/mainnet/transaction/')
+        cy.url().should('include', parentConsensusTimestamp)
+        cy.get('title').contains('Transaction ' + parentConsensusTimestamp)
     })
 
     it('should detect navigation to unknown transaction ID', () => {
@@ -269,9 +272,9 @@ describe('Transaction Navigation', () => {
 
         cy.get('[data-cy="select-page-size"]')
             .select('5')
-            .then(($type) => {
-                cy.wrap($type).should('have.value', '5')
-            })
+
+        cy.get('[data-cy="select-page-size"]')
+            .should('have.value', '5')
 
         cy.get('table')
             .find('tbody tr')
@@ -279,14 +282,12 @@ describe('Transaction Navigation', () => {
 
         cy.get('[data-cy="select-page-size"]')
             .select('50')
-            .then(($type) => {
-                cy.wrap($type).should('have.value', '50')
-            })
+
+        cy.get('[data-cy="select-page-size"]')
+            .should('have.value', '50')
 
         cy.get('table')
             .find('tbody tr')
             .should('have.length', 50)
-
     })
-
 })

--- a/tests/e2e/specs/TransferGraphs.cy.ts
+++ b/tests/e2e/specs/TransferGraphs.cy.ts
@@ -112,48 +112,76 @@ describe('Transfer Graphs Navigation', () => {
 
         cy.go('back')
 
+        /*
+                cy.get('[data-cy=tokenTransfers]')
+                    .find('[data-cy="tokenExtra"]')
+                    .eq(0)
+                    .then(($token) => {
+                        cy.wrap($token)
+                            .find('a')
+                            .click({force: true})
+                            .then(($name) => {
+                                cy.url().should('include', '/mainnet/token/')
+                                cy.contains('Token ')
+                                cy.contains($name.text())
+                            })
+                    })
+        */
+
         cy.get('[data-cy=tokenTransfers]')
             .find('[data-cy="tokenExtra"]')
             .eq(0)
-            .then(($token) => {
-                cy.wrap($token)
-                    .find('a')
-                    .click({force: true})
-                    .then(($name) => {
-                        cy.url().should('include', '/mainnet/token/')
-                        cy.contains('Token ')
-                        cy.contains($name.text())
-                    })
+            .find('a')
+            .then(($name) => {
+                cy.wrap($name).as('targetToken')
+                const text = $name.text().trim()
+                cy.wrap(text).as('text')
             })
+
+        cy.get('@targetToken').click({force: true})
+
+        cy.url().should('include', '/mainnet/token/')
+        cy.contains('Token ')
+        cy.get('@text').then((text) => {
+            cy.contains(`${text}`)
+        })
 
         cy.go('back')
 
         cy.get('[data-cy=tokenTransfers]')
             .find('[data-cy="tokenExtra"]')
             .eq(1)
-            .then(($token) => {
-                cy.wrap($token)
-                    .find('a')
-                    .click({force: true})
-                    .then(($name) => {
-                        cy.url().should('include', '/mainnet/token/')
-                        cy.contains('Token ')
-                        cy.contains($name.text())
-                    })
+            .find('a')
+            .then(($name) => {
+                cy.wrap($name).as('targetToken')
+                const text = $name.text().trim()
+                cy.wrap(text).as('text')
             })
+
+        cy.get('@targetToken').click({force: true})
+
+        cy.url().should('include', '/mainnet/token/')
+        cy.contains('Token ')
+        cy.get('@text').then((text) => {
+            cy.contains(`${text}`)
+        })
 
         cy.go('back')
 
         cy.get('[data-cy=tokenTransfers]')
             .find('[data-cy=destinationAccount]')
+            .find('a')
             .then(($account) => {
-                cy.wrap($account)
-                    .find('a')
-                    .click({force: true})
-                cy.url().should('include', '/mainnet/account/' + $account.text())
-                cy.get('title').contains('Account ' + $account.text())
+                cy.wrap($account).as('targetAccount')
+                const text = $account.text().trim()
+                cy.wrap(text).as('text')
             })
 
-    })
+        cy.get('@targetAccount').click({force: true})
 
+        cy.get('@text').then((text) => {
+            cy.url().should('include', '/mainnet/account/' + text)
+            cy.get('title').contains('Account ' + text)
+        })
+    })
 })


### PR DESCRIPTION
**Description**:

Re-activate "_unsafe-to-chain-command_" checks in `eslint.config.mjs` and refactor e2e tests to suppress related errors.