### PR TITLE
chore: update fast-uri override version

### DIFF
--- a/_frontend/package-lock.json
+++ b/_frontend/package-lock.json
@@ -11833,9 +11833,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
+      "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
       "devOptional": true,
       "funding": [
         {

--- a/_frontend/package.json
+++ b/_frontend/package.json
@@ -96,8 +96,17 @@
     "ethers": {
       "ws": "8.21.0"
     },
-    "fast-uri": "3.1.5",
+    "fast-uri": "3.1.6",
     "glob": "13.0.6",
     "axios": "1.20.0"
+  },
+  "allowScripts": {
+    "vue-demi@0.14.10": true,
+    "@reown/appkit@1.8.23": true,
+    "cbor-extract@2.2.2": true,
+    "cypress@15.21.1": true,
+    "esbuild@0.28.2": true,
+    "fsevents@2.3.3": true,
+    "keccak@3.0.4": true
   }
 }


### PR DESCRIPTION
**Description**:

- update `fast-uri` override to `3.1.6` release
- add `allowScripts` section in `package.json`

