### PR TITLE
chore: bump @oruga-ui/oruga-next from 0.11.2 to 0.11.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@hashgraph/sdk": "^2.69.0",
         "@hedera-name-service/hns-resolution-sdk": "^2.0.15",
         "@kabuto-sh/ns": "^0.14.2",
-        "@oruga-ui/oruga-next": "^0.11.2",
+        "@oruga-ui/oruga-next": "^0.11.4",
         "@oruga-ui/theme-oruga": "^0.7.1",
         "@vuepic/vue-datepicker": "^11.0.2",
         "@vueuse/core": "^13.3.0",
@@ -4182,16 +4182,22 @@
       "license": "MIT"
     },
     "node_modules/@oruga-ui/oruga-next": {
-      "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/@oruga-ui/oruga-next/-/oruga-next-0.11.2.tgz",
-      "integrity": "sha512-cmsvErakNBJ2MJbAs1tI9NjVmqWN2OIKJuooUSmGO//ZYNZQ07LTyuSiOOGFnemF9gYZ29/DhRPIo71dbV6v1g==",
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/@oruga-ui/oruga-next/-/oruga-next-0.11.4.tgz",
+      "integrity": "sha512-zeuycH6FJI5z0Ohqr41a0m8jUQ37XCV7xE46hb22MQvvHxYLnNpB21nRsSOl6qEhDX1zijj+qIaxk0R4w5+5uw==",
       "license": "MIT",
       "dependencies": {
-        "vue-component-type-helpers": "^2.2.10"
+        "vue-component-type-helpers": "^3.0.2"
       },
       "peerDependencies": {
         "vue": "^3.0.0"
       }
+    },
+    "node_modules/@oruga-ui/oruga-next/node_modules/vue-component-type-helpers": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/vue-component-type-helpers/-/vue-component-type-helpers-3.0.4.tgz",
+      "integrity": "sha512-WtR3kPk8vqKYfCK/HGyT47lK/T3FaVyWxaCNuosaHYE8h9/k0lYRZ/PI/+T/z2wP+uuNKmL6z30rOcBboOu/YA==",
+      "license": "MIT"
     },
     "node_modules/@oruga-ui/theme-oruga": {
       "version": "0.7.1",
@@ -18901,6 +18907,7 @@
       "version": "2.2.10",
       "resolved": "https://registry.npmjs.org/vue-component-type-helpers/-/vue-component-type-helpers-2.2.10.tgz",
       "integrity": "sha512-iDUO7uQK+Sab2tYuiP9D1oLujCWlhHELHMgV/cB13cuGbG4qwkLHvtfWb6FzvxrIOPDnU0oHsz2MlQjhYDeaHA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/vue-eslint-parser": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@hashgraph/sdk": "^2.69.0",
     "@hedera-name-service/hns-resolution-sdk": "^2.0.15",
     "@kabuto-sh/ns": "^0.14.2",
-    "@oruga-ui/oruga-next": "^0.11.2",
+    "@oruga-ui/oruga-next": "^0.11.4",
     "@oruga-ui/theme-oruga": "^0.7.1",
     "@vuepic/vue-datepicker": "^11.0.2",
     "@vueuse/core": "^13.3.0",

--- a/tests/unit/account/Accounts.spec.ts
+++ b/tests/unit/account/Accounts.spec.ts
@@ -52,7 +52,7 @@ describe("Accounts.vue", () => {
 
         const table = card.findComponent(AccountTable)
         expect(table.exists()).toBe(true)
-        expect(table.get('thead').text()).toBe("ID CREATED TOKENS MEMO BALANCE")
+        expect(table.get('thead').text()).toBe("IDCREATEDTOKENSMEMOBALANCE")
         expect(table.get('tbody').text()).toBe(
             "0.0.730631" +
             "5:12:31.6676 AMFeb 28, 2022, UTC" +

--- a/tests/unit/account/HbarAllowanceTable.spec.ts
+++ b/tests/unit/account/HbarAllowanceTable.spec.ts
@@ -77,7 +77,7 @@ describe("HbarAllowanceTable.vue", () => {
         await flushPromises()
         // console.log(wrapper.text())
 
-        expect(wrapper.find('thead').text()).toBe("SPENDER TIME AMOUNT REMAINING AMOUNT GRANTED")
+        expect(wrapper.find('thead').text()).toBe("SPENDERTIMEAMOUNT REMAININGAMOUNT GRANTED")
         expect(wrapper.find('tbody').text()).toBe(
             "0.0.1584" + "10:55:30.2660 PMFeb 11, 2025, UTC" + "100.00000000ℏ" + "100.00000000ℏ" +
             "0.0.1515" + "12:30:27.1747 PMJun 21, 2024, UTC" + "15.00000000ℏ" + "15.00000000ℏ" +

--- a/tests/unit/account/NftAllSerialsAllowanceTable.spec.ts
+++ b/tests/unit/account/NftAllSerialsAllowanceTable.spec.ts
@@ -86,7 +86,7 @@ describe("HbarAllowanceTable.vue", () => {
         controller.mount()
         await flushPromises()
 
-        expect(wrapper.find('thead').text()).toBe("SPENDER TOKEN ID TIME")
+        expect(wrapper.find('thead').text()).toBe("SPENDERTOKEN IDTIME")
         expect(wrapper.find('tbody').text()).toBe(
             "0.0.1500" + "0.0.4457902" + "?" + "3:03:19.2987 PMJul 2, 2024, UTC" +
             "0.0.1584" + "0.0.4457902" + "?" + "3:04:15.9256 PMJul 2, 2024, UTC" +

--- a/tests/unit/account/NftAllowanceTable.spec.ts
+++ b/tests/unit/account/NftAllowanceTable.spec.ts
@@ -89,7 +89,7 @@ describe("HbarAllowanceTable.vue", () => {
         await flushPromises()
         // console.log(wrapper.text())
 
-        expect(wrapper.find('thead').text()).toBe("TOKEN ID SERIAL # SPENDER TIME")
+        expect(wrapper.find('thead').text()).toBe("TOKEN IDSERIAL #SPENDERTIME")
         expect(wrapper.find('tbody').text()).toBe(
             "0.0.4458222" + "?" + "1" + "0.0.1584" + "9:09:43.2674 AMJul 1, 2024, UTC" +
             "0.0.4457902" + "?" + "12" + "0.0.1789" + "7:59:26.4548 AMJul 12, 2024, UTC" +

--- a/tests/unit/account/TokenAllowanceTable.spec.ts
+++ b/tests/unit/account/TokenAllowanceTable.spec.ts
@@ -90,7 +90,7 @@ describe("HbarAllowanceTable.vue", () => {
         await flushPromises()
         // console.log(wrapper.text())
 
-        expect(wrapper.find('thead').text()).toBe("SPENDER TOKEN ID AMOUNT REMAINING AMOUNT GRANTED TIME")
+        expect(wrapper.find('thead').text()).toBe("SPENDERTOKEN IDAMOUNT REMAININGAMOUNT GRANTEDTIME")
         expect(wrapper.find('tbody').text()).toBe(
             "0.0.1580" + "0.0.3038008" + "?" + "2:05:52.3540 PMJul 5, 2024, UTC" +
             "0.0.1584" + "0.0.3038008" + "?" + "3:12:16.7637 PMJul 10, 2024, UTC" +

--- a/tests/unit/account/TokensSection.spec.ts
+++ b/tests/unit/account/TokensSection.spec.ts
@@ -237,7 +237,7 @@ describe("TokensSection.vue", () => {
 
         const nftsTable = tokensSection.get("#nftsTable")
         expect(nftsTable.find('thead').text()).toBe(
-            "IMAGE TOKEN ID SERIAL # COLLECTION NAME SYMBOL NFT NAME CREATOR FREEZE STATUS"
+            "IMAGETOKEN IDSERIAL #COLLECTION NAMESYMBOLNFT NAMECREATORFREEZE STATUS"
         )
         expect(nftsTable.find('tbody').text()).toBe(
             "NFT0.0.7483832Ħ Frens KingdomĦFRENSKINGD…" +
@@ -269,7 +269,7 @@ describe("TokensSection.vue", () => {
         await flushPromises()
 
         const associationsTable = tokensSection.get("#fungibleTable")
-        expect(associationsTable.find('thead').text()).toBe("TOKEN ID NAME SYMBOL BALANCE FREEZE STATUS")
+        expect(associationsTable.find('thead').text()).toBe("TOKEN IDNAMESYMBOLBALANCEFREEZE STATUS")
         expect(associationsTable.find('tbody').text()).toBe(
             "0.0.34332104" + "HSUITE" + "HSuite" + "234,264.7909" + "UNFROZEN" +
             "0.0.49292859" + "Token SymbolA7" + "TokenA7" + "0.31669471" + "FROZEN"
@@ -305,7 +305,7 @@ describe("TokensSection.vue", () => {
         await flushPromises()
 
         const pendingNfts = table.get("#pendingNftsTable")
-        expect(pendingNfts.find('thead').text()).toBe("IMAGE TOKEN ID SERIAL # COLLECTION NAME SYMBOL SENDER AIRDROP TIME")
+        expect(pendingNfts.find('thead').text()).toBe("IMAGETOKEN IDSERIAL #COLLECTION NAMESYMBOLSENDERAIRDROP TIME")
         expect(pendingNfts.find('tbody').text()).toBe(
             "NFT" + "0.0.4901646" + "2" + "Token SymbolA7" + "TokenA7" + "0.0.1437" + "9:29:10.6225 AMOct 3, 2024, UTC" +
             "NFT" + "0.0.4901646" + "1" + "Token SymbolA7" + "TokenA7" + "0.0.1437" + "9:28:57.7817 AMOct 3, 2024, UTC"
@@ -316,7 +316,7 @@ describe("TokensSection.vue", () => {
         await flushPromises()
 
         const pendingFungible = table.get("#pendingFungibleTable")
-        expect(pendingFungible.find('thead').text()).toBe("TOKEN ID NAME SYMBOL AMOUNT SENDER  AIRDROP TIME")
+        expect(pendingFungible.find('thead').text()).toBe("TOKEN IDNAMESYMBOLAMOUNTSENDER AIRDROP TIME")
         expect(pendingFungible.find('tbody').text()).toBe(
             "0.0.4943664" + "Ħ Frens Kingdom" + "ĦFRENSKINGD…" + "84" + "0.0.1437" + "2:21:33.5553 PMOct 10, 2024, UTC" +
             "0.0.2255333" + "Ħ Frens Kingdom Dude" + "ĦFRENSKINGD…4,200" + "0.0.1437" + "2:27:26.2113 PMOct 10, 2024, UTC"

--- a/tests/unit/block/BlockDetails.spec.ts
+++ b/tests/unit/block/BlockDetails.spec.ts
@@ -120,7 +120,7 @@ describe("BlockDetails.vue", () => {
         expect(wrapper.get("#blockTransactions").text()).toMatch(RegExp("^Block Transactions"))
         const table = wrapper.findComponent(BlockTransactionTable)
         expect(table.exists()).toBe(true)
-        expect(table.get('thead').text()).toBe("ID TYPE CONTENT TIME")
+        expect(table.get('thead').text()).toBe("IDTYPECONTENTTIME")
         expect(table.get('tbody').text()).toBe("0.0.29624024@1646025139.152901498CRYPTO TRANSFER0.0.29624024\n" + "\n" +
             "123423\n" + "\n" +
             "0.0.296939115:12:31.6676 AMFeb 28, 2022, UTC")
@@ -217,7 +217,7 @@ describe("BlockDetails.vue", () => {
         expect(wrapper.get("#blockTransactions").text()).toMatch(RegExp("^Block Transactions"))
         const table = wrapper.findComponent(BlockTransactionTable)
         expect(table.exists()).toBe(true)
-        expect(table.get('thead').text()).toBe("ID TYPE CONTENT TIME")
+        expect(table.get('thead').text()).toBe("IDTYPECONTENTTIME")
         expect(table.get('tbody').text()).toBe("0.0.29624024@1646025139.152901498CRYPTO TRANSFER0.0.29624024\n" + "\n" +
             "123423\n" + "\n" +
             "0.0.296939115:12:31.6676 AMFeb 28, 2022, UTC")

--- a/tests/unit/block/Blocks.spec.ts
+++ b/tests/unit/block/Blocks.spec.ts
@@ -55,7 +55,7 @@ describe("Blocks.vue", () => {
 
         const table = card.findComponent(BlockTable)
         expect(table.exists()).toBe(true)
-        expect(table.get('thead').text()).toBe("NUMBER START TIME NO. TRANSACTIONS GAS USED")
+        expect(table.get('thead').text()).toBe("NUMBERSTART TIMENO. TRANSACTIONSGAS USED")
         expect(table.get('tbody').text()).toBe(
             "25175998" + "6:58:31.3281 AMSep 23, 2022, UTC" + "3" + "0" +
             "25175997" + "6:58:28.2114 AMSep 23, 2022, UTC" + "5" + "0"

--- a/tests/unit/contract/ContractDetails.spec.ts
+++ b/tests/unit/contract/ContractDetails.spec.ts
@@ -369,7 +369,7 @@ describe("ContractDetails.vue", () => {
         const resultTable = wrapper.findComponent(ContractResultTable)
         expect(resultTable.exists()).toBe(true)
 
-        expect(resultTable.find('thead').text()).toBe("TIME FROM MESSAGE TRANSFER AMOUNT")
+        expect(resultTable.find('thead').text()).toBe("TIMEFROMMESSAGETRANSFER AMOUNT")
         const rows = resultTable.find('tbody').findAll('tr')
 
         let cells = rows[0].findAll('td')

--- a/tests/unit/contract/Contracts.spec.ts
+++ b/tests/unit/contract/Contracts.spec.ts
@@ -58,7 +58,7 @@ describe("Contracts.vue", () => {
 
         const table = card.findComponent(ContractTable)
         expect(table.exists()).toBe(true)
-        expect(table.get('thead').text()).toBe("ID CONTRACT NAME CREATED MEMO")
+        expect(table.get('thead').text()).toBe("IDCONTRACT NAMECREATEDMEMO")
         expect(table.get('tbody').text()).toBe(
             "0.0.749775" +
             " NOT VERIFIED " +

--- a/tests/unit/node/NodeTable.spec.ts
+++ b/tests/unit/node/NodeTable.spec.ts
@@ -54,7 +54,7 @@ describe("NodeTable.vue", () => {
             "api/v1/network/nodes",
         ])
 
-        expect(wrapper.get('thead').text()).toBe("NODE ID DESCRIPTION STAKE FOR CONSENSUS % STAKE RANGE REWARD RATE")
+        expect(wrapper.get('thead').text()).toBe("NODE IDDESCRIPTIONSTAKE FOR CONSENSUS%STAKE RANGEREWARD RATE")
         expect(wrapper.get('tbody').findAll('tr').length).toBe(3)
         expect(wrapper.get('tbody').text()).toBe(
             "0" +

--- a/tests/unit/node/Nodes.spec.ts
+++ b/tests/unit/node/Nodes.spec.ts
@@ -101,7 +101,7 @@ describe("Nodes.vue", () => {
         expect(wrapper2.text()).toMatch("3  Nodes")
         const table = wrapper2.findComponent(NodeTable)
         expect(table.exists()).toBe(true)
-        expect(table.get('thead').text()).toBe("NODE ID DESCRIPTION STAKE FOR CONSENSUS % STAKE RANGE REWARD RATE")
+        expect(table.get('thead').text()).toBe("NODE IDDESCRIPTIONSTAKE FOR CONSENSUS%STAKE RANGEREWARD RATE")
         expect(wrapper2.get('tbody').text()).toBe(
             "0" +
             "Hosted by Hedera | East Coast, USA" +

--- a/tests/unit/token/TokenDetails.spec.ts
+++ b/tests/unit/token/TokenDetails.spec.ts
@@ -722,7 +722,7 @@ describe("TokenDetails.vue", () => {
 
         const fixedFee = customFees.findComponent(FixedFeeTable)
         expect(fixedFee.exists()).toBe(true)
-        expect(fixedFee.get('thead').text()).toBe("FIXED FEE FEE CURRENCY COLLECTOR ACCOUNT")
+        expect(fixedFee.get('thead').text()).toBe("FIXED FEEFEE CURRENCYCOLLECTOR ACCOUNT")
         expect(fixedFee.get('tbody').text()).toBe(
             "5" + "0.0.2966295623423" + "0.0.617888" +
             "1" + "0.0.2966295623423" + "0.0.617889" +
@@ -731,7 +731,7 @@ describe("TokenDetails.vue", () => {
 
         const fractionalFee = customFees.findComponent(FractionalFeeTable)
         expect(fractionalFee.exists()).toBe(true)
-        expect(fractionalFee.get('thead').text()).toBe("FRACTIONAL FEE FEE CURRENCY COLLECTOR ACCOUNT MIN MAX NET")
+        expect(fractionalFee.get('thead').text()).toBe("FRACTIONAL FEEFEE CURRENCYCOLLECTOR ACCOUNTMINMAXNET")
         expect(fractionalFee.get('tbody').text()).toBe(
             "0.5%" + "0.0.2966295623423" + "0.0.617888" + "0.01" + "2" + "✓" +
             "0.1%" + "0.0.2966295623423" + "0.0.617889" + "0.01" + "2" +
@@ -826,7 +826,7 @@ describe("TokenDetails.vue", () => {
 
         const fixedFee = customFees.findComponent(FixedFeeTable)
         expect(fixedFee.exists()).toBe(true)
-        expect(fixedFee.get('thead').text()).toBe("FIXED FEE FEE CURRENCY COLLECTOR ACCOUNT")
+        expect(fixedFee.get('thead').text()).toBe("FIXED FEEFEE CURRENCYCOLLECTOR ACCOUNT")
         expect(fixedFee.get('tbody').text()).toBe(
             "5" + "0.0.748383" + testTokenSymbol + "0.0.617888" +
             "1" + "0.0.748383" + testTokenSymbol + "0.0.617889" +
@@ -837,7 +837,7 @@ describe("TokenDetails.vue", () => {
 
         const royalteeFee = customFees.findComponent(RoyaltyFeeTable)
         expect(royalteeFee.exists()).toBe(true)
-        expect(royalteeFee.get('thead').text()).toBe("PERCENTAGE FEE COLLECTOR ACCOUNT FALLBACK FEE FEE CURRENCY")
+        expect(royalteeFee.get('thead').text()).toBe("PERCENTAGE FEECOLLECTOR ACCOUNTFALLBACK FEEFEE CURRENCY")
         expect(royalteeFee.get('tbody').text()).toBe(
             "0.5%" + "0.0.617888" + "500" + "0.0.748383" + testTokenSymbol +
             "0.1%" + "0.0.617889" + "100" + "0.0.748383" + testTokenSymbol +

--- a/tests/unit/token/Tokens.spec.ts
+++ b/tests/unit/token/Tokens.spec.ts
@@ -53,7 +53,7 @@ describe("Tokens.vue", () => {
         const fungibleTab = wrapper.getComponent(Tokens_Fungible)
         expect(fungibleTab.text()).toMatch(RegExp("^Recent Fungible Token"))
         const table1 = fungibleTab.getComponent(TokenTable)
-        expect(table1.get('thead').text()).toBe("TOKEN NAME SYMBOL")
+        expect(table1.get('thead').text()).toBe("TOKENNAMESYMBOL")
         expect(table1.get('tbody').text()).toBe(
             SAMPLE_TOKENS.tokens[0].token_id +
             SAMPLE_TOKENS.tokens[0].name +
@@ -76,7 +76,7 @@ describe("Tokens.vue", () => {
         const nftsTab = wrapper2.getComponent(Tokens_Nfts)
         expect(nftsTab.text()).toMatch(RegExp("^Recent NFTs"))
         const table2 = nftsTab.getComponent(TokenTable)
-        expect(table2.get('thead').text()).toBe("TOKEN NAME SYMBOL")
+        expect(table2.get('thead').text()).toBe("TOKENNAMESYMBOL")
         expect(table2.get('tbody').text()).toBe(
             SAMPLE_TOKENS.tokens[0].token_id +
             SAMPLE_TOKENS.tokens[0].name +

--- a/tests/unit/topic/TopicDetails.spec.ts
+++ b/tests/unit/topic/TopicDetails.spec.ts
@@ -209,7 +209,7 @@ describe("TopicDetails.vue", () => {
         expect(table.exists()).toBe(true)
         const rows = table.findAll('tr')
         expect(rows.length).toBe(3)
-        expect (rows[0].text()).toMatch("FIXED FEE FEE CURRENCY COLLECTOR ACCOUNT")
+        expect (rows[0].text()).toMatch("FIXED FEEFEE CURRENCYCOLLECTOR ACCOUNT")
         expect (rows[1].text()).toMatch("3" + "0.0.5707212" + "?" + "0.0.4736212")
         expect (rows[2].text()).toMatch("4" + "0.0.5707213" + "?" + "0.0.4736212")
 

--- a/tests/unit/topic/Topics.spec.ts
+++ b/tests/unit/topic/Topics.spec.ts
@@ -46,7 +46,7 @@ describe("Topics.vue", () => {
 
         const table = card.findComponent(TopicTable)
         expect(table.exists()).toBe(true)
-        expect(table.get('thead').text()).toBe("TOPIC CREATED MEMO")
+        expect(table.get('thead').text()).toBe("TOPICCREATEDMEMO")
         expect(table.get('tbody').text()).toBe(
             "0.0.750040" +
             "6:14:56.3105 PMMar 7, 2022, UTC" +

--- a/tests/unit/transaction/TransactionByIdTable.spec.ts
+++ b/tests/unit/transaction/TransactionByIdTable.spec.ts
@@ -49,7 +49,7 @@ describe("TransactionByIdTable.vue", () => {
         await flushPromises()
         // console.log(wrapper.text())
 
-        expect(wrapper.find('thead').text()).toBe("Time Type Content Relationship Nonce".toUpperCase())
+        expect(wrapper.find('thead').text()).toBe("TIMETYPECONTENTRELATIONSHIPNONCE")
         expect(wrapper.find('tbody').text()).toBe(
             "1:29:17.0144 PMSep 6, 2022, UTC" + "CONTRACT CALL" + "0.0.48113503\n\n" + "50.00000000ℏ\n\n" + "0.0.48193749" + "Parent" + "0" +
             "1:29:17.0144 PMSep 6, 2022, UTC" + "TOKEN MINT" + "MINT\n\n" + "0.0.48193741" + "RSSE\n\n" + "0.0.48113503" + "Child" + "1" +
@@ -85,7 +85,7 @@ describe("TransactionByIdTable.vue", () => {
         await flushPromises()
         // console.log(wrapper.text())
 
-        expect(wrapper.find('thead').text()).toBe("Time Type Content Relationship".toUpperCase())
+        expect(wrapper.find('thead').text()).toBe("TIMETYPECONTENTRELATIONSHIP")
         const rows = wrapper.find('tbody').findAll('tr')
 
         let cells = rows[0].findAll('td')
@@ -121,7 +121,7 @@ describe("TransactionByIdTable.vue", () => {
         await flushPromises()
         // console.log(wrapper.text())
 
-        expect(wrapper.find('thead').text()).toBe("Time Type Content Nonce".toUpperCase())
+        expect(wrapper.find('thead').text()).toBe("TIMETYPECONTENTNONCE")
         const rows = wrapper.find('tbody').findAll('tr')
 
         let cells = rows[0].findAll('td')
@@ -158,7 +158,7 @@ describe("TransactionByIdTable.vue", () => {
         await flushPromises()
         // console.log(wrapper.text())
 
-        expect(wrapper.find('thead').text()).toBe("Time Type Content Relationship Nonce".toUpperCase())
+        expect(wrapper.find('thead').text()).toBe("TIMETYPECONTENTRELATIONSHIPNONCE")
         expect(wrapper.find('tbody').text()).toBe(
             "8:43:12.3706 PMJul 30, 2024, UTC" + "UPDATE ACCOUNT" + "Account:0.0.4452547" + "n/a" + "1" +
             "8:43:12.3706 PMJul 30, 2024, UTC" + "ETHEREUM TRANSACTION" + "Account:0.0.4640464" + "Parent" + "0" +

--- a/tests/unit/transaction/Transactions.spec.ts
+++ b/tests/unit/transaction/Transactions.spec.ts
@@ -76,7 +76,7 @@ describe("Transactions.vue", () => {
 
         const table = card.findComponent(TransactionTable)
         expect(table.exists()).toBe(true)
-        expect(table.get('thead').text()).toBe("ID TYPE CONTENT TIME")
+        expect(table.get('thead').text()).toBe("IDTYPECONTENTTIME")
         expect(table.get('tbody').text()).toBe(
             "0.0.29624024@1646025139.152901498CRYPTO TRANSFER0.0.29624024\n\n" +
             "123423\n\n" +


### PR DESCRIPTION
**Description**:

Bump Oruga and adjust unit tests accordingly (comparison with static strings for table column headers)

