### PR TITLE
chore: suppress release email flood

### DIFF
--- a/_frontend/.releaserc
+++ b/_frontend/.releaserc
@@ -12,7 +12,13 @@
         "preset": "conventionalcommits"
       }
     ],
-    "@semantic-release/github"
+    [
+      "@semantic-release/github",
+      {
+        "successComment": false,
+        "failComment": false
+      }
+    ]
   ],
   "verifyRelease": [
     [


### PR DESCRIPTION
**Description**:


Configure semantic-release/github to avoid commenting issues and PRs included in a release, to avoid generating a ton of GitHub notification emails at each release.

