### PR TITLE
fix: explorer fails to display registered node's complex admin key

### DIFF
--- a/_frontend/src/components/values/ComplexKeyValue.vue
+++ b/_frontend/src/components/values/ComplexKeyValue.vue
@@ -57,7 +57,7 @@
 
 <script setup lang="ts">
 
-import {computed, inject, PropType, ref} from "vue";
+import {computed, inject, onBeforeUnmount, onMounted, PropType, ref} from "vue";
 import {ComplexKeyLine} from "@/utils/ComplexKeyLine";
 import {hexToByte} from "@/utils/B64Utils";
 import * as hashgraph from "@hashgraph/proto";
@@ -66,6 +66,8 @@ import ContractLink from "@/components/values/link/ContractLink.vue";
 import {initialLoadingKey} from "@/AppKeys";
 
 import {routeManager} from "@/utils/RouteManager.ts";
+import {NetworkAnalyzer} from "@/utils/analyzer/NetworkAnalyzer.ts";
+import {RouteLocationRaw} from "vue-router";
 
 const MAX_INLINE_LEVEL = 1
 
@@ -98,6 +100,10 @@ const props = defineProps({
     default: false
   },
 })
+
+const networkAnalyzer = new NetworkAnalyzer()
+onMounted(() => networkAnalyzer.mount())
+onBeforeUnmount(() => networkAnalyzer.unmount())
 
 const key = computed(() => {
   let result: hashgraph.proto.Key | null
@@ -150,6 +156,7 @@ const lineStyle = (line: ComplexKeyLine): Record<string, string> => {
   }
 }
 
+// eslint-disable-next-line complexity
 const lineText = (line: ComplexKeyLine): string => {
   let result: string
   if (line.key.thresholdKey) {
@@ -165,11 +172,17 @@ const lineText = (line: ComplexKeyLine): string => {
 }
 
 const adminKeyRoute = computed(() => {
-  return props.accountId !== null
-      ? routeManager.makeRouteToAdminKey(props.accountId)
-      : props.nodeId !== null
-          ? routeManager.makeRouteToNodeAdminKey(props.nodeId.toString())
-          : null
+  let result: RouteLocationRaw | null
+  if (props.accountId !== null) {
+    result = routeManager.makeRouteToAdminKey(props.accountId)
+  } else if (props.nodeId !== null) {
+    result = networkAnalyzer.isConsensusNode(props.nodeId)
+        ? routeManager.makeRouteToNodeAdminKey(props.nodeId.toString())
+        : routeManager.makeRouteToRegisteredNodeAdminKey(props.nodeId.toString())
+  } else {
+    result = null
+  }
+  return result
 })
 
 const initialLoading = inject(initialLoadingKey, ref(false))

--- a/_frontend/src/pages/NodeAdminKeyDetails.vue
+++ b/_frontend/src/pages/NodeAdminKeyDetails.vue
@@ -8,19 +8,17 @@
 
   <PageFrameV2 :page-title="pageTitle">
 
-    <DashboardCardV2>
+    <DashboardCardV2 v-if="nodeExists">
       <template #title>
         <span>Admin Key for Node </span>
-        <div v-if="nodeId !== null">
-          <router-link :to="routeManager.makeRouteToNode(nodeId)">
-            <span>{{ nodeId }} - {{ nodeDescription }}</span>
+        <router-link :to="routeManager.makeRouteToNode(nodeId!)">
+          <span>{{ nodeId }}</span>
+          <span v-if="nodeDescription !== null"> - {{ nodeDescription }}</span>
           </router-link>
-        </div>
       </template>
 
       <template #content>
         <KeyValue
-            v-if="nodeId !== null"
             :in-details-page="true"
             :key-bytes="nodeKey?.key"
             :key-type="nodeKey?._type"
@@ -28,6 +26,8 @@
         />
       </template>
     </DashboardCardV2>
+
+    <NotificationBanner v-else :message="`Consensus Node ${nodeId} was not found`" is-error/>
 
   </PageFrameV2>
 
@@ -46,6 +46,7 @@ import DashboardCardV2 from "@/components/DashboardCardV2.vue";
 import {NodeAnalyzer} from "@/utils/analyzer/NodeAnalyzer.ts";
 
 import {routeManager} from "@/utils/RouteManager.ts";
+import NotificationBanner from "@/components/NotificationBanner.vue";
 
 const props = defineProps({
   nodeId: {
@@ -74,6 +75,7 @@ const nodeAnalyzer = new NodeAnalyzer(nodeId)
 onMounted(() => nodeAnalyzer.mount())
 onBeforeUnmount(() => nodeAnalyzer.unmount())
 
+const nodeExists = computed(() => nodeAnalyzer.node.value !== null)
 const nodeKey = nodeAnalyzer.adminKey
 const nodeDescription = nodeAnalyzer.shortNodeDescription
 

--- a/_frontend/src/pages/RegisteredNodeAdminKeyDetails.vue
+++ b/_frontend/src/pages/RegisteredNodeAdminKeyDetails.vue
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: Apache-2.0
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                     TEMPLATE                                                    -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<template>
+
+  <PageFrameV2 :page-title="pageTitle">
+
+    <DashboardCardV2 v-if="nodeExists">
+      <template #title>
+        <span>Admin Key for RegisteredNode </span>
+        <router-link :to="routeManager.makeRouteToRegisteredNode(nodeId!)">
+          <span>{{ nodeId }}</span>
+          <span v-if="nodeDescription !== null"> - {{ nodeDescription }}</span>
+        </router-link>
+      </template>
+
+      <template #content>
+        <KeyValue
+            :in-details-page="true"
+            :key-bytes="nodeKey?.key"
+            :key-type="nodeKey?._type"
+            :show-none="true"
+        />
+      </template>
+    </DashboardCardV2>
+
+    <NotificationBanner v-else :message="`Registered Node ${nodeId} was not found`" is-error/>
+
+  </PageFrameV2>
+
+</template>
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                      SCRIPT                                                     -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<script lang="ts" setup>
+
+import {computed, onBeforeUnmount, onMounted, PropType} from 'vue';
+import PageFrameV2 from "@/components/page/PageFrameV2.vue";
+import KeyValue from "@/components/values/KeyValue.vue";
+import DashboardCardV2 from "@/components/DashboardCardV2.vue";
+
+import {routeManager} from "@/utils/RouteManager.ts";
+import {RegisteredNodeAnalyzer} from "@/utils/analyzer/RegisteredNodeAnalyzer.ts";
+import NotificationBanner from "@/components/NotificationBanner.vue";
+
+const props = defineProps({
+  nodeId: {
+    type: String as PropType<string | null>,
+    default: null
+  },
+  network: String
+})
+
+//
+// node
+//
+
+const nodeId = computed(() => {
+  let result: number | null
+  if (props.nodeId !== null) {
+    const id = parseInt(props.nodeId)
+    result = isNaN(id) || id < 0 ? null : id
+  } else {
+    result = null
+  }
+  return result;
+})
+
+const nodeAnalyzer = new RegisteredNodeAnalyzer(nodeId)
+onMounted(() => nodeAnalyzer.mount())
+onBeforeUnmount(() => nodeAnalyzer.unmount())
+
+const nodeExists = computed(() => nodeAnalyzer.registeredNode.value !== null)
+const nodeKey = nodeAnalyzer.adminKey
+const nodeDescription = nodeAnalyzer.description
+
+const pageTitle = computed(() =>
+    nodeId.value !== null ? "Admin Key for Registered Node " + nodeId.value : null
+)
+
+</script>
+
+<style/>

--- a/_frontend/src/router.ts
+++ b/_frontend/src/router.ts
@@ -74,6 +74,7 @@ import Network_MirrorNodes from "@/pages/Network_MirrorNodes.vue";
 import Network_RpcRelays from "@/pages/Network_RpcRelays.vue";
 import RegisteredNodeDetails from "@/pages/RegisteredNodeDetails.vue";
 import Network_GeneralServices from "@/pages/Network_GeneralServices.vue";
+import RegisteredNodeAdminKeyDetails from "@/pages/RegisteredNodeAdminKeyDetails.vue";
 
 export enum TabId {
     Home = "Home",
@@ -696,6 +697,15 @@ export const routes: Array<RouteRecordRaw> = [
         path: '/:network/nodeAdminKey/:nodeId',
         name: 'NodeAdminKeyDetails',
         component: NodeAdminKeyDetails,
+        props: true,
+        meta: {
+            tabId: TabId.Network
+        }
+    },
+    {
+        path: '/:network/registeredNodeAdminKey/:nodeId',
+        name: 'RegisteredNodeAdminKeyDetails',
+        component: RegisteredNodeAdminKeyDetails,
         props: true,
         meta: {
             tabId: TabId.Network

--- a/_frontend/src/utils/RouteManager.ts
+++ b/_frontend/src/utils/RouteManager.ts
@@ -305,6 +305,12 @@ export class RouteManager {
         }
     }
 
+    public makeRouteToRegisteredNodeAdminKey(nodeId: string): RouteLocationRaw {
+        return {
+            name: 'RegisteredNodeAdminKeyDetails', params: {nodeId: nodeId, network: this.currentNetwork.value}
+        }
+    }
+
     //
     // Token
     //

--- a/_frontend/src/utils/analyzer/NetworkAnalyzer.ts
+++ b/_frontend/src/utils/analyzer/NetworkAnalyzer.ts
@@ -104,6 +104,14 @@ export class NetworkAnalyzer {
         }
     }
 
+    public findNodeById(nodeId: number): NetworkNode | null {
+        return this.nodes.value.find((n) => n.node_id === nodeId) ?? null
+    }
+
+    public findNodeByAccountId(nodeAccountId: string): NetworkNode | null {
+        return this.nodes.value.find((n) => n.node_account_id === nodeAccountId) ?? null
+    }
+
     //
     // Private
     //

--- a/_frontend/src/utils/analyzer/NetworkAnalyzer.ts
+++ b/_frontend/src/utils/analyzer/NetworkAnalyzer.ts
@@ -112,6 +112,10 @@ export class NetworkAnalyzer {
         return this.nodes.value.find((n) => n.node_account_id === nodeAccountId) ?? null
     }
 
+    public isConsensusNode(nodeId: number): boolean {
+        return this.findNodeById(nodeId)  !== null
+    }
+
     //
     // Private
     //

--- a/_frontend/src/utils/analyzer/NodeAnalyzer.ts
+++ b/_frontend/src/utils/analyzer/NodeAnalyzer.ts
@@ -29,21 +29,9 @@ export class NodeAnalyzer {
     public node: ComputedRef<NetworkNode | null> = computed(() => {
         let result: NetworkNode | null
         if (typeof this.nodeLoc.value == "number") {
-            result = null
-            for (const node of this.networkAnalyzer.nodes.value) {
-                if (node.node_id == this.nodeLoc.value) {
-                    result = node
-                    break
-                }
-            }
+            result = this.networkAnalyzer.findNodeById(this.nodeLoc.value)
         } else if (typeof this.nodeLoc.value == "string") {
-            result = null
-            for (const node of this.networkAnalyzer.nodes.value) {
-                if (node.node_account_id == this.nodeLoc.value) {
-                    result = node
-                    break
-                }
-            }
+            result = this.networkAnalyzer.findNodeByAccountId(this.nodeLoc.value)
         } else {
             result = null
         }

--- a/_frontend/src/utils/analyzer/RegisteredNodeAnalyzer.ts
+++ b/_frontend/src/utils/analyzer/RegisteredNodeAnalyzer.ts
@@ -22,6 +22,11 @@ export class RegisteredNodeAnalyzer {
         }
         return result
     })
+
+    public adminKey = computed(() => this.registeredNode.value?.admin_key ?? null)
+
+    public description = computed(() => this.registeredNode.value?.description ?? null)
+
     public serviceEndpoints = computed(() =>
         [...(this.registeredNode.value?.service_endpoints ?? [])].sort(sortRegisteredServiceEndPoint)
     )

--- a/_frontend/tests/unit/Mocks.ts
+++ b/_frontend/tests/unit/Mocks.ts
@@ -5235,7 +5235,10 @@ export const SAMPLE_REGISTERED_NODES: { registered_nodes: object[] } = {
             "timestamp": {"from": "1654531806.041135961", "to": null}
         },
         {
-            "admin_key": null,
+            "admin_key": {
+                "_type": "ProtobufEncoded",
+                "key": "2af001080212eb010a4e2a4c080112480a221220ef2d877b88b7464d9253560b8851316f5c2f6ddf935eb4eec0761a3262b0a48c0a221220a95d54cf49c1d08cd16d8908f37dfad95637134ffaf528a1d96da7f28d45f1390a98012a950108021290010a221220c44c911fa45166e356b498463184459dd9ee760bacc083de348691d6357e06340a221220ef2d877b88b7464d9253560b8851316f5c2f6ddf935eb4eec0761a3262b0a48c0a221220a95d54cf49c1d08cd16d8908f37dfad95637134ffaf528a1d96da7f28d45f1390a221220daa5da866bf4e990c14eff4336f5ab4b416c85a31289c8cb8ae1b4a54ce8c111"
+            },
             "created_timestamp": "1654531900.000000000",
             "description": "Mirror Node | West Coast, USA",
             "registered_node_id": 1,

--- a/_frontend/tests/unit/account/RegisteredNodeAdminKeyDetails.spec.ts
+++ b/_frontend/tests/unit/account/RegisteredNodeAdminKeyDetails.spec.ts
@@ -9,11 +9,12 @@ import {SAMPLE_NETWORK_NODES, SAMPLE_REGISTERED_NODES} from "../Mocks"
 import {fetchGetURLs} from "../MockUtils"
 import RegisteredNodeAdminKeyDetails from "@/pages/RegisteredNodeAdminKeyDetails.vue"
 import KeyValue from "@/components/values/KeyValue.vue"
+import ComplexKeyValue from "@/components/values/ComplexKeyValue.vue"
 import router from "@/utils/RouteManager.ts"
 
 describe("RegisteredNodeAdminKeyDetails.vue", () => {
 
-    it("displays the registered node admin key", async () => {
+    it("displays a simple registered node admin key", async () => {
         await router.push("/")
         const mock = new MockAdapter(axios as any)
         mock.onGet("api/v1/network/registered-nodes").reply(200, SAMPLE_REGISTERED_NODES)
@@ -40,6 +41,47 @@ describe("RegisteredNodeAdminKeyDetails.vue", () => {
         expect(key.exists()).toBe(true)
         expect(key.text()).toContain("ED25519")
         expect(key.text()).toContain("d6e8334")
+
+        mock.restore()
+        wrapper.unmount()
+    })
+
+    it("displays a complex registered node admin key", async () => {
+        await router.push("/")
+        const mock = new MockAdapter(axios as any)
+        mock.onGet("api/v1/network/registered-nodes").reply(200, SAMPLE_REGISTERED_NODES)
+        mock.onGet("api/v1/network/nodes").reply(200, SAMPLE_NETWORK_NODES)
+
+        const wrapper = mount(RegisteredNodeAdminKeyDetails, {
+            global: {
+                plugins: [router, Oruga]
+            },
+            props: {
+                nodeId: "1"
+            }
+        })
+
+        await flushPromises()
+
+        expect(fetchGetURLs(mock)).toStrictEqual([
+            "api/v1/network/registered-nodes",
+            "api/v1/network/nodes"
+        ])
+        expect(wrapper.text()).toContain("Admin Key for RegisteredNode 1 - Mirror Node | West Coast, USA")
+
+        const key = wrapper.findComponent(ComplexKeyValue)
+        expect(key.exists()).toBe(true)
+        expect(key.text()).toBe(
+            "THRESHOLD (2 of 2)" +
+            "THRESHOLD (1 of 2)" +
+            "ED25519: ef2d877b88b7464d9253560b8851316f5c2f6ddf935eb4eec0761a3262b0a48c" +
+            "ED25519: a95d54cf49c1d08cd16d8908f37dfad95637134ffaf528a1d96da7f28d45f139" +
+            "THRESHOLD (2 of 4)" +
+            "ED25519: c44c911fa45166e356b498463184459dd9ee760bacc083de348691d6357e0634" +
+            "ED25519: ef2d877b88b7464d9253560b8851316f5c2f6ddf935eb4eec0761a3262b0a48c" +
+            "ED25519: a95d54cf49c1d08cd16d8908f37dfad95637134ffaf528a1d96da7f28d45f139" +
+            "ED25519: daa5da866bf4e990c14eff4336f5ab4b416c85a31289c8cb8ae1b4a54ce8c111"
+        )
 
         mock.restore()
         wrapper.unmount()

--- a/_frontend/tests/unit/account/RegisteredNodeAdminKeyDetails.spec.ts
+++ b/_frontend/tests/unit/account/RegisteredNodeAdminKeyDetails.spec.ts
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {describe, expect, it} from 'vitest'
+import {flushPromises, mount} from "@vue/test-utils"
+import axios from "axios"
+import MockAdapter from "axios-mock-adapter"
+import Oruga from "@oruga-ui/oruga-next"
+import {SAMPLE_NETWORK_NODES, SAMPLE_REGISTERED_NODES} from "../Mocks"
+import {fetchGetURLs} from "../MockUtils"
+import RegisteredNodeAdminKeyDetails from "@/pages/RegisteredNodeAdminKeyDetails.vue"
+import KeyValue from "@/components/values/KeyValue.vue"
+import router from "@/utils/RouteManager.ts"
+
+describe("RegisteredNodeAdminKeyDetails.vue", () => {
+
+    it("displays the registered node admin key", async () => {
+        await router.push("/")
+        const mock = new MockAdapter(axios as any)
+        mock.onGet("api/v1/network/registered-nodes").reply(200, SAMPLE_REGISTERED_NODES)
+        mock.onGet("api/v1/network/nodes").reply(200, SAMPLE_NETWORK_NODES)
+
+        const wrapper = mount(RegisteredNodeAdminKeyDetails, {
+            global: {
+                plugins: [router, Oruga]
+            },
+            props: {
+                nodeId: "0"
+            }
+        })
+
+        await flushPromises()
+
+        expect(fetchGetURLs(mock)).toStrictEqual([
+            "api/v1/network/registered-nodes",
+            "api/v1/network/nodes"
+        ])
+        expect(wrapper.text()).toContain("Admin Key for RegisteredNode 0 - Block Node | East Coast, USA")
+
+        const key = wrapper.findComponent(KeyValue)
+        expect(key.exists()).toBe(true)
+        expect(key.text()).toContain("ED25519")
+        expect(key.text()).toContain("d6e8334")
+
+        mock.restore()
+        wrapper.unmount()
+    })
+
+    it("displays an error for an unknown registered node", async () => {
+        await router.push("/")
+        const mock = new MockAdapter(axios as any)
+        mock.onGet("api/v1/network/registered-nodes").reply(200, SAMPLE_REGISTERED_NODES)
+        mock.onGet("api/v1/network/nodes").reply(200, SAMPLE_NETWORK_NODES)
+
+        const wrapper = mount(RegisteredNodeAdminKeyDetails, {
+            global: {
+                plugins: [router, Oruga]
+            },
+            props: {
+                nodeId: "999"
+            }
+        })
+
+        await flushPromises()
+
+        expect(wrapper.text()).toContain("Registered Node 999 was not found")
+
+        mock.restore()
+        wrapper.unmount()
+    })
+})

--- a/_frontend/tests/unit/values/ComplexKeyValue.spec.ts
+++ b/_frontend/tests/unit/values/ComplexKeyValue.spec.ts
@@ -2,13 +2,68 @@
 
 
 import {describe, expect, it} from 'vitest'
-import {mount} from "@vue/test-utils";
+import {flushPromises, mount} from "@vue/test-utils";
+import axios from "axios";
+import MockAdapter from "axios-mock-adapter";
 import ComplexKeyValue from "@/components/values/ComplexKeyValue.vue";
 import router from "@/utils/RouteManager.ts";
+import {SAMPLE_NETWORK_NODES} from "../Mocks";
 
 describe("ComplexKeyValue.vue", () => {
 
     const COMPLEX_KEY = "0x2a880208021283020a562a54080112500a2632240a221220ef2d877b88b7464d9253560b8851316f5c2f6ddf935eb4eec0761a3262b0a48c0a2632240a221220a95d54cf49c1d08cd16d8908f37dfad95637134ffaf528a1d96da7f28d45f1390aa8012aa501080212a0010a2632240a221220c44c911fa45166e356b498463184459dd9ee760bacc083de348691d6357e06340a2632240a221220ef2d877b88b7464d9253560b8851316f5c2f6ddf935eb4eec0761a3262b0a48c0a2632240a221220a95d54cf49c1d08cd16d8908f37dfad95637134ffaf528a1d96da7f28d45f1390a2632240a221220daa5da866bf4e990c14eff4336f5ab4b416c85a31289c8cb8ae1b4a54ce8c111"
+
+    it("routes consensus-node keys to NodeAdminKeyDetails", async () => {
+        await router.push("/")
+        const mock = new MockAdapter(axios as any)
+        mock.onGet("api/v1/network/nodes").reply(200, SAMPLE_NETWORK_NODES)
+
+        const wrapper = mount(ComplexKeyValue, {
+            global: {
+                plugins: [router]
+            },
+            props: {
+                keyBytes: COMPLEX_KEY,
+                nodeId: 2
+            }
+        })
+
+        await flushPromises()
+        await wrapper.get("a").trigger("click")
+        await flushPromises()
+
+        expect(router.currentRoute.value.name).toBe("NodeAdminKeyDetails")
+        expect(router.currentRoute.value.params.nodeId).toBe("2")
+
+        mock.restore()
+        wrapper.unmount()
+    })
+
+    it("routes registered-node keys to RegisteredNodeAdminKeyDetails", async () => {
+        await router.push("/")
+        const mock = new MockAdapter(axios as any)
+        mock.onGet("api/v1/network/nodes").reply(200, SAMPLE_NETWORK_NODES)
+
+        const wrapper = mount(ComplexKeyValue, {
+            global: {
+                plugins: [router]
+            },
+            props: {
+                keyBytes: COMPLEX_KEY,
+                nodeId: 99
+            }
+        })
+
+        await flushPromises()
+        await wrapper.get("a").trigger("click")
+        await flushPromises()
+
+        expect(router.currentRoute.value.name).toBe("RegisteredNodeAdminKeyDetails")
+        expect(router.currentRoute.value.params.nodeId).toBe("99")
+
+        mock.restore()
+        wrapper.unmount()
+    })
 
     it("props.keyBytes set with complex key", async () => {
 


### PR DESCRIPTION
Fixes #2704

**Description**:

Introduce new route to `RegisteredNodeAdminKeyDetails` page.
ComplexKeyValue now determines whether it is displaying a consensus node's or registered node's admin key and route to the corresponding details page.

**Notes for reviewer**:

- Fix deployed on staging server.

- Screenshots
<img width="1268" height="594" alt="Screenshot 2026-08-20 at 17 08 54" src="https://github.com/user-attachments/assets/4032813c-6eb2-478d-809b-16759a189196" />

<img width="1268" height="411" alt="Screenshot 2026-08-20 at 17 11 44" src="https://github.com/user-attachments/assets/2841365c-3eb8-46c9-be83-2aa81a977bac" />
