### PR TITLE
chore: replace docker/setup-buildx-action by step-security/setup-buildx-action

### DIFF
--- a/.github/workflows/zxc-release-explorer-docker-container.yaml
+++ b/.github/workflows/zxc-release-explorer-docker-container.yaml
@@ -94,7 +94,7 @@ jobs:
         uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+        uses: step-security/setup-buildx-action@a4709e2865773e1792246433e8eb922f9743a875 # v4.2.0
         with:
           version: v0.16.2
           driver-opts: network=host


### PR DESCRIPTION
Replace GH action by its more secure StepSecurity counterpart.

Fixes #2614 
