### PR TITLE
chore: replace fontawesome icons by lucide icons

### DIFF
--- a/src/components/AxiosStatus.vue
+++ b/src/components/AxiosStatus.vue
@@ -31,7 +31,7 @@
         @click="showErrorDialog = true"
     />
   </template>
-  <ModalDialog v-model:show-dialog="showErrorDialog" iconClass="fa fa-2x fa-exclamation-triangle has-text-danger">
+  <ModalDialog v-model:show-dialog="showErrorDialog">
     <template #modalDialogContent>
       <TaskPanel :mode="TaskPanelMode.error">
         <template #taskPanelMessage>{{ explanation }}</template>

--- a/src/components/allowances/HbarAllowanceTable.vue
+++ b/src/components/allowances/HbarAllowanceTable.vue
@@ -41,7 +41,11 @@
     </o-table-column>
 
     <o-table-column v-if="isWalletConnected" v-slot="props" position="right">
-      <i class="fa fa-pen" @click="emit('editAllowance', props.row)"/>
+      <Pencil
+          class="icon-in-table"
+          :size="16"
+          @click="emit('editAllowance', props.row)"
+      />
     </o-table-column>
 
     <template v-slot:bottom-left>
@@ -77,6 +81,7 @@ import AccountLink from "@/components/values/link/AccountLink.vue";
 import HbarAmount from "@/components/values/HbarAmount.vue";
 import TablePageSize from "@/components/transaction/TablePageSize.vue";
 import {walletManager} from "@/utils/RouteManager.ts";
+import {Pencil} from "lucide-vue-next";
 
 const emit = defineEmits(["editAllowance"])
 

--- a/src/components/allowances/NftAllSerialsAllowanceTable.vue
+++ b/src/components/allowances/NftAllSerialsAllowanceTable.vue
@@ -37,7 +37,12 @@
     </o-table-column>
 
     <o-table-column v-if="isWalletConnected" v-slot="props" field="action" position="right">
-      <i v-if="props.row.isEditable" class="far fa-trash-alt" @click="emit('deleteAllowance', props.row)"/>
+      <Trash2
+          v-if="props.row.isEditable"
+          class="icon-in-table"
+          :size="16"
+          @click="emit('deleteAllowance', props.row)"
+      />
       <InfoTooltip
           v-else
           label="The allowance cannot be modified because the NFT collection is no longer associated with this account."
@@ -81,6 +86,7 @@ import {NftAllSerialsAllowanceTableController} from "@/components/allowances/Nft
 import {isValidAssociation} from "@/schemas/MirrorNodeUtils.ts";
 import TablePageSize from "@/components/transaction/TablePageSize.vue";
 import {walletManager} from "@/utils/RouteManager.ts";
