### PR TITLE
fix: display node account ID in node table

### DIFF
--- a/_frontend/src/components/node/NodeTable.vue
+++ b/_frontend/src/components/node/NodeTable.vue
@@ -24,7 +24,7 @@
         </div>
       </o-table-column>
 
-      <o-table-column v-if="!enableStaking" v-slot="props" field="node_account_id" label="ACCOUNT">
+      <o-table-column v-slot="props" field="node_account_id" label="ACCOUNT">
         <div class="h-is-numeric regular-node-column">
           {{ props.row.node_account_id }}
         </div>

--- a/_frontend/src/components/node/NodeTable.vue
+++ b/_frontend/src/components/node/NodeTable.vue
@@ -172,8 +172,7 @@ const handleClick = (node: NetworkNode, c: unknown, i: number, ci: number, event
 }
 
 #node-table table.o-table > tbody > tr > td {
-  padding-top: 0;
-  padding-bottom: 0;
+  padding: 0 8px;
 }
 
 .regular-node-column {

--- a/_frontend/src/components/node/NodeTable.vue
+++ b/_frontend/src/components/node/NodeTable.vue
@@ -39,14 +39,18 @@
       </o-table-column>
 
       <o-table-column v-if="enableStaking" v-slot="props" field="stake" label="STAKE FOR CONSENSUS" position="right">
-        <Tooltip :text="tooltipStake">
+        <Tooltip>
+          <template #content>
+            <div>{{ tooltipStake }}</div>
+            <div>{{ tooltipPercentage(props.row) }}</div>
+          </template>
           <div class="regular-node-column">
             <HbarAmount :amount="props.row.stake" :decimals="0"/>
           </div>
         </Tooltip>
       </o-table-column>
 
-      <o-table-column v-if="enableStaking" v-slot="props" field="percentage" label="%" position="right">
+      <o-table-column v-if="false" v-slot="props" field="percentage" label="%" position="right">
         <Tooltip :text="tooltipPercentage">
           <div class="regular-node-column">
             <StringValue :string-value="makeWeightPercentage(props.row)"/>
@@ -140,7 +144,11 @@ const props = defineProps({
 })
 
 const tooltipStake = "Total amount of HBAR staked to this specific validator for consensus."
-const tooltipPercentage = "Total amount of HBAR staked to this validator for consensus / total amount of HBAR staked to all validators for consensus."
+
+const tooltipPercentage = (node: NetworkNode) => {
+  return `(${makeWeightPercentage(node)} of the total of all validators)`
+}
+
 const tooltipRewardRate = "Approximate annual reward rate based on the reward earned during the last 24h period."
 
 const enableStaking = routeManager.enableStaking
@@ -150,7 +158,7 @@ onMounted(() => networkAnalyzer.mount())
 onBeforeUnmount(() => networkAnalyzer.unmount())
 
 const makeWeightPercentage = (node: NetworkNode) => {
-  return node.stake && props.stakeTotal ? makeStakePercentage(node, props.stakeTotal) : "0"
+  return node.stake && props.stakeTotal ? makeStakePercentage(node, props.stakeTotal) : "0%"
 }
 
 const handleClick = (node: NetworkNode, c: unknown, i: number, ci: number, event: Event) => {

--- a/_frontend/src/components/node/NodeTable.vue
+++ b/_frontend/src/components/node/NodeTable.vue
@@ -18,7 +18,7 @@
         @cell-click="handleClick"
     >
 
-      <o-table-column v-slot="props" field="node_id" label="NODE ID">
+      <o-table-column v-slot="props" field="node_id" label="ID">
         <div class="regular-node-column node_id">
           {{ props.row.node_id }}
         </div>

--- a/_frontend/src/components/node/StakeRange.vue
+++ b/_frontend/src/components/node/StakeRange.vue
@@ -44,7 +44,7 @@ import {computed, PropType} from "vue";
 import {NetworkNode} from "@/schemas/MirrorNodeSchemas";
 import {NetworkAnalyzer} from "@/utils/analyzer/NetworkAnalyzer";
 
-const progressSize = 250 // size (width) of progress in pixels
+const progressSize = 180 // size (width) of progress in pixels
 
 const props = defineProps({
   node: Object as PropType<NetworkNode | undefined>,

--- a/_frontend/tests/unit/node/NodeTable.spec.ts
+++ b/_frontend/tests/unit/node/NodeTable.spec.ts
@@ -23,7 +23,6 @@ HMSF.forceUTC = true
 describe("NodeTable.vue", () => {
 
     const tooltipStake = "Total amount of HBAR staked to this specific validator for consensus."
-    const tooltipPercentage = "Total amount of HBAR staked to this validator for consensus / total amount of HBAR staked to all validators for consensus."
     const tooltipRewardRate = "Approximate annual reward rate based on the reward earned during the last 24h period."
 
     it("should list the 3 nodes in the table", async () => {
@@ -54,29 +53,29 @@ describe("NodeTable.vue", () => {
             "api/v1/network/nodes",
         ])
 
-        expect(wrapper.get('thead').text()).toBe("NODE IDDESCRIPTIONSTAKE FOR CONSENSUS%STAKE RANGEREWARD RATE")
+        expect(wrapper.get('thead').text()).toBe("IDACCOUNTDESCRIPTIONSTAKE FOR CONSENSUSSTAKE RANGEREWARD RATE")
         expect(wrapper.get('tbody').findAll('tr').length).toBe(3)
         expect(wrapper.get('tbody').text()).toBe(
             "0" +
+            "0.0.3" +
             "Hosted by Hedera | East Coast, USA" +
-            "6,000,000ℏ" + tooltipStake +
-            "25.00%" + tooltipPercentage +
+            "6,000,000ℏ" + tooltipStake + "(25.00% of the total of all validators)" +
             " min  max " +
             "Rewarded:5,000,000ℏNot Rewarded:1,000,000ℏMin:1,000,000ℏMax:30,000,000ℏ" +
             "1%" + tooltipRewardRate +
 
             "1" +
+            "0.0.4" +
             "Hosted by Hedera | East Coast, USA" +
-            "9,000,000ℏ" + tooltipStake +
-            "37.50%" + tooltipPercentage +
+            "9,000,000ℏ" + tooltipStake + "(37.50% of the total of all validators)" +
             " min  max " +
             "Rewarded:7,000,000ℏNot Rewarded:2,000,000ℏMin:1,000,000ℏMax:30,000,000ℏ" +
             "2%" + tooltipRewardRate +
 
             "2" +
+            "0.0.5" +
             "Hosted by Hedera | Central, USA" +
-            "9,000,000ℏ" + tooltipStake +
-            "37.50%" + tooltipPercentage +
+            "9,000,000ℏ" + tooltipStake + "(37.50% of the total of all validators)" +
             " min  max " +
             "Rewarded:7,000,000ℏNot Rewarded:2,000,000ℏMin:1,000,000ℏMax:30,000,000ℏ" +
             "3%" + tooltipRewardRate

--- a/_frontend/tests/unit/node/Nodes.spec.ts
+++ b/_frontend/tests/unit/node/Nodes.spec.ts
@@ -27,7 +27,6 @@ HMSF.forceUTC = true
 describe("Nodes.vue", () => {
 
     const tooltipStake = "Total amount of HBAR staked to this specific validator for consensus."
-    const tooltipPercentage = "Total amount of HBAR staked to this validator for consensus / total amount of HBAR staked to all validators for consensus."
     const tooltipRewardRate = "Approximate annual reward rate based on the reward earned during the " +
         "last 24h period."
 
@@ -101,28 +100,26 @@ describe("Nodes.vue", () => {
         expect(wrapper2.text()).toMatch("3  Nodes")
         const table = wrapper2.findComponent(NodeTable)
         expect(table.exists()).toBe(true)
-        expect(table.get('thead').text()).toBe("NODE IDDESCRIPTIONSTAKE FOR CONSENSUS%STAKE RANGEREWARD RATE")
+        expect(table.get('thead').text()).toBe("IDACCOUNTDESCRIPTIONSTAKE FOR CONSENSUSSTAKE RANGEREWARD RATE")
         expect(wrapper2.get('tbody').text()).toBe(
             "0" +
+            "0.0.3" +
             "Hosted by Hedera | East Coast, USA" +
-            "6,000,000ℏ" + tooltipStake +
-            "25.00%" + tooltipPercentage +
+            "6,000,000ℏ" + tooltipStake + "(25.00% of the total of all validators)" +
             " min  max " +
             "Rewarded:5,000,000ℏNot Rewarded:1,000,000ℏMin:1,000,000ℏMax:30,000,000ℏ" +
             "1%" + tooltipRewardRate +
             "1" +
+            "0.0.4" +
             "Hosted by Hedera | East Coast, USA" +
-            "9,000,000ℏ" + tooltipStake +
-            "37.50%" +
-            tooltipPercentage +
+            "9,000,000ℏ" + tooltipStake + "(37.50% of the total of all validators)" +
             " min  max " +
             "Rewarded:7,000,000ℏNot Rewarded:2,000,000ℏMin:1,000,000ℏMax:30,000,000ℏ" +
             "2%" + tooltipRewardRate +
             "2" +
+            "0.0.5" +
             "Hosted by Hedera | Central, USA" +
-            "9,000,000ℏ" + tooltipStake +
-            "37.50%" +
-            tooltipPercentage +
+            "9,000,000ℏ" + tooltipStake + "(37.50% of the total of all validators)" +
             " min  max " +
             "Rewarded:7,000,000ℏ" +
             "Not Rewarded:2,000,000ℏMin:1,000,000ℏMax:30,000,000ℏ" +


### PR DESCRIPTION
**Description**:

Display account ID in node table unconditionally (it was present only when staking was not activated).
Make table more dense and staking diagram more compact.
Display staking weight % in the tooltip of STAKE FOR CONSENSUS.