### PR TITLE
fix: removed useless 0.0.800 branch in hbar transfer graph

### DIFF
--- a/src/utils/TransactionTools.ts
+++ b/src/utils/TransactionTools.ts
@@ -3,6 +3,7 @@
 import {StakingRewardTransfer, Transaction, TransactionType, Transfer} from "@/schemas/MirrorNodeSchemas";
 import {TransactionID} from "@/utils/TransactionID";
 
+// eslint-disable-next-line max-lines-per-function, complexity
 export function makeEntityType(row: Transaction): string | null {
     let result: string | null
 
@@ -65,6 +66,7 @@ export function makeEntityType(row: Transaction): string | null {
     return result
 }
 
+// eslint-disable-next-line max-lines-per-function, complexity
 export function makeTypeLabel(type: TransactionType | undefined): string {
     let result: string
     switch (type) {
@@ -291,6 +293,7 @@ export function computeNetAmount(transfers: Transfer[] | undefined, transactionF
     return result
 }
 
+// eslint-disable-next-line complexity
 export function makeNetOfRewards(transfers: Transfer[] | undefined, rewards: StakingRewardTransfer[] | undefined): Transfer[] {
     let result = Array<Transfer>()
     let totalRewardAmount = 0

--- a/src/utils/TransactionTools.ts
+++ b/src/utils/TransactionTools.ts
@@ -312,11 +312,13 @@ export function makeNetOfRewards(transfers: Transfer[] | undefined, rewards: Sta
                     }
                 }
             }
-            result.push({
-                amount: netAmount,
-                account: t.account,
-                is_approval: t.is_approval
-            })
+            if (netAmount != 0) {
+                result.push({
+                    amount: netAmount,
+                    account: t.account,
+                    is_approval: t.is_approval
+                })
+            }
         }
     } else {
         result = transfers ?? []

--- a/tests/unit/transfer_graphs/layout/HbarTransferLayout.spec.ts
+++ b/tests/unit/transfer_graphs/layout/HbarTransferLayout.spec.ts
@@ -768,13 +768,13 @@ describe("HbarTransferLayout.vue", () => {
         expect(compactLayout.sources.length).toBe(1)
         expect(compactLayout.destinations.length).toBe(1)
 
-        const cs0 = fullLayout.sources[0]
+        const cs0 = compactLayout.sources[0]
         expect(cs0.transfer.account).toBe("0.0.1859883")
         expect(cs0.transfer.amount).toBe(-9100185749)
         expect(cs0.description).toBe(null)
         expect(cs0.payload).toBe(true)
 
-        const cd0 = fullLayout.destinations[0]
+        const cd0 = compactLayout.destinations[0]
         expect(cd0.transfer.account).toBe("0.0.2105083")
         expect(cd0.transfer.amount).toBe(+9100000000)
         expect(cd0.description).toBe("Transfer")

--- a/tests/unit/transfer_graphs/layout/HbarTransferLayout.spec.ts
+++ b/tests/unit/transfer_graphs/layout/HbarTransferLayout.spec.ts
@@ -780,4 +780,105 @@ describe("HbarTransferLayout.vue", () => {
         expect(cd0.description).toBe("Transfer")
         expect(cd0.payload).toBe(true)
     })
+
+
+    test("Transfer and payment of reward (take #2)", async () => {
+
+        const transaction = {
+            "charged_tx_fee": 118031,
+            "transfers": [
+                {
+                    "account": "0.0.3",
+                    "amount": 4798,
+                    "is_approval": false
+                },
+                {
+                    "account": "0.0.98",
+                    "amount": 113233,
+                    "is_approval": false
+                },
+                {
+                    "account": "0.0.800",
+                    "amount": -231664272,
+                    "is_approval": false
+                },
+                {
+                    "account": "0.0.1784243",
+                    "amount": -118046,
+                    "is_approval": false
+                },
+                {
+                    "account": "0.0.1934439",
+                    "amount": 231664287,
+                    "is_approval": false
+                }
+            ],
+            "staking_reward_transfers": [
+                {
+                    "account": "0.0.1934439",
+                    "amount": 231664272
+                }
+            ]
+        } as Transaction
+
+        //
+        // FULL
+        //
+
+        const fullLayout = new HbarTransferLayout(transaction, NETWORK_NODES)
+
+        expect(fullLayout.transaction).toBe(transaction)
+        // expect(fullLayout.destinationAmount).toBe(+TransferTotal)
+        expect(fullLayout.rowCount).toBe(3)
+        expect(fullLayout.sources.length).toBe(1)
+        expect(fullLayout.destinations.length).toBe(3)
+
+        const s0 = fullLayout.sources[0]
+        expect(s0.transfer.account).toBe("0.0.1784243")
+        expect(s0.transfer.amount).toBe(-118046)
+        expect(s0.description).toBe(null)
+        expect(s0.payload).toBe(true)
+
+        const d0 = fullLayout.destinations[0]
+        expect(d0.transfer.account).toBe("0.0.1934439")
+        expect(d0.transfer.amount).toBe(+15)
+        expect(d0.description).toBe("Transfer")
+        expect(d0.payload).toBe(true)
+
+        const d1 = fullLayout.destinations[1]
+        expect(d1.transfer.account).toBe("0.0.3")
+        expect(d1.transfer.amount).toBe(+4798)
+        expect(d1.description).toBe("Node fee (Hedera)")
+        expect(d1.payload).toBe(false)
+
+        const d2 = fullLayout.destinations[2]
+        expect(d2.transfer.account).toBe("0.0.98")
+        expect(d2.transfer.amount).toBe(+113233)
+        expect(d2.description).toBe("Hedera fee collection account")
+        expect(d2.payload).toBe(false)
+
+        //
+        // COMPACT
+        //
+
+        const compactLayout = new HbarTransferLayout(transaction, NETWORK_NODES, false)
+
+        expect(compactLayout.transaction).toBe(transaction)
+        expect(compactLayout.destinationAmount).toBe(+15)
+        expect(compactLayout.rowCount).toBe(1)
+        expect(compactLayout.sources.length).toBe(1)
+        expect(compactLayout.destinations.length).toBe(1)
+
+        const cs0 = compactLayout.sources[0]
+        expect(cs0.transfer.account).toBe("0.0.1784243")
+        expect(cs0.transfer.amount).toBe(-118046)
+        expect(cs0.description).toBe(null)
+        expect(cs0.payload).toBe(true)
+
+        const cd0 = compactLayout.destinations[0]
+        expect(cd0.transfer.account).toBe("0.0.1934439")
+        expect(cd0.transfer.amount).toBe(+15)
+        expect(cd0.description).toBe("Transfer")
+        expect(cd0.payload).toBe(true)
+    })
 })


### PR DESCRIPTION
**Description**:

Changes below fix a display issue in `Hbar Transfers` section.

Without these changes, `Hbar Transfers` for [this transaction](https://hashscan.io/mainnet/transaction/1677120502.107531752) are displayed like this:
<img width="985" height="289" alt="image" src="https://github.com/user-attachments/assets/121fa932-a359-426e-8ac4-58be9d2f9e89" />

Destination 0.0.800 (with 0 hbar) should not be displayed.
With the changes, `Hbar Transfers` is now correctly displayed:
<img width="985" height="265" alt="image" src="https://github.com/user-attachments/assets/3bb77a56-b962-4b86-b6ac-9dbd6a5473fe" />


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
