### PR TITLE
chore: replace docker/login-action with the StepSecurity equivalent

### DIFF
--- a/.github/workflows/zxc-release-explorer-docker-container.yaml
+++ b/.github/workflows/zxc-release-explorer-docker-container.yaml
@@ -103,7 +103,7 @@ jobs:
               mirrors = ["https://hub.mirror.docker.lat.ope.eng.hashgraph.io"]
 
       - name: Authorize Docker
-        uses: docker/login-action@371161bbe7024a29a25c5e19bfcbc0804fe9ad2c # v4.5.2
+        uses: step-security/docker-login-action@bd6978fd4ef9a5f78130095b298b8a721afcb0d8 # v4.5.1
         if: ${{ inputs.dry-run-enabled != true }}
         with:
           registry: ghcr.io

--- a/.github/workflows/zxc-release-explorer-helm-chart.yaml
+++ b/.github/workflows/zxc-release-explorer-helm-chart.yaml
@@ -46,7 +46,7 @@ jobs:
           version: "v3.12.3" #  helm version
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@371161bbe7024a29a25c5e19bfcbc0804fe9ad2c # v4.5.2
+        uses: step-security/docker-login-action@bd6978fd4ef9a5f78130095b298b8a721afcb0d8 # v4.5.1
         with:
           registry: ghcr.io
           username: ${{ github.actor }}


### PR DESCRIPTION
**Description**:

Fixes #2612 

Replace `docker/login-action` with the StepSecurity equivalent: `step-security/docker-login-action`