### PR TITLE
fix: four bytes analyzer

### DIFF
--- a/_frontend/src/utils/analyzer/call/FourByteAnalyzer.ts
+++ b/_frontend/src/utils/analyzer/call/FourByteAnalyzer.ts
@@ -69,7 +69,7 @@ export class FourByteAnalyzer {
 
     private static resolveSignatureCollisions(records: SignatureRecord[], callParams: string): SignatureRecord | null {
         //
-        // Some selectors (like 0x70a08231) have multiple signatures registered on 4bytes.directory.
+        // Some selectors (like 0xa9059cbb) have multiple signatures registered on 4bytes.directory.
         // We select the first signature which enables to decode inputArgs.
         //
         let result: SignatureRecord | null = null

--- a/_frontend/src/utils/analyzer/call/FourByteAnalyzer.ts
+++ b/_frontend/src/utils/analyzer/call/FourByteAnalyzer.ts
@@ -73,7 +73,7 @@ export class FourByteAnalyzer {
         // We select the first signature which enables to decode inputArgs.
         //
         let result: SignatureRecord | null = null
-        for (const r of records.sort(sortSignatureRecordById)) {
+        for (const r of [...records].sort(sortSignatureRecordById)) {
             try {
                 const ff = ethers.FunctionFragment.from(r.text_signature)
                 const decodedArgs = ethers.AbiCoder.defaultAbiCoder().decode(ff.inputs, callParams)

--- a/_frontend/tests/unit/utils/analyzer/FourByteAnalyzer.spec.ts
+++ b/_frontend/tests/unit/utils/analyzer/FourByteAnalyzer.spec.ts
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {describe, expect, test, vi} from 'vitest'
+import {ethers} from 'ethers'
+import {FourByteAnalyzer} from '@/utils/analyzer/call/FourByteAnalyzer'
+import {SignatureCache, type SignatureRecord, type SignatureResponse} from '@/utils/cache/SignatureCache'
+
+const buildCallParams = (): string => {
+    const address = '0x1111111111111111111111111111111111111111'
+    const amount = 1_000_000_000_000_000_000n
+    return ethers.AbiCoder.defaultAbiCoder().encode(['address', 'uint256'], [address, amount])
+}
+
+describe('FourByteAnalyzer', () => {
+    test('resolveSignatureCollisions picks transfer(address,uint256) without mutating the input order', async () => {
+        const records: SignatureRecord[] = [
+            {id: 31780, created_at: '', text_signature: 'many_msg_babbage(bytes1)', hex_signature: '0x', bytes_signature: ''},
+            {id: 145, created_at: '', text_signature: 'transfer(address,uint256)', hex_signature: '0xa9059cbb', bytes_signature: ''},
+            {id: 161159, created_at: '', text_signature: 'transfer(bytes4[9],bytes5[6],int48[11])', hex_signature: '0x', bytes_signature: ''},
+            {id: 313067, created_at: '', text_signature: 'func_2093253501(bytes)', hex_signature: '0x', bytes_signature: ''},
+            {id: 844280, created_at: '', text_signature: 'join_tg_invmru_haha_fd06787(address,bool)', hex_signature: '0x', bytes_signature: ''},
+            {id: 1111734, created_at: '', text_signature: 'workMyDirefulOwner(uint256,uint256)', hex_signature: '0x', bytes_signature: ''},
+        ]
+        const originalOrder = records.map((record) => record.id)
+
+        const selected = (FourByteAnalyzer as any).resolveSignatureCollisions(records, buildCallParams())
+
+        expect(selected?.text_signature).toBe('transfer(address,uint256)')
+        expect(records.map((record) => record.id)).toEqual(originalOrder)
+    })
+
+    test('search4bytes resolves the selector to transfer(address,uint256)', async () => {
+        const records: SignatureRecord[] = [
+            {id: 31780, created_at: '', text_signature: 'many_msg_babbage(bytes1)', hex_signature: '0x', bytes_signature: ''},
+            {id: 145, created_at: '', text_signature: 'transfer(address,uint256)', hex_signature: '0xa9059cbb', bytes_signature: ''},
+            {id: 161159, created_at: '', text_signature: 'transfer(bytes4[9],bytes5[6],int48[11])', hex_signature: '0x', bytes_signature: ''},
+            {id: 313067, created_at: '', text_signature: 'func_2093253501(bytes)', hex_signature: '0x', bytes_signature: ''},
+            {id: 844280, created_at: '', text_signature: 'join_tg_invmru_haha_fd06787(address,bool)', hex_signature: '0x', bytes_signature: ''},
+            {id: 1111734, created_at: '', text_signature: 'workMyDirefulOwner(uint256,uint256)', hex_signature: '0x', bytes_signature: ''},
+        ]
+        const response: SignatureResponse = {
+            count: records.length,
+            next: null,
+            previous: null,
+            results: records,
+        }
+
+        const lookupSpy = vi.spyOn(SignatureCache.instance, 'lookup').mockResolvedValue(response)
+
+        const fragment = await (FourByteAnalyzer as any).search4bytes('a9059cbb', buildCallParams())
+
+        expect(lookupSpy).toHaveBeenCalledWith('a9059cbb')
+        expect(fragment?.format('sighash')).toBe('transfer(address,uint256)')
+    })
+})

--- a/_frontend/tests/unit/utils/cache/SignatureCache.spec.ts
+++ b/_frontend/tests/unit/utils/cache/SignatureCache.spec.ts
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {describe, expect, test} from 'vitest'
+import MockAdapter from 'axios-mock-adapter'
+import axios from 'axios'
+import {SignatureCache} from '@/utils/cache/SignatureCache'
+
+const buildResponse = () => ({
+    count: 2,
+    next: null,
+    previous: null,
+    results: [
+        {id: 31780, created_at: '', text_signature: 'many_msg_babbage(bytes1)', hex_signature: '0x', bytes_signature: ''},
+        {id: 145, created_at: '', text_signature: 'transfer(address,uint256)', hex_signature: '0xa9059cbb', bytes_signature: ''},
+    ],
+})
+
+describe('SignatureCache', () => {
+    test('returns the API response payload and keeps the records intact', async () => {
+        SignatureCache.instance.clear()
+
+        const mock = new MockAdapter(axios as any)
+        const response = buildResponse()
+        const matcher = 'https://www.4byte.directory/api/v1/signatures/?format=json&hex_signature=a9059cbb'
+        mock.onGet(matcher).reply(200, response)
+
+        const cached = await SignatureCache.instance.lookup('a9059cbb')
+
+        expect(cached).toStrictEqual(response)
+        expect(cached?.results.map((record) => record.id)).toStrictEqual([31780, 145])
+
+        mock.restore()
+    })
+})


### PR DESCRIPTION
**Description**

This change fixes the 4-byte signature collision handling for function-call decoding. For transfer-style payloads such as the `a9059cbb` selector, the analyzer now correctly resolves to `transfer(address,uint256)` while preserving the original response ordering from the cache layer.

What changed:
- Adjusted the collision-resolution logic in `frontend/src/utils/analyzer/call/FourByteAnalyzer.ts` to sort a copy of the signature records instead of mutating the original array in place.
- Added regression coverage for:
  - the analyzer’s collision-resolution path in `frontend/tests/unit/utils/analyzer/FourByteAnalyzer.spec.ts`
  - the cache response path in `frontend/tests/unit/utils/cache/SignatureCache.spec.ts`

**Related issue(s)**

Some selectors can return multiple candidate signatures from 4byte.directory. The analyzer should try them in ascending ID order and select the first signature that decodes the call payload correctly. The previous implementation used `Array.sort()` directly on the incoming array, which mutated the input order unexpectedly.

**Notes for reviewer**:

See also https://swirldslabs.slack.com/archives/C0361991PGD/p1785847035673079

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
