### PR TITLE
chore: replace github actions by their StepSecurity counterparts

### DIFF
--- a/.github/workflows/flow-release-explorer.yaml
+++ b/.github/workflows/flow-release-explorer.yaml
@@ -47,7 +47,7 @@ jobs:
             marked-mangle@1.1.10 marked-gfm-heading-id@4.1.1 semantic-release-conventional-commits@3.0.0
 
       - name: Setup JQ
-        uses: dcarbone/install-jq-action@4fcb5062d7ce9bc4382d1a352d19ba3ba2c317c1 # v4.0.1
+        uses: step-security/install-jq-action@01c80bba4b4dfda4f9f5df20aa272d43e93a9fb1 # v4.0.1
         with:
           version: 1.7
 

--- a/.github/workflows/zxc-release-explorer-docker-container.yaml
+++ b/.github/workflows/zxc-release-explorer-docker-container.yaml
@@ -93,7 +93,7 @@ jobs:
           cache-dependency-path: _frontend/package-lock.json
 
       - name: Setup Docker Buildx QEMU
-        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+        uses: step-security/setup-qemu-action@1d653f731ddc90c553742100d15205c94b792314 # v4.2.0
 
       - name: Set up Docker Buildx
         uses: step-security/setup-buildx-action@a4709e2865773e1792246433e8eb922f9743a875 # v4.2.0
@@ -119,7 +119,7 @@ jobs:
         run: npm run build
 
       - name: Build Image
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        uses: step-security/docker-build-push-action@144392094f7fc3199dda455efe3b70dbea4b72a0 # v7.3.0
         env:
           SOURCE_DATE_EPOCH: ${{ steps.commit.outputs.source-date }}
         with:


### PR DESCRIPTION
**Description**:

Replace the following GitHub actions by their (safer) StepSecurity counterpart:
 - docker/build-push-action -> step-security/docker-build-push-action
 - docker/setup-qemu-action -> step-security/setup-qemu-action
 - dcarbone/install-jq-action -> step-security/install-jq-action
 
**Related issue(s)**:

Fixes #2615
Fixes #2613
Fixes #2597

**Notes for reviewer**:

We only replace actions which have an equivalent at the same release level.