### PR TITLE
chore: replace mikefarah/yq with step-security/mikefarah-yq

### DIFF
--- a/.github/workflows/zxc-release-explorer-helm-chart.yaml
+++ b/.github/workflows/zxc-release-explorer-helm-chart.yaml
@@ -53,7 +53,7 @@ jobs:
           password: ${{ github.token }}
 
       - name: Update Helm Chart Version
-        uses: mikefarah/yq@1b9b4ac5187171d2e5e3129be0cfa827c7f9d53d # v4.53.3
+        uses: step-security/mikefarah-yq@8846e5dd1d464630a33e8195401e3a3d8fb1f0d7 # v4.53.3
         env:
           relver: ${{ inputs.new-version }}
         with:


### PR DESCRIPTION
**Description**:

Replace github action `mikefarah/yq` with its StepSecurity counterpart: `step-security/mikefarah-yq`.