### PR TITLE
chore: Update CODEOWNERS to include dependabot.yml

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,6 +12,7 @@
 
 # Protection Rules for Github Configuration Files and Actions Workflows
 /.github/                                       @hiero-ledger/github-maintainers
+/.github/dependabot.yml                         @hiero-ledger/github-maintainers @hiero-ledger/hiero-mirror-node-explorer-maintainers
 /.github/workflows/                             @hiero-ledger/github-maintainers @hiero-ledger/hiero-mirror-node-explorer-maintainers
 
 # Self-protection for root CODEOWNERS files (this file should not exist and should definitely require approval)


### PR DESCRIPTION
## Description

Updates codeownership for the `dependabot.yml` file to include `@hiero-ledger/hiero-mirror-node-explorer-maintainers`

### Related Issue(s)

Closes #2698 

