### PR TITLE
chore: separate config for src/ and tests/ in eslint.config.mjs

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -8,13 +8,13 @@ import globals from 'globals'
 export default tseslint.config(
 //    { ignores: ['*.d.ts', '**/coverage', '**/dist'] },
     {
+        files: ['src/**/*.{ts,vue}'],
         extends: [
             eslint.configs.recommended,
             ...tseslint.configs.recommended,
             ...eslintPluginVue.configs['flat/essential'],
             pluginCypress.configs.recommended
         ],
-        files: ['**/*.{ts,vue}'],
         languageOptions: {
             ecmaVersion: 'latest',
             sourceType: 'module',
@@ -25,13 +25,35 @@ export default tseslint.config(
         },
         rules: {
 
-
             "@typescript-eslint/no-explicit-any": "off",
 
             "vue/no-reserved-component-names": "off",
             "vue/multi-word-component-names": "off",
             "vue/no-mutating-props": "off",
 
+            "complexity": ["error", 8],
+            "max-lines-per-function": ["error", 50]
+        }
+    },
+    {
+        files: ['tests/**/*.ts'],
+        extends: [
+            eslint.configs.recommended,
+            ...tseslint.configs.recommended,
+            ...eslintPluginVue.configs['flat/essential'],
+            pluginCypress.configs.recommended
+        ],
+        languageOptions: {
+            ecmaVersion: 'latest',
+            sourceType: 'module',
+            globals: globals.browser,
+            parserOptions: {
+                parser: tseslint.parser,
+            },
+        },
+        rules: {
+            "max-lines-per-function": "off",
+            "@typescript-eslint/no-explicit-any": "off",
         }
     }
 )


### PR DESCRIPTION
**Description**:

Changes below separate configuration `src/` and `tests/` sources in `eslint.config.mjs`.
For `src/` sources, the following checks are enabled (aligned on setup of Static Code analysis GH action):
- `complexity: ["error", 8]`
- `max-lines-per-function: ["error", 50]`

For `tests/` sources,  the following checks are disabled:
- `max-lines-per-function`
- `@typescript-eslint/no-explicit-any`

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
