### PR TITLE
feat: customize Oruga to use Lucide icons

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -57,9 +57,6 @@ updates:
       walletconnect:
         patterns:
           - "@walletconnect/*"
-      fortawesome:
-        patterns:
-          - "@fortawesome/*"
       cypress:
         patterns:
           - "cypress"

--- a/_frontend/index.html
+++ b/_frontend/index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta property="og:locale" content="en_US">
     <meta property="og:type" content="website">
-    <script crossorigin="anonymous" src="https://kit.fontawesome.com/9871036907.js"></script>
 </head>
 <body>
 <div id="app"></div>

--- a/_frontend/package-lock.json
+++ b/_frontend/package-lock.json
@@ -10,10 +10,6 @@
       "dependencies": {
         "@bokuweb/zstd-wasm": "0.0.27",
         "@ethereum-sourcify/bytecode-utils": "1.6.1",
-        "@fortawesome/fontawesome-svg-core": "7.3.1",
-        "@fortawesome/free-brands-svg-icons": "7.3.1",
-        "@fortawesome/free-solid-svg-icons": "7.3.1",
-        "@fortawesome/vue-fontawesome": "3.3.3",
         "@hashgraph/proto": "2.25.0",
         "@hashgraph/sdk": "2.81.0",
         "@hedera-name-service/hns-resolution-sdk": "2.0.15",
@@ -4409,61 +4405,6 @@
         "@vue/composition-api": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@fortawesome/fontawesome-common-types": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-7.3.1.tgz",
-      "integrity": "sha512-k0C0sdHmZtAo6dRDtd1Z/qcpyHbL0CKsjV8seMY/21xGhY5Wsv0XRmiI/xEEH4y2c9b1+jvgNs/3EqhV27yUEA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@fortawesome/fontawesome-svg-core": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-7.3.1.tgz",
-      "integrity": "sha512-BoxVN3PKnMbgStHhjoaky/oWdxHomDqmBVA24IA3KEmssFGeI7u9YT/BJceOjIum/t6TpPa/vcMKaVYQeIQ/3Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@fortawesome/fontawesome-common-types": "7.3.1"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@fortawesome/free-brands-svg-icons": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-7.3.1.tgz",
-      "integrity": "sha512-8eiNzycuFhy3mZsi5EVO8JpO3H8l7/kSCl4Gk4iUew9hJuzYFqAAD6kqgeEup3+YZ9hL+5cjjorGzrRLkYuURg==",
-      "license": "(CC-BY-4.0 AND MIT)",
-      "dependencies": {
-        "@fortawesome/fontawesome-common-types": "7.3.1"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@fortawesome/free-solid-svg-icons": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-7.3.1.tgz",
-      "integrity": "sha512-v0BLa0eqg7ubvVWeNSHVBs8fWH/GJicERZoJaxJ3FE/lj67VSqzoMg9pzfZVOfLMX10y0pGwQAuxoRVVH2patg==",
-      "license": "(CC-BY-4.0 AND MIT)",
-      "dependencies": {
-        "@fortawesome/fontawesome-common-types": "7.3.1"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@fortawesome/vue-fontawesome": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/@fortawesome/vue-fontawesome/-/vue-fontawesome-3.3.3.tgz",
-      "integrity": "sha512-Jbjze98gGcVBSdkscLbnDlHECumMAFVWDarMtycctn9qL3p92ApnV36VW4PwVrcm9IWrHnnE6ZL9x7MXStSCfA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@fortawesome/fontawesome-svg-core": "~1 || ~6 || ~7",
-        "vue": ">= 3.0.0 < 4"
       }
     },
     "node_modules/@grpc/grpc-js": {

--- a/_frontend/package.json
+++ b/_frontend/package.json
@@ -26,10 +26,6 @@
   "dependencies": {
     "@bokuweb/zstd-wasm": "0.0.27",
     "@ethereum-sourcify/bytecode-utils": "1.6.1",
-    "@fortawesome/fontawesome-svg-core": "7.3.1",
-    "@fortawesome/free-brands-svg-icons": "7.3.1",
-    "@fortawesome/free-solid-svg-icons": "7.3.1",
-    "@fortawesome/vue-fontawesome": "3.3.3",
     "@hashgraph/proto": "2.25.0",
     "@hashgraph/sdk": "2.81.0",
     "@hedera-name-service/hns-resolution-sdk": "2.0.15",

--- a/_frontend/src/components/OrugaLucideIcon.vue
+++ b/_frontend/src/components/OrugaLucideIcon.vue
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                      SCRIPT                                                     -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<template>
+  <component :is="lucideIcon" :size="lucideSize"/>
+</template>
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                     TEMPLATE                                                    -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<script lang="ts" setup>
+
+import {ChevronLeft, ChevronRight, CircleQuestionMark, LoaderCircle, LucideIcon} from "@lucide/vue";
+import {computed, PropType} from "vue";
+
+const props = defineProps({
+  icon: {
+    type: String,
+    required: true,
+  },
+  size: {
+    type: [String, Number] as PropType<string | number>,
+    default: undefined,
+  },
+});
+
+const lucideSize = computed<number | undefined>(() => {
+  if (props.size === undefined || props.size === "") {
+    return undefined;
+  }
+  return Number(props.size);
+});
+
+const iconMap: Record<string, LucideIcon> = {
+
+  // List of internal icons used by Oruga is in _frontend/node_modules/@oruga-ui/oruga-next/src/utils/icons.ts
+  // We should only need the following, but we can add more if needed.
+  'chevron-left': ChevronLeft,
+  'chevron-right': ChevronRight,
+  'loading': LoaderCircle,
+}
+
+const lucideIcon = computed(() => iconMap[props.icon] ?? CircleQuestionMark)
+
+</script>
+
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+<!--                                                       STYLE                                                     -->
+<!-- --------------------------------------------------------------------------------------------------------------- -->
+
+<style/>

--- a/_frontend/src/main.ts
+++ b/_frontend/src/main.ts
@@ -11,6 +11,7 @@ import {AxiosMonitor} from "@/utils/AxiosMonitor";
 import {CoreConfig} from "@/config/CoreConfig";
 import {NetworkConfig} from "@/config/NetworkConfig";
 import router, {routeManager} from "@/utils/RouteManager.ts";
+import OrugaLucideIcon from "@/components/OrugaLucideIcon.vue";
 
 AxiosMonitor.instance.setTargetAxios(axios)
 
@@ -54,8 +55,24 @@ const createAndMount = async () => {
     head.appendChild(link);
 
     const app = createApp(Root, {coreConfig, networkConfig})
+
+    app.component("oruga-lucide-icon", OrugaLucideIcon)
     app.use(router)
-    app.use(createOruga())
+    app.use(createOruga({
+        iconPack: 'basicCustomPack',
+        iconComponent: 'oruga-lucide-icon',
+        customIconPacks: {
+            basicCustomPack: {
+                iconPrefix: '',
+                sizes: {
+                    default: "24",
+                    small: "16",
+                    medium: "24",
+                    large: "32",
+                }
+            }
+        }
+    }))
     app.mount('#app')
 }
 

--- a/_frontend/src/main.ts
+++ b/_frontend/src/main.ts
@@ -4,9 +4,6 @@ import {createApp} from 'vue'
 import Root from './Root.vue'
 import axios from 'axios'
 import {createOruga} from '@oruga-ui/oruga-next'
-import {FontAwesomeIcon} from "@fortawesome/vue-fontawesome";
-import {library} from "@fortawesome/fontawesome-svg-core";
-import {faForward} from "@fortawesome/free-solid-svg-icons";
 
 import "@oruga-ui/theme-oruga/style.css";
 import "@/styles/explorer.css";
@@ -14,9 +11,6 @@ import {AxiosMonitor} from "@/utils/AxiosMonitor";
 import {CoreConfig} from "@/config/CoreConfig";
 import {NetworkConfig} from "@/config/NetworkConfig";
 import router, {routeManager} from "@/utils/RouteManager.ts";
-
-library.add(faForward);
-export default FontAwesomeIcon;
 
 AxiosMonitor.instance.setTargetAxios(axios)
 
@@ -60,9 +54,8 @@ const createAndMount = async () => {
     head.appendChild(link);
 
     const app = createApp(Root, {coreConfig, networkConfig})
-    app.component("font-awesome-icon", FontAwesomeIcon as any)
     app.use(router)
-    app.use(createOruga({iconPack: 'fas'}))
+    app.use(createOruga())
     app.mount('#app')
 }
 


### PR DESCRIPTION
**Description**:

Remove the last dependency on FontAwesome (which is via the icon pack used by Oruga):
 - Configure a custom icon pack for Oruga in `main.ts` based on a custom icon component: `OrugaLucideIcon`
 - `OrugaLucideIcon` is a simple dynamic component which maps icon names as requested by Oruga to Lucide icons.
 
**Note**: `OrugaLucideIcon` is not intended as a generic component mapping any icon used by the Oruga component library, it only deals with the icons used by the Table and Pagination components: `chevron-left`,  `chevron-right`, `loading` (the ultimate goal being to fully remove the Oruga dependency).

**Related issue(s)**:

Fixes #2686 