+import {Trash2} from 'lucide-vue-next';
 
 interface DisplayedNftAllowance extends NftAllowance {
   isEditable: boolean

--- a/src/components/allowances/NftAllowanceTable.vue
+++ b/src/components/allowances/NftAllowanceTable.vue
@@ -43,7 +43,11 @@
     </o-table-column>
 
     <o-table-column v-if="isWalletConnected" v-slot="props" field="action" position="right">
-      <i class="far fa-trash-alt" @click="emit('deleteAllowance', props.row)"/>
+      <Trash2
+          class="icon-in-table"
+          :size="16"
+          @click="emit('deleteAllowance', props.row)"
+      />
     </o-table-column>
 
     <template v-slot:bottom-left>
@@ -80,6 +84,7 @@ import TokenLink from "@/components/values/link/TokenLink.vue";
 import {NftAllowanceTableController} from "@/components/allowances/NftAllowanceTableController";
 import TablePageSize from "@/components/transaction/TablePageSize.vue";
 import {walletManager} from "@/utils/RouteManager.ts";
+import {Trash2} from 'lucide-vue-next';
 
 const emit = defineEmits(["deleteAllowance"])
 

--- a/src/components/allowances/TokenAllowanceTable.vue
+++ b/src/components/allowances/TokenAllowanceTable.vue
@@ -45,9 +45,15 @@
     </o-table-column>
 
     <o-table-column v-if="isWalletConnected" v-slot="props" field="edit-icon" position="right">
-      <i v-if="props.row.isEditable" class="fa fa-pen" @click="emit('editAllowance', props.row)"/>
+      <Pencil
+          v-if="props.row.isEditable"
+          class="icon-in-table"
+          :size="16"
+          @click="emit('editAllowance', props.row)"
+      />
       <InfoTooltip
           v-else
+          class="icon-in-table"
           label="The allowance cannot be modified because the token is no longer associated with this account."
       />
     </o-table-column>
@@ -90,6 +96,7 @@ import TokenLink from "@/components/values/link/TokenLink.vue";
 import InfoTooltip from "@/components/InfoTooltip.vue";
 import TablePageSize from "@/components/transaction/TablePageSize.vue";
 import {walletManager} from "@/utils/RouteManager.ts";
+import {Pencil} from 'lucide-vue-next';
 
 interface DisplayedTokenAllowance extends TokenAllowance {
   isEditable: boolean

--- a/src/components/page/header/wallet/WalletStatusButton.vue
+++ b/src/components/page/header/wallet/WalletStatusButton.vue
@@ -20,8 +20,8 @@
           {{ accountId !== null ? accountId : "No account" }}
         </div>
         <div class="right">
-          <i v-if="!showWalletOptions" class="fas fa-solid fa-angle-down"/>
-          <i v-else class="fas fa-solid fa-angle-up"/>
+          <ChevronDown v-if="!showWalletOptions" :size="18"/>
+          <ChevronUp v-else :size="18" />
         </div>
       </ButtonView>
     </template>
@@ -42,6 +42,7 @@ import {ref} from "vue";
 import DropdownPanel from "@/components/DropdownPanel.vue";
 import ButtonView from "@/elements/ButtonView.vue";
 import {ButtonSize} from "@/dialogs/core/DialogUtils.ts";
+import {ChevronDown, ChevronUp} from "lucide-vue-next"
 import WalletOptions from "@/components/page/header/wallet/WalletOptions.vue";
 import {walletManager} from "@/utils/RouteManager.ts";
 

--- a/src/components/token/NftFile.vue
+++ b/src/components/token/NftFile.vue
@@ -14,9 +14,11 @@
       :no-anchor="props.noAnchor"
   >
     <template #placeHolder>
-      <File :size="50"/>
-      <div class="place-holder-text">
-        {{ props.type }}
+      <div class="place-holder-content">
+        <File :size="50"/>
+        <div class="place-holder-text">
+          {{ props.type }}
+        </div>
       </div>
     </template>
   </MediaContent>
@@ -59,6 +61,12 @@ const props = defineProps({
 <!-- --------------------------------------------------------------------------------------------------------------- -->
 
 <style scoped>
+
+div.place-holder-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
 
 div.place-holder-text {
   font-size: 10px;

--- a/src/components/token/NftFile.vue
+++ b/src/components/token/NftFile.vue
@@ -7,16 +7,16 @@
 <template>
 
   <MediaContent
-      :url="url"
-      :type="type"
-      :size="size"
+      :url="props.url"
+      :type="props.type"
+      :size="props.size"
       :auto="false"
-      :no-anchor="noAnchor"
+      :no-anchor="props.noAnchor"
   >
     <template #placeHolder>
       <File :size="50"/>
       <div class="place-holder-text">
-        {{ type }}
+        {{ props.type }}
       </div>
     </template>
   </MediaContent>
@@ -27,33 +27,28 @@
 <!--                                                      SCRIPT                                                     -->
 <!-- --------------------------------------------------------------------------------------------------------------- -->
 
-<script lang="ts">
+<script setup lang="ts">
 
-import {defineComponent, PropType} from "vue";
+import {PropType} from "vue";
 import {File} from "lucide-vue-next";
 import MediaContent from "@/components/MediaContent.vue";
 
-export default defineComponent({
-  name: "NftFile",
-  components: {MediaContent, File},
-
-  props: {
-    url: {
-      type: String as PropType<string | null>,
-      default: null
-    },
-    type: {
-      type: String as PropType<string | null>,
-      default: null
-    },
-    size: {
-      type: Number,
-      default: 50
-    },
-    noAnchor: {
-      type: Boolean,
-      default: false
-    },
+const props = defineProps({
+  url: {
+    type: String as PropType<string | null>,
+    default: null
+  },
+  type: {
+    type: String as PropType<string | null>,
+    default: null
+  },
+  size: {
+    type: Number,
+    default: 50
+  },
+  noAnchor: {
+    type: Boolean,
+    default: false
   },
 })
 

--- a/src/components/token/NftFile.vue
+++ b/src/components/token/NftFile.vue
@@ -14,9 +14,7 @@
       :no-anchor="noAnchor"
   >
     <template #placeHolder>
-      <div class="icon mt-4" style="font-size: 50px">
-        <i class="fas fa-file"></i>
-      </div>
+      <File :size="50"/>
       <div class="place-holder-text">
         {{ type }}
       </div>
@@ -32,11 +30,12 @@
 <script lang="ts">
 
 import {defineComponent, PropType} from "vue";
+import {File} from "lucide-vue-next";
 import MediaContent from "@/components/MediaContent.vue";
 
 export default defineComponent({
   name: "NftFile",
-  components: {MediaContent},
+  components: {MediaContent, File},
 
   props: {
     url: {

--- a/src/components/transaction/NftTransactionSummary.vue
+++ b/src/components/transaction/NftTransactionSummary.vue
@@ -6,21 +6,25 @@
 
 <template>
   <template v-if="transaction">
-    <NftDetailsTransferGraph v-if="shouldGraph" :transaction="transactionDetail"/>
-    <div v-else-if="isTokenAssociation">
+
+    <NftDetailsTransferGraph
+        v-if="shouldGraph"
+        :transaction="transactionDetail"
+    />
+
+    <div v-else-if="isTokenAssociation" class="h-should-wrap tx-summary">
       {{ transaction?.sender_account_id }}
-      <span v-if="tokens.length">
-                <i class="fas fa-link mr-1 h-is-low-contrast"></i>
-                <TokenExtra :token-id="tokens[0]"/>
-                <span
-                    v-if="additionalTokensNumber"
-                    class="h-is-smaller h-is-extra-text h-should-wrap"
-                >
-                    {{ " ( + " + additionalTokensNumber + " more )" }}
-                </span>
-            </span>
+      <template v-if="tokens.length">
+        <Link :size="16" :stroke-width="2.5" class="h-is-low-contrast"/>
+        <TokenExtra :token-id="tokens[0]"/>
+        <span v-if="additionalTokensNumber" class="h-is-smaller h-is-extra-text h-should-wrap">
+          {{ ' (+' + additionalTokensNumber + ' more)' }}
+        </span>
+      </template>
     </div>
+
     <div v-else/>
+
   </template>
   <div v-else/>
 </template>
@@ -35,6 +39,7 @@ import {NftTransactionTransfer, TransactionType,} from "@/schemas/MirrorNodeSche
 import TokenExtra from "@/components/values/link/TokenExtra.vue"
 import {NftTransactionAnalyzer} from "./NftTransactionAnalyzer"
 import NftDetailsTransferGraph from "@/components/transfer_graphs/NftDetailsTransferGraph.vue";
+import {Link} from "lucide-vue-next"
 
 const GRAPH_TRANSACTION_TYPES = [
   TransactionType.CRYPTOTRANSFER,

--- a/src/components/transaction/TransactionSummary.vue
+++ b/src/components/transaction/TransactionSummary.vue
@@ -13,15 +13,15 @@
         :compact="true"
     />
 
-    <div v-else-if="isTokenAssociation" class="h-should-wrap">
+    <div v-else-if="isTokenAssociation" class="h-should-wrap tx-summary">
       <EntityIOL :entity-id="entityId"/>
-      <span v-if="tokens.length">
-        <i class="fas fa-link mr-1 h-is-low-contrast"></i>
+      <template v-if="tokens.length">
+        <Link :size="16" :stroke-width="2.5" class="h-is-low-contrast"/>
         <TokenExtra :token-id="tokens[0]"/>
         <span v-if="additionalTokensNumber" class="h-is-smaller h-is-extra-text h-should-wrap">
-          {{ ' ( + ' + additionalTokensNumber + ' more )' }}
+          {{ ' (+' + additionalTokensNumber + ' more)' }}
         </span>
-      </span>
+      </template>
     </div>
 
     <div v-else-if="displayMemo" class="h-should-wrap">
@@ -50,6 +50,7 @@ import TransferGraphSection from "@/components/transfer_graphs/TransferGraphSect
 import {TransactionAnalyzer} from "@/components/transaction/TransactionAnalyzer";
 import TokenExtra from "@/components/values/link/TokenExtra.vue";
 import EntityIOL from "@/components/values/link/EntityIOL.vue";
+import {Link} from "lucide-vue-next";
 
 const GRAPH_TRANSACTION_TYPES = [
   TransactionType.CRYPTOTRANSFER,

--- a/src/components/values/FunctionError.vue
+++ b/src/components/values/FunctionError.vue
@@ -41,7 +41,7 @@
         <template v-else>
           <HexaDumpValue :byte-string="error" :show-none="true"/>
           <div v-if="errorDecodingStatus" class="h-is-extra-text">
-            <span class="icon fas fa-exclamation-circle h-is-low-contrast is-small mt-1 mr-1"/>
+            <CircleAlert class="h-is-low-contrast mr-1" :size="16" style="vertical-align: text-top"/>
             <span>{{ errorDecodingStatus }}</span>
           </div>
         </template>
@@ -58,6 +58,7 @@
 <script setup lang="ts">
 
 import {computed, PropType} from 'vue';
+import {CircleAlert} from "lucide-vue-next";
 import HexaDumpValue from "@/components/values/HexaDumpValue.vue";
 import {FunctionCallAnalyzer} from "@/utils/analyzer/FunctionCallAnalyzer";
 import Property from "@/components/Property.vue";

--- a/src/components/values/FunctionInput.vue
+++ b/src/components/values/FunctionInput.vue
@@ -38,7 +38,7 @@
         <template #value>
           <ByteCodeValue :byte-code="inputArgsOnly ?? undefined"/>
           <div v-if="inputDecodingStatus" class="h-is-extra-text">
-            <span class="icon fas fa-exclamation-circle h-is-low-contrast is-small mt-1 mr-1"/>
+            <CircleAlert class="h-is-low-contrast mr-1" :size="16" style="vertical-align: text-top"/>
             <span>{{ inputDecodingStatus }}</span>
           </div>
         </template>
@@ -54,7 +54,7 @@
       <template #value>
         <ByteCodeValue :byte-code="input ?? undefined"/>
         <div v-if="functionDecodingStatus" class="h-is-extra-text">
-          <span class="icon fas fa-exclamation-circle h-is-low-contrast is-small mt-1 mr-1"/>
+          <CircleAlert class="h-is-low-contrast mr-1" :size="16" style="vertical-align: text-top"/>
           <span>{{ functionDecodingStatus }}</span>
         </div>
       </template>
@@ -69,7 +69,8 @@
 
 <script setup lang="ts">
 
-import {PropType} from 'vue';
+import {computed, PropType} from 'vue';
+import {CircleAlert} from 'lucide-vue-next';
 import {FunctionCallAnalyzer} from "@/utils/analyzer/FunctionCallAnalyzer";
 import Property from "@/components/Property.vue";
 import FunctionValue from "@/components/values/FunctionValue.vue";

--- a/src/components/values/FunctionResult.vue
+++ b/src/components/values/FunctionResult.vue
@@ -29,7 +29,7 @@
       <template v-slot:value>
         <ByteCodeValue :byte-code="output ?? undefined"/>
         <div v-if="outputDecodingStatus" class="h-is-extra-text">
-          <span class="icon fas fa-exclamation-circle h-is-low-contrast is-small mt-1 mr-1"/>
+          <CircleAlert class="h-is-low-contrast mr-1" :size="16" style="vertical-align: text-top"/>
           <span>{{ outputDecodingStatus }}</span>
         </div>
       </template>

--- a/src/components/values/FunctionResult.vue
+++ b/src/components/values/FunctionResult.vue
@@ -46,6 +46,7 @@
 <script setup lang="ts">
 
 import {PropType} from 'vue';
+import {CircleAlert} from "lucide-vue-next";
 import {FunctionCallAnalyzer} from "@/utils/analyzer/FunctionCallAnalyzer";
 import Property from "@/components/Property.vue";
 import FunctionValue from "@/components/values/FunctionValue.vue";

--- a/src/components/values/TimestampValue.vue
+++ b/src/components/values/TimestampValue.vue
@@ -24,9 +24,7 @@
     <template v-else>
       <span class="icon-text">
         <span class="h-is-numeric">{{ timestamp }}</span>
-        <span class="icon h-is-low-contrast-light">
-          <i class="fas fa-exclamation-triangle"></i>
-        </span>
+        <TriangleAlert :size="16" style="vertical-align: text-top"/>
       </span>
     </template>
   </span>
@@ -47,9 +45,11 @@ import {computed, defineComponent, inject, PropType, ref} from "vue";
 import {HMSF} from "@/utils/HMSF";
 import {initialLoadingKey} from "@/AppKeys";
 import {infiniteDuration} from "@/schemas/MirrorNodeSchemas";
+import { TriangleAlert } from 'lucide-vue-next';
 
 export default defineComponent({
   name: "TimestampValue",
+  components: {TriangleAlert},
 
   props: {
     timestamp: {

--- a/src/dialogs/abi/ContractAbiEntry.vue
+++ b/src/dialogs/abi/ContractAbiEntry.vue
@@ -4,7 +4,7 @@
 <!--                                                     TEMPLATE                                                    -->
 <!-- --------------------------------------------------------------------------------------------------------------- -->
 
-<!-- TODO: remove BULMA styling, use Lucide icons, redo chips,...-->
+<!-- TODO: remove BULMA styling, redo chips,...-->
 
 <template>
   <div class="entry-container">
@@ -13,7 +13,8 @@
         data-cy="execFunction"
         class="exec-button"
         v-on:click="handleClick()">
-      <i :class="{ 'fa-play': !isGetter, 'fa-redo': isGetter}" class="fas fa-xs"/>
+      <RotateCw v-if="isGetter" :size="12" :stroke-width="3" style="vertical-align: text-top"/>
+      <Play v-else :size="12" :stroke-width="3" style="vertical-align: text-top"/>
     </button>
     <div class="entry-content">
       <div class="entry-index">
@@ -33,7 +34,7 @@
     <!-- Row 1 -->
     <div/>
     <div v-if="hasResult">
-      <span class="icon h-is-low-contrast"><i class="fas fa-long-arrow-alt-right"/></span>
+      <MoveRight :size="14" :stroke-width="3" style="display: inline; vertical-align: text-top" class="h-is-low-contrast"/>
       <span class="ml-1">
         {{ callOutput }}
       </span>
@@ -61,6 +62,7 @@ import "prismjs/components/prism-solidity.js";
 import SolidityCode from "@/components/SolidityCode.vue";
 import ContractAbiDialog from "@/dialogs/abi/ContractAbiDialog.vue";
 import {ContractCallBuilder} from "@/dialogs/abi/ContractCallBuilder.ts";
+import {MoveRight, Play, RotateCw} from 'lucide-vue-next';
 
 const props = defineProps({
   contractCallBuilder: {
@@ -139,6 +141,7 @@ button.exec-button {
   background-color: transparent;
   border: 0;
   border-radius: 0;
+  cursor: pointer;
 }
 
 div.entry-content {
@@ -152,7 +155,7 @@ div.entry-index {
 
 .source-code {
   background-color: var(--background-secondary);
-  padding: 0px 4px;
+  padding: 0 4px;
 }
 
 </style>

--- a/src/dialogs/core/ModalDialog.vue
+++ b/src/dialogs/core/ModalDialog.vue
@@ -45,7 +45,6 @@ const showDialog = defineModel("showDialog", {
 })
 
 const props = defineProps({
-  iconClass: String,
   width: {
     type: Number,
     default: 400

--- a/src/dialogs/verification/FileList.vue
+++ b/src/dialogs/verification/FileList.vue
@@ -39,7 +39,7 @@
     >
 
       <o-table-column v-slot="props" field="type_and_name">
-        <div class="table-row ">
+        <div class="table-row">
 
           <div v-if="isMetadata(props.row)">
             <FileJson :size="20"/>
@@ -61,12 +61,13 @@
             {{ props.row.path }}
           </div>
 
-          <div v-if="!isMetadata(props.row) && props.row.target"
-               class="icon ml-1 h-is-low-contrast"
-               style="font-size: 14px"
-          >
-            <i class="fa fa-arrow-left"></i>
-          </div>
+          <ArrowLeft
+              v-if="!isMetadata(props.row) && props.row.target"
+              :size="18"
+              :stroke-width="2.5"
+              class="icon-in-table h-is-low-contrast"
+          />
+
         </div>
       </o-table-column>
 
@@ -83,7 +84,7 @@
 import {computed, PropType, ref} from "vue";
 import {OTable, OTableColumn} from "@oruga-ui/oruga-next";
 import {ContractSourceAnalyzerItem} from "@/utils/analyzer/ContractSourceAnalyzer.ts";
-import {FileJson} from 'lucide-vue-next';
+import {ArrowLeft, FileJson} from 'lucide-vue-next';
 
 const props = defineProps({
   auditItems: {

--- a/src/styles/explorer.css
+++ b/src/styles/explorer.css
@@ -430,6 +430,11 @@ a.h-banner-link:hover {
     }
 }
 
+.icon-in-table {
+    display: block;
+    float: right;
+}
+
 /*  ============================================================================
     Maintain code which is still using BULMA classes
 */

--- a/tests/unit/token/NftFile.spec.ts
+++ b/tests/unit/token/NftFile.spec.ts
@@ -1,7 +1,10 @@
+// noinspection DuplicatedCode
+
 // SPDX-License-Identifier: Apache-2.0
 
 import {describe, expect, test} from 'vitest'
 import {flushPromises, mount} from "@vue/test-utils";
+import {File} from "lucide-vue-next";
 import NftFile from "@/components/token/NftFile.vue";
 import Oruga from "@oruga-ui/oruga-next";
 
@@ -23,9 +26,8 @@ describe("NftFile.vue", () => {
         // console.log(wrapper.text())
 
         expect(wrapper.text()).toBe('')
-        const icon = wrapper.find('i')
+        const icon = wrapper.findComponent(File)
         expect(icon.exists()).toBe(true)
-        expect(icon.attributes('class')).toContain('fa-file')
 
         expect(wrapper.find('img').exists()).toBe(false)
         expect(wrapper.find('video').exists()).toBe(false)
@@ -49,9 +51,8 @@ describe("NftFile.vue", () => {
         // console.log(wrapper.text())
 
         expect(wrapper.text()).toBe('')
-        const icon = wrapper.find('i')
+        const icon = wrapper.findComponent(File)
         expect(icon.exists()).toBe(true)
-        expect(icon.attributes('class')).toContain('fa-file')
 
         const image = wrapper.find('img')
         expect(image.exists()).toBe(true)
@@ -78,10 +79,8 @@ describe("NftFile.vue", () => {
         // console.log(wrapper.html())
         // console.log(wrapper.text())
 
-        expect(wrapper.text()).toBe('')
-        const icon = wrapper.find('i')
+        const icon = wrapper.findComponent(File)
         expect(icon.exists()).toBe(true)
-        expect(icon.attributes('class')).toContain('fa-file')
 
         const image = wrapper.find('img')
         expect(image.exists()).toBe(true)
@@ -110,10 +109,8 @@ describe("NftFile.vue", () => {
         // console.log(wrapper.html())
         // console.log(wrapper.text())
 
-        expect(wrapper.text()).toBe('image/jpeg')
-        const icon = wrapper.find('i')
+        const icon = wrapper.findComponent(File)
         expect(icon.exists()).toBe(true)
-        expect(icon.attributes('class')).toContain('fa-file')
 
         const image = wrapper.find('img')
         expect(image.exists()).toBe(true)
@@ -141,9 +138,8 @@ describe("NftFile.vue", () => {
         // console.log(wrapper.text())
 
         expect(wrapper.text()).toBe('video/mp4')
-        const icon = wrapper.find('i')
+        const icon = wrapper.findComponent(File)
         expect(icon.exists()).toBe(true)
-        expect(icon.attributes('class')).toContain('fa-file')
 
         const video = wrapper.find('video')
         expect(video.exists()).toBe(true)
@@ -173,9 +169,8 @@ describe("NftFile.vue", () => {
         // console.log(wrapper.text())
 
         expect(wrapper.text()).toBe('foo/bar')
-        const icon = wrapper.find('i')
+        const icon = wrapper.findComponent(File)
         expect(icon.exists()).toBe(true)
-        expect(icon.attributes('class')).toContain('fa-file')
 
         const image = wrapper.find('img')
         expect(image.exists()).toBe(true)


### PR DESCRIPTION
**Description**:

- Replace remaining fontawesome icons.
- Fontawesome icons used indirectly (i.e. those included by the Oruga components we use) are still there. 
